### PR TITLE
Add Cognito User Pool Configuration to Swagger Build

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -110,10 +110,6 @@
                             [#case "userpool"] 
                                 [#if deploymentSubsetRequired("apigateway", true)]
 
-                                    [#assign UserPoolId = formatUserPoolId(link.Tier, link.Component)]
-                                    [#assign userPoolArns += [ getExistingReference(
-                                                                    UserPoolId, 
-                                                                    ARN_ATTRIBUTE_TYPE )]]
                                     [#assign policyId = formatDependentPolicyId(apiId, UserPoolId )]
 
                                     [@createPolicy 
@@ -265,25 +261,7 @@
                 dependencies=[invalidLogMetricId]
             /]
 
-            [#if userPoolArns?has_content ]
-                [@cfResource
-                    mode=listMode
-                    id= 
-                        formatDependentAPIGatewayAuthorizerId(apiId)
-                    type="AWS::ApiGateway::Authorizer" 
-                    properties=
-                        {
-                            "Name" : "CognitoUserPoolAuthorizers",
-                            "ProviderARNs" : userPoolArns,
-                            "RestApiId" : getReference(apiId),
-                            "Type" : "COGNITO_USER_POOLS",
-                            "IdentitySource" : "method.request.header.Authorization"
-                        }
-                    dependencies=apiId 
-                    outputs={}
-                /]
-            [/#if]        
-
+    
             [#if occurrence.CloudFront.Configured && occurrence.CloudFront.Enabled]
                 [#assign origin =
                     getCFAPIGatewayOrigin(

--- a/aws/templates/createSwaggerExtensions.ftl
+++ b/aws/templates/createSwaggerExtensions.ftl
@@ -8,10 +8,14 @@
 [#assign defaultVariable = integrationsObject.Variable ! ""]
 [#assign defaultValidation = integrationsObject.Validation ! "all"]
 [#assign defaultSig4 = integrationsObject.Sig4 ! false]
-[#assign defaultCorsHeaders = integrationsObject.corsHeaders ! ["Content-Type","X-Amz-Date","Authorization","X-Api-Key"]]
+[#assign defaultCorsHeaders = integrationsObject.corsHeaders ! ["*"]]
 [#assign defaultCorsMethods = integrationsObject.corsMethods ! ["*"] ]
 [#assign defaultCorsOrigin = integrationsObject.corsOrigin ! ["*"] ] 
+[#assign defaultUserPool = integrationsObject.userPool && integrationsObject.userPoolArn?has_content]
+[#assign defaultCognitoPoolName = integrationsObject.cognitoPoolName!"CognitoUserPool" ]
+[#assign defaultCognitoAuthHeader = integrationsObject.cognitoAuthHeader!"Authorization" ]
 [#assign gatewayErrorReporting = integrationsObject.GatewayErrorReporting ! "full"]
+
 [#assign gatewayErrorMap =
           {
               "ACCESS_DENIED": {
@@ -137,7 +141,7 @@
     ]
 [/#function]
 
-[#macro security sig4 apiKey]
+[#macro security sig4 apiKey userPool]
     "security": [
         [#local count = 0]
         [#if sig4]
@@ -151,7 +155,15 @@
             {
                 "api_key": []
             }
+            [#local count += 1]
         [/#if]
+        [#if userPool]
+            [#if count > 0],[/#if]
+            {
+                defaultCognitoPoolName : []
+            }
+        [/#if]
+
     ]
 [/#macro]
 
@@ -187,8 +199,8 @@
     ]
 [/#macro]
 
-[#macro methodEntry verb type apiVariable validation sig4 apiKey corsConfiguration={} ]
-    [@security sig4 apiKey /],
+[#macro methodEntry verb type apiVariable validation sig4 apiKey userPool corsConfiguration={} ]
+    [@security sig4 apiKey userPool /],
     [@validator validation /],
     [#switch type]
         [#case "docker"]
@@ -279,8 +291,22 @@
           "in": "header",
           "x-amazon-apigateway-authtype": "awsSigv4"
         }
+        [#if integrationsObject.userPoolArn?has_content ]
+            ,defaultCognitoPoolName: {
+                "type": "apiKey",
+                "name": defaultCognitoAuthHeader,
+                "in": "header",
+                "x-amazon-apigateway-authtype": "cognito_user_pools",
+                "x-amazon-apigateway-authorizer": {
+                    "type": "cognito_user_pools",
+                    "providerARNs": [
+                            integrationsObject.userPoolArn
+                    ]
+            }
+        [/#if]
+
     },
-    [@security defaultSig4 defaultApiKey /]
+    [@security defaultSig4 defaultApiKey defaultUserPool /]
     ,[@validator defaultValidation /]
     [#if binaryTypes?has_content ]
         ,[@binaryMediaTypes binaryTypes /]
@@ -315,6 +341,7 @@
                                     defaultValidation
                                     defaultSig4
                                     defaultApiKey
+                                    defaultUserPool
                                     corsConfiguration
                                 /]
                         }
@@ -336,6 +363,7 @@
                                             pattern.Validation ! defaultValidation
                                             pattern.Sig4 ! defaultSig4
                                             pattern.ApiKey ! defaultApiKey
+                                            pattern.UserPool ! defaultUserPool
                                         /]
                                         [#assign matchSeen = true]
                                         [#break]
@@ -350,6 +378,7 @@
                                     defaultValidation
                                     defaultSig4
                                     defaultApiKey
+                                    defaultUserPool
                                 /]
                             [/#if]
                         }

--- a/aws/templates/createSwaggerExtensions.ftl
+++ b/aws/templates/createSwaggerExtensions.ftl
@@ -11,7 +11,7 @@
 [#assign defaultCorsHeaders = integrationsObject.corsHeaders ! ["*"]]
 [#assign defaultCorsMethods = integrationsObject.corsMethods ! ["*"] ]
 [#assign defaultCorsOrigin = integrationsObject.corsOrigin ! ["*"] ] 
-[#assign defaultUserPool = integrationsObject.userPool && integrationsObject.userPoolArn?has_content]
+[#assign defaultUserPool = integrationsObject.userPool ! false ]
 [#assign defaultCognitoPoolName = integrationsObject.cognitoPoolName!"CognitoUserPool" ]
 [#assign defaultCognitoAuthHeader = integrationsObject.cognitoAuthHeader!"Authorization" ]
 [#assign gatewayErrorReporting = integrationsObject.GatewayErrorReporting ! "full"]
@@ -160,7 +160,7 @@
         [#if userPool]
             [#if count > 0],[/#if]
             {
-                defaultCognitoPoolName : []
+                "${defaultCognitoPoolName}" : []
             }
         [/#if]
 
@@ -292,16 +292,17 @@
           "x-amazon-apigateway-authtype": "awsSigv4"
         }
         [#if integrationsObject.userPoolArn?has_content ]
-            ,defaultCognitoPoolName: {
+            ,"${defaultCognitoPoolName}": {
                 "type": "apiKey",
-                "name": defaultCognitoAuthHeader,
+                "name": "${defaultCognitoAuthHeader}",
                 "in": "header",
                 "x-amazon-apigateway-authtype": "cognito_user_pools",
                 "x-amazon-apigateway-authorizer": {
                     "type": "cognito_user_pools",
                     "providerARNs": [
-                            integrationsObject.userPoolArn
+                            "${integrationsObject.userPoolArn}"
                     ]
+                }
             }
         [/#if]
 


### PR DESCRIPTION
When an a Cognito User pool authorizer is setup on an API gateway via Cloudformation they are overridden by the Swagger based import. 

This moves the authorizer configuration into the swagger spec and allows for Userpool auth to be enabled on paths like existing sig4 or API key configuration. 

In its current state the Arn of the Cognito User Pool needs to be added to the apigw.json configuration due to the way the Swagger spec is built

Properties for apigw.json are: 

    "userPool" : booleen - Enables UserPool Auth
    "userPoolArn" : string - the ARN of the user Pool

