### PR TITLE
Allow CognitoUser pool to invoke Lambda Function

### DIFF
--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -93,6 +93,31 @@
                                 [/#switch]
                                 [#break]
                             [/#if]
+                            [#switch getComponentType(targetComponent)]
+                            [#case "userpool"] 
+                                [#if deploymentSubsetRequired("lambda", true)]
+
+                                    [#assign policyId = formatDependentPolicyId(
+                                                            lambdaId, 
+                                                            formatUserPoolId(link.Tier, link.Component))]
+
+                                    [@createPolicy 
+                                        mode=listMode
+                                        id=policyId
+                                        name=lambdaName
+                                        statements=[
+                                            getPolicyStatement(
+                                                "lambda:InvokeFunction",
+                                                formatLambdaArn(lambdaId)    
+                                            )
+                                        ]
+                                        roles=formatDependentUserPoolIdentityAuthRoleId(
+                                                link.Tier, 
+                                                link.Component)
+                                    /]
+                                [/#if]
+                            [#break]
+                        [/#switch]
                         [/#list]
                     [/#if]
                 [/#if]

--- a/aws/templates/createSwaggerExtensions.ftl
+++ b/aws/templates/createSwaggerExtensions.ftl
@@ -220,7 +220,10 @@
                 [#-- "uri" : "${r"${stageVariables." + apiVariable + r"}"}", --]
                 "uri" : "arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${region}:${account}:function:${r"${stageVariables." + apiVariable + r"}"}/invocations",
                 "passthroughBehavior" : "never",
-                "httpMethod" : "POST"
+                "httpMethod" : "POST" 
+                [#if userPool ] 
+                ,"credentials" : "arn:aws:iam::*:user/*"
+                [/#if]
             },
             "responses" : {}
             [#break]

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -19,3 +19,10 @@
                 extensions,
                 fn)]
 [/#function]
+
+[#function formatLambdaArn lambdaId account={ "Ref" : "AWS::AccountId" }]
+    [#return
+        formatRegionalArn(
+            "lambda",
+            getReference(lambdaId))]
+[/#function]


### PR DESCRIPTION
When invoking a lambda function via API Gateway the identity provided to the Lambda function is the API Gateways id. If using Cognito you would like to idenitfy the user in lambda.

This changes passes the user credentials to the lambda function when called and enables the Cognito auth role to invoke the lambda function 