### PR TITLE
Fix Security Group Component Reference

### DIFF
--- a/aws/templates/resource/resource_vpc.ftl
+++ b/aws/templates/resource/resource_vpc.ftl
@@ -184,7 +184,7 @@
             extensions=extensions
             ingressRules=ingressRules /]
     [#else]
-        [@createDependentSecurityGroup 
+        [@createComponentSecurityGroup 
             mode=mode 
             tier=tier 
             component=component


### PR DESCRIPTION
When running Gen3 as a solution template the following error is being produced: 

15:20:17 Jan 16, 2018 4:20:17 AM freemarker.log._JULLoggerFactory$JULLogger error
15:20:17 SEVERE: Error executing FreeMarker template
15:20:17 FreeMarker template error:
15:20:17 Macro "createDependentSecurityGroup" has no parameter with name "extensions".
15:20:17 
15:20:17 ----

Checked createDependentSecurityGroup and it doesn't have an extension parameter, however it looks like createComponentSecurityGroup does have the extension parameter and it is being used in in the same section of the code generation. 

Updated the SecurityGroup creation method to support the extensions. 