### PR TITLE
Add Public App data bucket 

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -201,7 +201,23 @@
             "appdata",
             (appSettingsObject.FilePrefixes.AppData)!
                 (appSettingsObject.DefaultFilePrefix)!
-                deploymentUnit)]
+                deploymentUnit)]     
+[/#function]
+
+[#function getAppDataPublicFilePrefix publicDataPrefix=""]
+
+    [#if segmentObject.Data?has_content  && segmentObject.Data.PublicPrefix?has_content]
+        [#return formatSegmentPrefixPath(
+            "appdata",
+            (appSettingsObject.FilePrefixes.AppData)!
+                (appSettingsObject.DefaultFilePrefix)!
+                deploymentUnit,
+            (segmentObject.Data.PublicPrefix))]
+    [#else]
+        [#return 
+            ""
+        ]
+    [/#if]
 [/#function]
 
 [#function getBackupsFilePrefix]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -204,15 +204,15 @@
                 deploymentUnit)]     
 [/#function]
 
-[#function getAppDataPublicFilePrefix publicDataPrefix=""]
+[#function getAppDataPublicFilePrefix ]
 
-    [#if segmentObject.Data?has_content  && segmentObject.Data.PublicPrefix?has_content]
+    [#if segmentObject.Data?has_content  && segmentObject.Data.Public?has_content]
         [#return formatSegmentPrefixPath(
             "appdata",
             (appSettingsObject.FilePrefixes.AppData)!
                 (appSettingsObject.DefaultFilePrefix)!
                 deploymentUnit,
-            (segmentObject.Data.PublicPrefix))]
+            (segmentObject.Data.Public.Prefix))]
     [#else]
         [#return 
             ""

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -189,7 +189,8 @@
         } +
         attributeIfContent("APP_RUN_MODE", mode) +
         attributeIfContent("BUILD_REFERENCE", buildCommit!"") +
-        attributeIfContent("APP_REFERENCE", appReference!"")
+        attributeIfContent("APP_REFERENCE", appReference!"") + 
+        attributeIfContent("APPDATA_PUBLIC_PREFIX" getAppDataPublicFilePrefix())
     ]
 [/#function]
 

--- a/aws/templates/segment/segment_s3.ftl
+++ b/aws/templates/segment/segment_s3.ftl
@@ -93,7 +93,7 @@
                                 group)]
                 
                 [#if (ipAddressGroupsUsage["dataPublic"][groupId])?has_content]
-                    [#assign dataPublicCIDRList +=  (ipAddressGroupsUsage["publish"][groupId]).CIDR ]
+                    [#assign dataPublicCIDRList +=  (ipAddressGroupsUsage["dataPublic"][groupId]).CIDR ]
                 [/#if]
             [/#list]
         [/#if]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -156,6 +156,12 @@
     [#assign dataExpiration =
         (segmentObject.Data.Expiration)!
         (environmentObject.Data.Expiration)!""]
+    [#assign dataPublicPrefix = 
+        (segmentObject.Data.PublicPrefix)!
+        (environmentObject.Data.PublicPrefix)!""]
+    [#assign dataPublicWhiteList = 
+        (segmentObject.Data.PublicWhitelist)!
+        (environmentObject.Data.PublicWhitelist)![]]
 [/#if]
 
 [#-- Solution --]
@@ -223,7 +229,7 @@
 [#-- Annotate IPAddressGroups --]
 [#assign ipAddressGroupsUsage =
     {
-        "DefaultUsageList" : ["es", "ssh", "http", "https", "waf", "publish"]
+        "DefaultUsageList" : ["es", "ssh", "http", "https", "waf", "publish", "dataPublic"]
     }
 ]
 [#list ipAddressGroups as groupKey,groupValue]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -157,11 +157,11 @@
         (segmentObject.Data.Expiration)!
         (environmentObject.Data.Expiration)!""]
     [#assign dataPublicPrefix = 
-        (segmentObject.Data.PublicPrefix)!
-        (environmentObject.Data.PublicPrefix)!""]
+        (segmentObject.Data.Public.Prefix)!
+        (environmentObject.Data.Public.Prefix)!""]
     [#assign dataPublicWhiteList = 
-        (segmentObject.Data.PublicWhitelist)!
-        (environmentObject.Data.PublicWhitelist)![]]
+        (segmentObject.Data.Public.IPWhitelist)!
+        (environmentObject.Data.Public.IPWhitelist)![]]
 [/#if]
 
 [#-- Solution --]


### PR DESCRIPTION
Some applications need to be able to make S3 data available with public read access. This adds support for a public prefix which when set adds an S3 Bucket policy to the AppData Segment Bucket. 

The policy allows public read access to data hosted within a sub prefix of the components appdata prefix. 

A IP whitelist is also required to restrict the access and make the user specific global if they want it to be fully public 