### PR TITLE
Add ability to define custom error page for SPA

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -758,6 +758,10 @@
                         {
                             "Name" : "CountryGroups",
                             "Default" : []
+                        },
+                        {
+                            "Name" : "ErrorPage",
+                            "Default" : "/index.html"
                         }
                     ]
                 },

--- a/aws/templates/solution/solution_spa.ftl
+++ b/aws/templates/solution/solution_spa.ftl
@@ -46,7 +46,7 @@
 
         [#assign spaCacheBehaviour = getCFSPACacheBehaviour(spaOrigin) ]
         [#assign configCacheBehaviour = getCFSPACacheBehaviour(configOrigin, "/config/*", {"Default" : 60}) ]
-                   
+
         [#assign restrictions = {} ]
         [#if occurrence.CloudFront.CountryGroups?has_content]
             [#list asArray(occurrence.CloudFront.CountryGroups) as countryGroup]
@@ -74,7 +74,14 @@
                     occurrence.CloudFront.AssumeSNI),
                     occurrence.Certificate.Configured && occurrence.Certificate.Enabled)
             comment=cfName
-            customErrorResponses=getErrorResponse(404) + getErrorResponse(403)
+            customErrorResponses=getErrorResponse(
+                                        404, 
+                                        200,
+                                        occurrence.CloudFront.ErrorPage) + 
+                                getErrorResponse(
+                                        403, 
+                                        200,
+                                        occurrence.CloudFront.ErrorPage)
             defaultCacheBehaviour=spaCacheBehaviour
             defaultRootObject="index.html"
             logging=valueIfTrue(


### PR DESCRIPTION
Currently when cloudfront returns a 404 or 403 error page it is set to returning the index.html page. 

This makes sense for applications that authenticate a user as this forces them back to the login page or to a standard index page.

For static sites this has the potential to return actual content instead of an error page.

This allows for the custom error page to be defined in the SPA Cloudfront configuration 

````json
{
  "SPA" : {
      "CloudFront" : { 
          "ErrorPage" : "/index.html" 
       }
  } 
}
````