### PR TITLE
User Pools Identity Pool Support

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -112,6 +112,28 @@
                                     [#assign userPoolArns += [ getExistingReference(
                                                                     formatUserPoolId(link.Tier, link.Component), 
                                                                     ARN_ATTRIBUTE_TYPE )]]
+
+                                    [#assign policyId = formatDependentPolicyId(apiId, link.Component )]
+                                    [@createPolicy 
+                                        mode=listMode
+                                        id=policyId
+                                        name=apiName
+                                        statements=[
+                                            getPolicyStatement(
+                                                "execute-api:Execution-operation",
+                                                formatRegionalArn(
+                                                        "execute-api",
+                                                        getReference(apiId)   
+                                                    )
+                                            )
+                                        ]
+                                        roles=getExistingReference(
+                                                formatDependentUserPoolIdentityUnAuthRoleId(
+                                                    link.Tier, 
+                                                    link.Component),
+                                                    ARN_ATTRIBUTE_TYPE
+                                                )
+                                    /]
                                 [/#if]
                             [#break]
                         [/#switch]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -827,6 +827,10 @@
                     "Default" : 30
                 },
                 {
+                    "Name" : "allowUnauthIds",
+                    "Default" : false
+                }
+                {
                     "Name" : "passwordPolicy",
                     "Children" : [
                         {

--- a/aws/templates/createSwaggerExtensions.ftl
+++ b/aws/templates/createSwaggerExtensions.ftl
@@ -226,6 +226,7 @@
                 "requestTemplates": {
                     "application/json": "{ \"statusCode\" : 200}"
                 },
+                "contentHandling" : "CONVERT_TO_TEXT",
                 "responses": {
                     "default": {
                         "statusCode": 200,

--- a/aws/templates/createSwaggerExtensions.ftl
+++ b/aws/templates/createSwaggerExtensions.ftl
@@ -235,6 +235,9 @@
                                 "${key}": "${value}"
                                 [#sep],[/#sep]
                             [/#list]
+                        },
+                        "responseTemplates" : { 
+                            "application/json" : "{}"
                         }
                     }
                 }

--- a/aws/templates/id/id_userpool.ftl
+++ b/aws/templates/id/id_userpool.ftl
@@ -2,6 +2,8 @@
 
 [#assign USERPOOL_RESOURCE_TYPE = "userpool"]
 [#assign USERPOOL_CLIENT_RESOURCE_TYPE = "userpoolclient" ]
+[#assign USERPOOL_IDENTITYPOOL_RESOURCE_TYPE = "userpoolidentitypool" ]
+
 [#function formatUserPoolId tier component extensions...]
     [#return formatComponentResourceId(
                 USERPOOL_RESOURCE_TYPE,
@@ -16,4 +18,37 @@
             tier,
             component,
             extensions)]
+[/#function]
+
+[#function formatUserPoolIdentityPoolId tier component extensions... ]
+    [#return formatComponentResourceId(
+            USERPOOL_IDENTITYPOOL_RESOURCE_TYPE,
+            tier,
+            component,
+            extensions)]
+[/#function]
+
+[#function formatDependentUserPoolIdentityRoleMappingId resourceId extensions...]
+    [#return formatDependentResourceId(
+                "userPoolIdentityPoolRoleMapping",
+                resourceId,
+                extensions)]
+[/#function]
+
+[#function formatDependentUserPoolIdentityUnAuthRoleId tier component ]
+    [#return 
+        formatComponentRoleId(
+            tier, 
+            component, 
+            "IdentityUnAuthRole")
+    ]
+[/#function]
+
+[#function formatDependentUserPoolIdentityAuthRoleId tier component ]
+    [#return 
+        formatComponentRoleId(
+            tier, 
+            component, 
+            "IdentityAuthRole")
+    ]
 [/#function]

--- a/aws/templates/name/name_userpool.ftl
+++ b/aws/templates/name/name_userpool.ftl
@@ -17,3 +17,14 @@
             component
             userpool))]
 [/#function]
+
+[#function formatUserPoolIdentityPoolName tier component userpool ]
+    [#return formatNameSeperator(
+        "_"
+        "identitypool",
+        productName,
+        segmentName,
+        getTierName(tier),
+        getComponentName(component)
+        userpool)]
+[/#function]

--- a/aws/templates/name/name_userpool.ftl
+++ b/aws/templates/name/name_userpool.ftl
@@ -19,12 +19,12 @@
 [/#function]
 
 [#function formatUserPoolIdentityPoolName tier component userpool ]
-    [#return formatNameSeperator(
-        "_"
-        "identitypool",
+    [#return formatId(
         productName,
         segmentName,
-        getTierName(tier),
-        getComponentName(component)
-        userpool)]
+        getTierId(tier),
+        getComponentId(component),
+        userpool
+        
+    )]
 [/#function]

--- a/aws/templates/name/start.ftl
+++ b/aws/templates/name/start.ftl
@@ -8,10 +8,6 @@
     [#return concatenate(parts, "-")]
 [/#function]
 
-[#function formatNameSeperator seperator parts...]
-    [#return concatenate(parts, seperator)]
-[/#function]
-
 [#function formatDomainName parts...]
     [#return concatenate(parts, ".")]
 [/#function]

--- a/aws/templates/name/start.ftl
+++ b/aws/templates/name/start.ftl
@@ -8,6 +8,10 @@
     [#return concatenate(parts, "-")]
 [/#function]
 
+[#function formatNameSeperator seperator parts...]
+    [#return concatenate(parts, seperator)]
+[/#function]
+
 [#function formatDomainName parts...]
     [#return concatenate(parts, ".")]
 [/#function]

--- a/aws/templates/policy/policy_userpool.ftl
+++ b/aws/templates/policy/policy_userpool.ftl
@@ -1,0 +1,28 @@
+[#--UserPool --]
+
+[#function getUserPoolUnAuthPolicy ]
+    [#return
+        [
+            getPolicyStatement(
+                    [
+                        "mobileanalytics:PutEvents",
+                        "cognito-sync:*"
+                    ]
+            )
+        ]
+    ]
+[/#function]
+
+[#function getUserPoolAuthPolicy]
+    [#return
+        [
+            getPolicyStatement(
+                [
+                    "mobileanalytics:PutEvents",
+                    "cognito-sync:*",
+                    "cognito-identity:*"
+                ]
+            )
+        ]
+    ]
+[/#function]

--- a/aws/templates/resource/resource_iam.ftl
+++ b/aws/templates/resource/resource_iam.ftl
@@ -119,6 +119,7 @@
             mode
             id
             trustedServices=[]
+            federatedServices=[]
             trustedAccounts=[]
             multiFactor=false
             condition=""
@@ -144,7 +145,7 @@
         properties=
             attributeIfTrue(
                 "AssumeRolePolicyDocument",
-                trustedServices?has_content || trustedAccountArns?has_content,
+                trustedServices?has_content || trustedAccountArns?has_content || federatedServices?has_content,
                 {
                     "Version": "2012-10-17",
                     "Statement": [
@@ -152,8 +153,14 @@
                             "Effect": "Allow",
                             "Principal":
                                 attributeIfContent("Service", trustedServices) +
-                                attributeIfContent("AWS", trustedAccountArns),
-                            "Action": [ "sts:AssumeRole" ]
+                                attributeIfContent("AWS", trustedAccountArns) +
+                                attributeIfContent("Federated", federatedServices),
+                            "Action": valueIfTrue( 
+                                            [ "sts:AssumeRoleWithWebIdentity" ],
+                                            federatedServices?has_content,
+                                            [ "sts:AssumeRole" ]
+                                        )
+
                         } +
                         attributeIfTrue(
                             "Condition",

--- a/aws/templates/resource/resource_userpool.ftl
+++ b/aws/templates/resource/resource_userpool.ftl
@@ -224,7 +224,7 @@
     /]
 [/#macro]
 
-[#macro createUserPoolIdentityPollRoleMapping mode id  
+[#macro createUserPoolIdentityPoolRoleMapping mode id  
     IdentityPoolId,
     authenticatedRoleArn,
     unauthenticatedRoleArn

--- a/aws/templates/resource/resource_userpool.ftl
+++ b/aws/templates/resource/resource_userpool.ftl
@@ -28,6 +28,25 @@
     }
 ]
 
+[#assign USERPOOL_IDENTITYPOOL_OUTPUT_MAPPINGS = 
+    {
+        REFERENCE_ATTRIBUTE_TYPE : { 
+            "UseRef" : true
+        },
+        NAME_ATTRIBUTE_TYPE : {
+            "Attribute" : "Name"
+        }
+    }
+]
+
+[#assign outputMappings +=
+    {
+        USERPOOL_RESOURCE_TYPE : USERPOOL_OUTPUT_MAPPINGS,
+        USERPOOL_CLIENT_RESOURCE_TYPE : USERPOOL_CLIENT_OUTPUT_MAPPINGS,
+        USERPOOL_IDENTITYPOOL_RESOURCE_TYPE : USERPOOL_IDENTITYPOOL_OUTPUT_MAPPINGS
+    }
+]
+
 [#function getUserPoolPasswordPolicy length="8" lowercase=true uppercase=true numbers=true symbols=true]
     [#return 
         {
@@ -64,6 +83,20 @@
 
     [#return 
         autoVerifyArray
+    ]
+[/#function]
+
+[#function getIdentityPoolCognitoProvider UserPoolId userPoolClientId serverSideToken=true ]
+
+    [#assign userPoolRef = getReference(UserPoolId, NAME_ATTRIBUTE_TYPE)]
+    [#assign userpoolClientRef = getReference(userPoolClientId )]
+
+    [#return
+        {
+            "ProviderName" : userPoolRef,
+            "ClientId" : userpoolClientRef,
+            "ServerSideTokenCheck" : serverSideToken
+        }
     ]
 [/#function]
 
@@ -163,3 +196,57 @@
         dependencies=dependencies
     /]
 [/#macro]
+
+[#macro createUserPoolIdentityPool mode id name
+    cognitoIdProviders
+    allowUnauthenticatedIdentities=false
+    tier=""
+    component=""
+    dependencies=""
+    outputId=""
+]
+
+    [@cfResource 
+        mode=mode
+        id=id
+        type="AWS::Cognito::IdentityPool"
+        properties=
+            {
+                "IdentityPoolName" : name,
+                "AllowUnauthenticatedIdentities" : allowUnauthenticatedIdentities,
+                "CognitoIdentityProviders" : [ 
+                    cognitoIdProviders
+                ]
+            }
+        outputs=USERPOOL_IDENTITY_POOL_OUTPUT_MAPPINGS
+        outputId=outputId
+        dependencies=dependencies
+    /]
+[/#macro]
+
+[#macro createUserPoolIdentityPollRoleMapping mode id  
+    IdentityPoolId,
+    authenticatedRoleArn,
+    unauthenticatedRoleArn
+    tier=""
+    component=""
+    dependencies=""
+    outputId=""
+]
+    [@cfResource
+        mode=mode
+        id=id
+        type="AWS::Cognito::IdentityPoolRoleAttachment"
+        properties=
+            {
+                "IdentityPoolId" : IdentityPoolId,
+                "Roles" : { 
+                    "authenticated" : authenticatedRoleArn,
+                    "unauthenticated" : unauthenticatedRoleArn
+                }
+            }
+        outputId=outputId
+        dependencies=dependencies
+    /]
+[/#macro]
+

--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -11,8 +11,8 @@
     [#assign userPoolIdentityAuthRoleId = formatDependentUserPoolIdentityAuthRoleId(tier, component)]
     [#assign userPoolIdentityRoleMappingId = formatDependentUserPoolIdentityRoleMappingId(userPoolIdentityPoolId)]
     [#assign userPoolName = componentFullName]
+    [#assign userPoolIdentityPoolName = formatUserPoolIdentityPoolName(tier,component, userpool)]
     [#assign userPoolClientName = formatUserPoolClientName(tier,component,userpool) ]
-    [#assign userPoolIdentityPoolName = formatUserPoolIdentityPoolName(tier,component,userpool)]
     [#assign dependencies = [] ]
     [#assign smsVerification = false]
 

--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -5,10 +5,15 @@
 
     [#assign userPoolId = formatUserPoolId(tier, component)]
     [#assign userPoolClientId = formatUserPoolClientId(tier, component)]
+    [#assign userPoolIdentityPoolId = formatUserPoolIdentityPoolId(tier,component)]
+    [#assign userPoolRoleId = formatComponentRoleId(tier, component)]
+    [#assign userPoolIdentityUnAuthRoleId = formatDependentUserPoolIdentityUnAuthRoleId(tier, component)]
+    [#assign userPoolIdentityAuthRoleId = formatDependentUserPoolIdentityAuthRoleId(tier, component)]
+    [#assign userPoolIdentityRoleMappingId = formatDependentUserPoolIdentityRoleMappingId(userPoolIdentityPoolId)]
     [#assign userPoolName = componentFullName]
     [#assign userPoolClientName = formatUserPoolClientName(tier,component,userpool) ]
+    [#assign userPoolIdentityPoolName = formatUserPoolIdentityPoolName(tier,component,userpool)]
     [#assign dependencies = [] ]
-    [#assign userPoolRoleId = formatComponentRoleId(tier, component)]
     [#assign smsVerification = false]
 
     [#if (userpool.MFA?has_content && userpool.MFA) || (userpool.VerifyPhone?has_content && userpool.VerifyPhone)]
@@ -70,12 +75,76 @@
         mode=listMode
         component=component
         tier=tier
+        dependencies=dependencies
         id=userPoolClientId
         name=userPoolClientName
         userPoolId=userPoolId
         generateSecret=userpool.clientGenerateSecret
         tokenValidity=userpool.clientTokenValidity
+
+    /]
+
+    [#assign cognitoIdentityPoolProvider = getIdentityPoolCognitoProvider( userPoolId, userPoolClientId )]
+
+    [@createUserPoolIdentityPool 
+        mode=listMode
+        component=component
+        tier=tier
         dependencies=dependencies
+        id=userPoolIdentityPoolId
+        name=userPoolIdentityPoolName
+        cognitoIdProviders=cognitoIdentityPoolProvider
+        allowUnauthenticatedIdentities=userpool.allowUnauthIds
+    /]
+
+    [@createRole
+        mode=listMode
+        id=userPoolIdentityUnAuthRoleId
+        policies=[
+            getPolicyDocument(
+                getUserPoolUnAuthPolicy(),
+                "DefaultUnAuthIdentityRole"
+            )
+        ]
+        federatedServices="cognito-identity.amazonaws.com"
+        condition={
+              "StringEquals": {
+                "cognito-identity.amazonaws.com:aud": getReference(userPoolIdentityPoolId)
+              },
+              "ForAnyValue:StringLike": {
+                "cognito-identity.amazonaws.com:amr": "unauthenticated"
+              }
+        }
+    /]
+
+    [@createRole 
+        mode=listMode
+        id=userPoolIdentityAuthRoleId
+        policies=[
+            getPolicyDocument(
+                getUserPoolAuthPolicy(),
+                "DefaultAuthIdentityRole"
+            )
+        ]
+        federatedServices="cognito-identity.amazonaws.com"
+        condition={
+              "StringEquals": {
+                "cognito-identity.amazonaws.com:aud": getReference(userPoolIdentityPoolId)
+              },
+              "ForAnyValue:StringLike": {
+                "cognito-identity.amazonaws.com:amr": "authenticated"
+              }
+        }
+    /]
+
+    [@createUserPoolIdentityPollRoleMapping
+        mode=listMode
+        component=component
+        tier=tier
+        id=userPoolIdentityRoleMappingId
+        IdentityPoolId=getReference(userPoolIdentityPoolId)
+        authenticatedRoleArn=getReference(userPoolIdentityAuthRoleId, ARN_ATTRIBUTE_TYPE)
+        unauthenticatedRoleArn=getReference(userPoolIdentityUnAuthRoleId, ARN_ATTRIBUTE_TYPE)
     /]
 
 [/#if]

--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -137,7 +137,7 @@
         }
     /]
 
-    [@createUserPoolIdentityPollRoleMapping
+    [@createUserPoolIdentityPoolRoleMapping
         mode=listMode
         component=component
         tier=tier


### PR DESCRIPTION
- Adds the setup of an Identity pool for a cognito user pool. 
- Creates IAM roles with a default policy attached for unauthenticated users and authenticated users. 
- Adds API gateway link support to update the role with a policy to allow invoke access on the API
- Adds IAM Role creation for Federated services and web identity roles 