### PR TITLE
Add API Gateway Mock Response for CORS Headers

### DIFF
--- a/aws/templates/createSwaggerExtensions.ftl
+++ b/aws/templates/createSwaggerExtensions.ftl
@@ -291,6 +291,28 @@
                         "options": { 
                                 "summary": "CORS Configuration",
                                 "description": "API Gateway Mock Response with CORS headers",
+                                "responses" : {
+                                    200 : { 
+                                        "description" : "CORS Response",
+                                        "headers": {
+                                        "Access-Control-Allow-Origin": {
+                                            "type": "string"
+                                        },
+                                        "Access-Control-Allow-Methods": {
+                                            "type": "string"
+                                        },
+                                        "Access-Control-Allow-Headers": {
+                                            "type": "string"
+                                        }
+                                        }
+                                    }
+                                },
+                                "cosumes" : [
+                                    "application/json"
+                                ],
+                                "produces" : [
+                                    "application/json
+                                ]
                                 [@methodEntry
                                     "options"
                                     "mock-cors" 


### PR DESCRIPTION
Cross-Origin Resource Sharing (CORS) is used to authorise access to resources using headers. 

Its implemented using the options verb which is expected to respond with a set of headers that describe how the resource can be accessed. 

This PR checks to see if the options verb has been added as part of the swagger spec that is being processed, if it hasn't then the API Gateway will be configured to use a mock response to implement CORS using the default configuration of: 

```json
                    "responses": {
                        "default": {
                            "statusCode": "200",
                            "responseParameters": {
                                "method.response.header.Access-Control-Allow-Headers": "Content-Type,X-Amz-Date,Authorization,X-Api-Key",
                                "method.response.header.Access-Control-Allow-Methods": "*",
                                "method.response.header.Access-Control-Allow-Origin": "*"
                            }
                        }
                    }
```

The set headers are based on the AWS recommended CORS setup for API Gateway.

This assumes that if a swagger spec has an options verb specified, CORS will be part of the implementation. 