### PR TITLE
Add schedules to Lambda Componets

### DIFF
--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -241,7 +241,7 @@
                             dependencies=roleId
                         /]
                         
-                        [#list fn.Schedules as schedule ]
+                        [#list (fn.Schedules!{})?values as schedule ]
                             [#if schedule?is_hash ]
                                 [#-- By default schedule event rule is disabled for all functions with rate 30 minutes --]
                                 [#-- To disable it set fn.Schedule.Enabled to "false" --]
@@ -254,7 +254,7 @@
                                         component,
                                         fn,
                                         occurrence,
-                                        schedule.Name
+                                        schedule.Id
                                         )]
             
                                 [#assign lambdaPermissionId =
@@ -263,7 +263,7 @@
                                         component,
                                         fn,
                                         occurrence,
-                                        schedule.Name
+                                        schedule.Id
                                         )]
                                 
                                 [@createScheduleEventRule
@@ -280,7 +280,8 @@
                                     mode=listMode
                                     id=lambdaPermissionId
                                     targetId=lambdaFunctionId
-                                    eventRuleId=eventRuleId
+                                    sourcePrincipal="events.amazonaws.com"
+                                    sourceId=eventRuleId
                                     dependencies=eventRuleId
                                 /]
                             [/#if]

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -243,11 +243,7 @@
                         
                         [#list (fn.Schedules!{})?values as schedule ]
                             [#if schedule?is_hash ]
-                                [#-- By default schedule event rule is disabled for all functions with rate 30 minutes --]
-                                [#-- To disable it set fn.Schedule.Enabled to "false" --]
-                                [#-- To change schedule expression set fn.Schedule.Expression --]
-                                [#-- The Input path is used to mimic a path request in the same way that Lambda does --]
-                                
+
                                 [#assign eventRuleId =
                                     formatEventRuleId(
                                         tier,

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -206,20 +206,6 @@
                                 component,
                                 fn,
                                 occurrence)]
-
-                        [#assign eventRuleId =
-                            formatEventRuleId(
-                                tier,
-                                component,
-                                fn,
-                                occurrence)]
-    
-                        [#assign lambdaPermissionId =
-                            formatLambdaPermissionId(
-                                tier,
-                                component,
-                                fn,
-                                occurrence)]
     
                         [#assign lambdaFunctionName =
                             formatLambdaFunctionName(
@@ -255,28 +241,50 @@
                             dependencies=roleId
                         /]
                         
-                        [#-- By default schedule event rule is enabled for all functions with rate 15 minutes --]
-                        [#-- To disable it set fn.Schedule.EnabledState to "false" --]
-                        [#-- To change schedule expression set fn.Schedule.Expression --]
-                        [#assign state = "DISABLED"]
-                        [#if fn.Schedule?has_content && fn.Schedule.EnabledState?has_content && fn.Schedule.EnabledState]
-                            [#assign state = "ENABLED"]
-                        [/#if]
-                        [@createScheduleEventRule
-                            mode=listMode
-                            id=eventRuleId
-                            targetId=lambdaFunctionId
-                            state=state
-                            scheduleExpression=(fn.Schedule.Expression)!"rate(15 minutes)"
-                            dependencies=lambdaFunctionId
-                        /]
-                        [@createLambdaPermission
-                            mode=listMode
-                            id=lambdaPermissionId
-                            targetId=lambdaFunctionId
-                            eventRuleId=eventRuleId
-                            dependencies=eventRuleId
-                        /]
+                        [#list fn.Schedules as schedule ]
+                            [#if schedule?is_hash ]
+                                [#-- By default schedule event rule is disabled for all functions with rate 30 minutes --]
+                                [#-- To disable it set fn.Schedule.Enabled to "false" --]
+                                [#-- To change schedule expression set fn.Schedule.Expression --]
+                                [#-- The Input path is used to mimic a path request in the same way that Lambda does --]
+                                
+                                [#assign eventRuleId =
+                                    formatEventRuleId(
+                                        tier,
+                                        component,
+                                        fn,
+                                        occurrence,
+                                        schedule.Name
+                                        )]
+            
+                                [#assign lambdaPermissionId =
+                                    formatLambdaPermissionId(
+                                        tier,
+                                        component,
+                                        fn,
+                                        occurrence,
+                                        schedule.Name
+                                        )]
+                                
+                                [@createScheduleEventRule
+                                    mode=listMode
+                                    id=eventRuleId
+                                    targetId=lambdaFunctionId
+                                    enabled=schedule.Enabled
+                                    scheduleExpression=schedule.Expression
+                                    path=schedule.InputPath
+                                    dependencies=lambdaFunctionId
+                                /]
+
+                                [@createLambdaPermission
+                                    mode=listMode
+                                    id=lambdaPermissionId
+                                    targetId=lambdaFunctionId
+                                    eventRuleId=eventRuleId
+                                    dependencies=eventRuleId
+                                /]
+                            [/#if]
+                        [/#list]
                     [/#if]
                 [/#list]
                 

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -672,10 +672,6 @@
                 {
                     "Name" : "UseSegmentKey",
                     "Default" : false
-                },
-                {
-                    "Name" : "Schedules",
-                    "Default" : [ ]
                 }
             ],
         "s3" : 

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -672,6 +672,10 @@
                 {
                     "Name" : "UseSegmentKey",
                     "Default" : false
+                },
+                {
+                    "Name" : "Schedules",
+                    "Default" : [ ]
                 }
             ],
         "s3" : 

--- a/aws/templates/resource/resource_event.ftl
+++ b/aws/templates/resource/resource_event.ftl
@@ -17,7 +17,14 @@
     }
 ]
 
-[#macro createScheduleEventRule mode id targetId state="ENABLED" scheduleExpression="rate(15 minutes)" dependencies=""]
+[#macro createScheduleEventRule mode id targetId enabled=false scheduleExpression="rate(30 minutes)" path="/healthcheck" dependencies=""]
+
+    [#if enabled ] 
+        [#assign state = "ENABLED" ]
+    [#else]
+        [#assign state = "DISABLED" ]
+    [/#if]
+
     [@cfResource
         mode=mode
         id=id
@@ -28,7 +35,10 @@
                 "State" : state,
                 "Targets" : [{
                     "Arn" : getReference(targetId, ARN_ATTRIBUTE_TYPE),
-                    "Id" : targetId
+                    "Id" : targetId,
+                    "Input" : getJSON(
+                        { "path" : path },
+                        true)
                 }]
             }
         outputs=EVENT_RULE_OUTPUT_MAPPINGS

--- a/aws/templates/resource/resource_lambda.ftl
+++ b/aws/templates/resource/resource_lambda.ftl
@@ -66,7 +66,7 @@
     /]
 [/#macro]
 
-[#macro createLambdaPermission mode id targetId eventRuleId dependencies=""]
+[#macro createLambdaPermission mode id targetId sourcePrincipal sourceId dependencies=""]
     [@cfResource
         mode=mode
         id=id
@@ -75,8 +75,8 @@
             {
                 "FunctionName" : getReference(targetId),
                 "Action" : "lambda:InvokeFunction",
-                "Principal" : "events.amazonaws.com",
-                "SourceArn" : getReference(eventRuleId, ARN_ATTRIBUTE_TYPE)
+                "Principal" : sourcePrincipal,
+                "SourceArn" : getReference(sourceId, ARN_ATTRIBUTE_TYPE)
             }
         outputs=LAMBDA_PERMISSION_OUTPUT_MAPPINGS
         dependencies=dependencies


### PR DESCRIPTION
This allows for schedules to be added to a lambda function explicitly. This can be used for automated lambda invokes, for tasks like reporting or cleanup. 

Schedules are a function property and have 4 values 

* Name - A generic name for cloudformation purposes 
* Enabled - State of the schedule 
* Expression - A cron or rate definition as per https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html 
* InputPath - A path which is sent in a JSON payload as { "path" : value } 

