### PR TITLE
Add Account level audit logging

### DIFF
--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -430,7 +430,7 @@ function isValidUnit() {
   # Check unit if required
   if [[ "${unit_required[${level}]}" == "true" ]]; then
     # Default deployment units for each level
-    declare -ga ACCOUNT_UNITS_ARRAY=("s3" "cert" "roles" "apigateway" "waf")
+    declare -ga ACCOUNT_UNITS_ARRAY=("audit" "s3" "cert" "roles" "apigateway" "waf")
     declare -ga PRODUCT_UNITS_ARRAY=("s3" "sns" "cert" "cmk")
     declare -ga APPLICATION_UNITS_ARRAY=(${unit})
     declare -ga SOLUTION_UNITS_ARRAY=(${unit})

--- a/aws/templates/account/account_audit.ftl
+++ b/aws/templates/account/account_audit.ftl
@@ -1,0 +1,16 @@
+[#-- Auditing configuration --]
+[#if deploymentUnit?contains("audit")] 
+
+    [#if deploymentSubsetRequired("s3", true)]
+
+        [#assign existingAuditName = getExistingReference(formatAccountS3Id("audit"))]
+        [@createS3Bucket
+            mode=listMode
+            id=formatAccountS3Id("audit")
+            name=valueIfContent(
+                existingAuditName,
+                existingAuditName,
+                formatName("account", "audit", accountObject.Seed))
+        /]
+    [/#if]
+[/#if]


### PR DESCRIPTION
Adds support for an audit log hosted in S3. 

The first stage of this is to enable S3 Server access logging for all s3 buckets deployed by codeontap to a centralised s3 bucket. 

Auditing is enabled at the account level, through the deployment of the audit deployment unit. If this is deployed all s3 buckets that are created will have Server Access logging enabled on it with logs going to an account level audit bucket. 

The option is intentionally not configurable at the bucket level to ensure that it is enabled if auditing is enabled.