### PR TITLE
Add SMS Configuration for User Pool MFA 

### DIFF
--- a/aws/templates/policy/policy_sns.ftl
+++ b/aws/templates/policy/policy_sns.ftl
@@ -1,0 +1,43 @@
+[#-- SNS --]
+
+[#function getSnsStatement actions id="" principals="" conditions=""]
+    [#local result = [] ]
+    [#if id?has_content]
+        [#local result +=
+            [
+                getPolicyStatement(
+                    actions,
+                    getReference(id, ARN_ATTRIBUTE_TYPE),
+                    principals,
+                    conditions)
+            ]
+        ]
+    [#else]
+        [#local result +=
+            [
+                getPolicyStatement(
+                    actions,
+                    "*",
+                    principals
+                    conditions
+                )
+            ]
+        ]
+    [/#if]
+    
+    [return result]
+[/#function]
+
+[#function snsAdminPermission id=""]
+    [#return
+        getSnsStatement(
+            "sns:*",
+            id)]
+[/#function]
+
+[#function snsPublishPermission id="" ] 
+    [#return
+        getSnsStatement(
+            "sns:publish",
+            id)]
+[/#function]

--- a/aws/templates/resource/resource_userpool.ftl
+++ b/aws/templates/resource/resource_userpool.ftl
@@ -31,6 +31,15 @@
     ]
 [/#function]
 
+[#function getUserPoolSMSConfiguration snsId externalId="" ]
+    [#return
+        {
+            "SnsCallerArn" : snsId
+        }   + 
+        attributeIfContent("ExternalId", externalId)
+    ]
+[/#function]
+
 [#function getUserPoolAutoVerifcation email=false phone=false ]
     [#assign autoVerifyArray=[]]
 
@@ -56,6 +65,7 @@
     component="" 
     loginAliases=[] 
     autoVerify=[]
+    smsConfiguration={}
     passwordPolicy={}  
     dependencies="" 
     outputId=""
@@ -105,6 +115,10 @@
             attributeIfContent(
                 "AutoVerifiedAttributes", 
                 autoVerify                
+            ) + 
+            attributeIfContent(
+                "SmsConfiguration",
+                smsConfiguration
             )
         outputs=USERPOOL_OUTPUT_MAPPINGS
         outputId=outputId

--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -4,8 +4,31 @@
     [#assign userpool = component.UserPool]
 
     [#assign userPoolId = formatUserPoolId(tier, component)]
-    [#assign userPoolName = componentShortFullName]
+    [#assign userPoolName = componentFullName]
     [#assign dependencies = [] ]
+    [#assign userPoolRoleId = formatComponentRoleId(tier, component)]
+    [#assign smsVerification = false]
+
+    [#if (userpool.MFA?has_content && userpool.MFA) || (userpool.VerifyPhone?has_content && userpool.VerifyPhone)]
+        [#if deploymentSubsetRequired("iam", true) &&
+        isPartOfCurrentDeploymentUnit(userPoolId) ]
+
+            [@createRole
+                mode=listMode
+                id=userPoolRoleId
+                trustedServices=["cognito-idp.amazonaws.com" ]
+                policies=
+                    [
+                        getPolicyDocument(
+                            snsPublishPermission() 
+                        )
+                    ]
+            /]
+        [/#if]
+
+        [#assign smsConfig = getUserPoolSMSConfiguration( getReference(userPoolRoleId), userPoolName )]
+        [#assign smsVerification = true]
+    [/#if]
 
     [@createUserPool 
         mode=listMode
@@ -21,8 +44,8 @@
         mfa=userpool.MFA
         adminCreatesUser=userpool.adminCreatesUser
         unusedTimeout=userpool.unusedAccountTimeout
-        autoVerify=(userpool.verifyEmail || userpool.VerifyPhone)?then(
-            getUserPoolAutoVerifcation(userpool.verifyEmail, userpool.VerifyPhone),
+        autoVerify=(userpool.verifyEmail || smsVerification)?then(
+            getUserPoolAutoVerifcation(userpool.verifyEmail, smsVerification),
             []
         )
         loginAliases=((userpool.loginAliases)?has_content)?then(
@@ -34,6 +57,9 @@
                                         userpool.passwordPolicy.uppsercase,
                                         userpool.passwordPolicy.numbers,
                                         userpool.passwordPolicy.specialCharacters),
+            {})
+        smsConfiguration=((smsConfig)?has_content)?then(
+            smsConfig,
             {})
     /]
 


### PR DESCRIPTION
Cognito UserPool MFA is performed through SNS based SMS messages. This adds support to add the IAM policy required to publish SNS Messages by Cognito 