### PR TITLE
Move API static doc generation to SwaggerUI

### DIFF
--- a/aws/manageStack.sh
+++ b/aws/manageStack.sh
@@ -175,6 +175,32 @@ function copy_apidoc_file() {
   return 0
 }
 
+function add_host_to_apidoc() { 
+  # adds the API Host endpoint to the swagger spec
+  local apihost="$1"; shift
+  local apidocs="$1"
+  local swaggerjson="${tmpdir}/swagger.json"
+
+  if [[ "${apidocs##*.}" == "zip" ]]; then
+      unzip -o "${apidocs}" -d "${tmpdir}"
+      RESULT=$?
+      [[ $RESULT -ne 0 ]] &&
+          fatal "Unable to unzip ${apidocs}" && exit
+  fi
+
+  if [[ -f ${swaggerjson} ]]; then 
+     jq --arg apihost $apihost '. + { host: $apihost} ' < ${swaggerjson} > "${swaggerjson}_host"
+    mv "${swaggerjson}_host" ${swaggerjson}
+  fi
+
+  if [[ "${apidocs##*.}" == "zip" ]]; then
+    rm "${apidocs}"
+    zip -rj "${apidocs}" "${tmpdir}"
+  fi
+
+  return 0
+}
+
 function process_stack() {
 
   local stack_status_file="${tmpdir}/stack_status"

--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -532,6 +532,10 @@
                                 buildCommit) + " " +
                         "   \"$\{tmpdir}\" || return $?",
                         "  #",
+                        "  # Insert host in Doc File ",
+                        "  add_host_to_apidoc" + " " + 
+                            dns + " " +
+                        "  \"$\{tmpdir/apidoc.zip}\"",
                         "  # Sync to the API Doc bucket",
                         "  copy_apidoc_file" + " " + docsS3BucketName + " " +
                         "   \"$\{tmpdir}/apidoc.html\" \"$\{tmpdir}/apidoc.zip\"",


### PR DESCRIPTION
Our existing docs generation doesn't seem to produce the expected results. Examples don't seem to be included correctly and the ability to test the API from the UI has been a requested feature. 

This changes the default docs generation from aglio to SwaggerUI. The swagger JSON is included in the static files and the docs generated on the fly using the swagger spec. 

To support the Test API the API host needs to be included in the SwaggerSpec which is added as part of the deployment process. 