### PR TITLE
add schedule event rule resource support

### DIFF
--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -207,6 +207,20 @@
                                 component,
                                 fn,
                                 occurrence)]
+
+                        [#assign eventRuleId =
+                            formatEventRuleId(
+                                tier,
+                                component,
+                                fn,
+                                occurrence)]
+    
+                        [#assign lambdaPermissionId =
+                            formatLambdaPermissionId(
+                                tier,
+                                component,
+                                fn,
+                                occurrence)]
     
                         [#assign lambdaFunctionName =
                             formatLambdaFunctionName(
@@ -240,6 +254,19 @@
                                     []
                                 )
                             dependencies=roleId
+                        /]
+                        [@createScheduleEventRule
+                            mode=listMode
+                            id=eventRuleId
+                            targetId=lambdaFunctionId
+                            dependencies=lambdaFunctionId
+                        /]
+                        [@createLambdaPermission
+                            mode=listMode
+                            id=lambdaPermissionId
+                            targetId=lambdaFunctionId
+                            eventRuleId=eventRuleId
+                            dependencies=eventRuleId
                         /]
                     [/#if]
                 [/#list]

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -255,10 +255,20 @@
                                 )
                             dependencies=roleId
                         /]
+                        
+                        [#-- By default schedule event rule is enabled for all functions with rate 15 minutes --]
+                        [#-- To disable it set fn.Schedule.EnabledState to "false" --]
+                        [#-- To change schedule expression set fn.Schedule.Expression --]
+                        [#assign state = "ENABLED"]
+                        [#if fn.Schedule?has_content && fn.Schedule.EnabledState?has_content && !fn.Schedule.EnabledState]
+                            [#assign state = "DISABLED"]
+                        [/#if]
                         [@createScheduleEventRule
                             mode=listMode
                             id=eventRuleId
                             targetId=lambdaFunctionId
+                            state=state
+                            scheduleExpression=(fn.Schedule.Expression)!"rate(15 minutes)"
                             dependencies=lambdaFunctionId
                         /]
                         [@createLambdaPermission

--- a/aws/templates/id/id_event.ftl
+++ b/aws/templates/id/id_event.ftl
@@ -1,0 +1,28 @@
+[#-- Event --]
+
+[#assign EVENT_RESOURCE_TYPE = "event" ]
+[#assign EVENT_RULE_RESOURCE_TYPE = "event" ]
+
+[#function formatEventId tier component extensions...]
+    [#return formatComponentResourceId(
+                EVENT_RESOURCE_TYPE,
+                tier,
+                component,
+                extensions)]
+[/#function]
+
+[#function formatEventRuleId tier component fn extensions...]
+    [#return formatComponentResourceId(
+                EVENT_RULE_RESOURCE_TYPE,
+                tier,
+                component,
+                extensions,
+                fn)]
+[/#function]
+
+[#function formatEventRuleArn ruleId account={ "Ref" : "AWS::AccountId" }]
+    [#return
+        formatRegionalArn(
+            "event",
+            getReference(ruleId))]
+[/#function]

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -2,6 +2,7 @@
 
 [#assign LAMBDA_RESOURCE_TYPE = "lambda" ]
 [#assign LAMBDA_FUNCTION_RESOURCE_TYPE = "lambda" ]
+[#assign LAMBDA_PERMISSION_RESOURCE_TYPE = "permission" ]
 
 [#function formatLambdaId tier component extensions...]
     [#return formatComponentResourceId(
@@ -14,6 +15,15 @@
 [#function formatLambdaFunctionId tier component fn extensions...]
     [#return formatComponentResourceId(
                 LAMBDA_FUNCTION_RESOURCE_TYPE,
+                tier,
+                component,
+                extensions,
+                fn)]
+[/#function]
+
+[#function formatLambdaPermissionId tier component fn extensions...]
+    [#return formatComponentResourceId(
+                LAMBDA_PERMISSION_RESOURCE_TYPE,
                 tier,
                 component,
                 extensions,

--- a/aws/templates/resource/resource_event.ftl
+++ b/aws/templates/resource/resource_event.ftl
@@ -1,0 +1,37 @@
+[#-- Events --]
+
+[#assign EVENT_RULE_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        ARN_ATTRIBUTE_TYPE : { 
+            "Attribute" : "Arn"
+        }
+    }
+]
+
+[#assign outputMappings +=
+    {
+        EVENT_RULE_RESOURCE_TYPE : EVENT_RULE_OUTPUT_MAPPINGS
+    }
+]
+
+[#macro createScheduleEventRule mode id targetId scheduleExpression="rate(15 minutes)" dependencies=""]
+    [@cfResource
+        mode=mode
+        id=id
+        type="AWS::Events::Rule"
+        properties=
+            {
+                "ScheduleExpression" : scheduleExpression,
+                "State" : "ENABLED",
+                "Targets" : [{
+                    "Arn" : getReference(targetId, ARN_ATTRIBUTE_TYPE),
+                    "Id" : targetId
+                }]
+            }
+        outputs=EVENT_RULE_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]

--- a/aws/templates/resource/resource_event.ftl
+++ b/aws/templates/resource/resource_event.ftl
@@ -17,7 +17,7 @@
     }
 ]
 
-[#macro createScheduleEventRule mode id targetId scheduleExpression="rate(15 minutes)" dependencies=""]
+[#macro createScheduleEventRule mode id targetId state="ENABLED" scheduleExpression="rate(15 minutes)" dependencies=""]
     [@cfResource
         mode=mode
         id=id
@@ -25,7 +25,7 @@
         properties=
             {
                 "ScheduleExpression" : scheduleExpression,
-                "State" : "ENABLED",
+                "State" : state,
                 "Targets" : [{
                     "Arn" : getReference(targetId, ARN_ATTRIBUTE_TYPE),
                     "Id" : targetId

--- a/aws/templates/resource/resource_lambda.ftl
+++ b/aws/templates/resource/resource_lambda.ftl
@@ -11,12 +11,25 @@
     }
 ]
 
+[#assign LAMBDA_PERMISSION_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+
 [#assign outputMappings +=
     {
         LAMBDA_FUNCTION_RESOURCE_TYPE : LAMBDA_FUNCTION_OUTPUT_MAPPINGS
     }
 ]
 
+[#assign outputMappings +=
+    {
+        LAMBDA_PERMISSION_RESOURCE_TYPE : LAMBDA_PERMISSION_OUTPUT_MAPPINGS
+    }
+]
 [#macro createLambdaFunction mode id container roleId securityGroupIds=[] subnetIds=[] dependencies=""]
     [@cfResource
         mode=mode
@@ -49,6 +62,23 @@
                     "SubnetIds" : getReferences(subnetIds)
                 })
         outputs=LAMBDA_FUNCTION_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]
+
+[#macro createLambdaPermission mode id targetId eventRuleId dependencies=""]
+    [@cfResource
+        mode=mode
+        id=id
+        type="AWS::Lambda::Permission"
+        properties=
+            {
+                "FunctionName" : getReference(targetId),
+                "Action" : "lambda:InvokeFunction",
+                "Principal" : "events.amazonaws.com",
+                "SourceArn" : getReference(eventRuleId, ARN_ATTRIBUTE_TYPE)
+            }
+        outputs=LAMBDA_PERMISSION_OUTPUT_MAPPINGS
         dependencies=dependencies
     /]
 [/#macro]


### PR DESCRIPTION
a scheduled event rule will be created along with lambda function in order to keep it warm.

an example - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#w2ab2c21c10d637c13