### PR TITLE
Split existing App data and New App Public locations

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -206,13 +206,12 @@
 
 [#function getAppDataPublicFilePrefix ]
 
-    [#if segmentObject.Data?has_content  && segmentObject.Data.Public?has_content]
+    [#if segmentObject.Data?has_content  && segmentObject.Data.Public?has_content && segmentObject.Data.Public.Enabled]
         [#return formatSegmentPrefixPath(
-            "appdata",
+            "apppublic",
             (appSettingsObject.FilePrefixes.AppData)!
                 (appSettingsObject.DefaultFilePrefix)!
-                deploymentUnit,
-            (segmentObject.Data.Public.Prefix))]
+                deploymentUnit)]
     [#else]
         [#return 
             ""

--- a/aws/templates/segment/segment_s3.ftl
+++ b/aws/templates/segment/segment_s3.ftl
@@ -82,7 +82,7 @@
         outputId=s3DataId
     /]
 
-    [#if dataPublicPrefix?has_content ]
+    [#if dataPublicEnabled ]
 
         [#assign dataPublicCIDRList = [] ]
 
@@ -107,7 +107,7 @@
             statements=
                 s3ReadPermission(
                     dataBucket,
-                    formatSegmentPrefixPath("appdata", "*", dataPublicPrefix),
+                    formatSegmentPrefixPath("apppublic"),
                     "*",
                     "*",
                     dataPublicWhitelistCondition

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -156,9 +156,9 @@
     [#assign dataExpiration =
         (segmentObject.Data.Expiration)!
         (environmentObject.Data.Expiration)!""]
-    [#assign dataPublicPrefix = 
-        (segmentObject.Data.Public.Prefix)!
-        (environmentObject.Data.Public.Prefix)!""]
+    [#assign dataPublicEnabled = 
+        (segmentObject.Data.Public.Enabled)!
+        (environmentObject.Data.Public.Enabled)!false]
     [#assign dataPublicWhiteList = 
         (segmentObject.Data.Public.IPWhitelist)!
         (environmentObject.Data.Public.IPWhitelist)![]]


### PR DESCRIPTION
The first implementation put the public data in with the existing App data. This change splits public data to a seperate root prefix in the S3 bucket. Ensuring that the data can't mix 