### PR TITLE
Add s3 link support

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -447,11 +447,10 @@
                                             ),
                                             formatName(
                                                 occurrence.Publish.DnsNamePrefix,
-                                                formatSegmentFullName(
+                                                formatComponentBucketName(
                                                     tier,
                                                     component,
-                                                    occurrence,
-                                                    vpc?remove_beginning("vpc-")
+                                                    occurrence)
                                                 )
                                             )
                                             )]    

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -91,6 +91,14 @@
         value?has_content?then(value,content)) ]
 [/#function]
 
+[#function firstContent alternatives=[] otherwise={}]
+    [#list asArray(alternatives) as alternative]
+        [#if alternative?has_content]
+            [#return alternative]
+        [/#if]
+    [#return otherwise ]
+[/#function]
+
 [#-- Recursively concatenate sequence of non-empty strings with a separator --]
 [#function concatenate args separator]
     [#local content = []]
@@ -1042,6 +1050,7 @@
                         [#case "apigateway"]
                         [#case "lambda"]
                         [#case "sqs"]
+                        [#case "s3"]
                             [#local result = targetOccurrence]
                             [#break]
                     [/#switch]
@@ -1238,6 +1247,27 @@
                     "Attributes" : {
                         "NAME" : getExistingReference(id, NAME_ATTRIBUTE_TYPE),
                         "URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE),
+                        "ARN" : getExistingReference(id, ARN_ATTRIBUTE_TYPE),
+                        "REGION" : regionId
+                    }
+                }
+            ]
+            [#break]
+
+        [#case "s3"]
+            [#local id =
+                formatComponentS3Id(
+                    target.Tier,
+                    target.Component,
+                    target)]
+            [#local result +=
+                {
+                    "ResourceId" : id,
+                    "Attributes" : {
+                        "NAME" : getExistingReference(id, NAME_ATTRIBUTE_TYPE),
+                        "FQDN" : getExistingReference(id, DNS_ATTRIBUTE_TYPE),
+                        "INTERNAL_FQDN" : getExistingReference(id, DNS_ATTRIBUTE_TYPE),
+                        "WEBSITE_URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE),
                         "ARN" : getExistingReference(id, ARN_ATTRIBUTE_TYPE),
                         "REGION" : regionId
                     }

--- a/aws/templates/name/name_s3.ftl
+++ b/aws/templates/name/name_s3.ftl
@@ -1,0 +1,25 @@
+[#-- S3 --]
+
+[#-- Resources --]
+
+[#function formatSegmentBucketName extensions...]
+    [#return
+        formatName(
+            valueIfTrue(
+                (tenantObject.Name)!"",
+                (segmentObject.S3.IncludeTenant)!false,
+                ""),
+            formatSegmentFullName(extensions),
+            vpc?remove_beginning("vpc-"))]
+[/#function]
+
+[#function formatComponentBucketName tier component extensions...]
+    [#return
+        formatName(
+            valueIfTrue(
+                (tenantObject.Name)!"",
+                (segmentObject.S3.IncludeTenant)!false,
+                ""),
+            formatComponentFullName(tier, component, extensions),
+            vpc?remove_beginning("vpc-"))]
+[/#function]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -126,20 +126,16 @@
     [#assign sshStandalone = ((segmentObject.SSH.Standalone)!false) || natHosted ]
     [#assign sshFromProxySecurityGroup = getExistingReference(formatSSHFromProxySecurityGroupId())]
 
-    [#assign operationsBucket = getExistingReference(formatS3OperationsId())]
-    [#if ! operationsBucket?has_content]
-        [#assign operationsBucket = formatSegmentFullName("ops", vpc?remove_beginning("vpc-"))]
-        [#if ((segmentObject.S3.IncludeTenant)!false) && tenantObject?has_content]
-            [#assign operationsBucket = formatName(tenantObject, operationsBucket) ]
-        [/#if]
+    [#assign operationsBucket =
+        firstContent(
+            getExistingReference(formatS3OperationsId()),
+            formatSegmentBucketName("ops"))]
     [/#if]
 
-    [#assign dataBucket = getExistingReference(formatS3DataId())]
-    [#if ! dataBucket?has_content]
-        [#assign dataBucket = formatSegmentFullName("data", vpc?remove_beginning("vpc-"))]
-        [#if ((segmentObject.S3.IncludeTenant)!false) && tenantObject?has_content]
-            [#assign dataBucket = formatName(tenantObject, dataBucket) ]
-        [/#if]
+    [#assign dataBucket =
+        firstContent(
+            getExistingReference(formatS3DataId()),
+            formatSegmentBucketName("data"))]
     [/#if]
 
     [#if segmentObject.Environment??]

--- a/aws/templates/solution/solution_s3.ftl
+++ b/aws/templates/solution/solution_s3.ftl
@@ -42,16 +42,9 @@
             mode=listMode
             id=s3Id
             name=
-                getExistingReference(s3Id)?has_content?then(
-                    getExistingReference(s3Id),
-                    formatHostDomainName(
-                        [
-                            (s3.Name != "S3")?then(s3.Name, componentName),
-                            occurrence,
-                            segmentDomainQualifier
-                        ],
-                        segmentDomain,
-                        occurrence.Style))
+                firstContent(
+                    getExistingReference(s3Id, NAME_ATTRIBUTE_TYPE),
+                    formatComponentBucketName(tier, component, occurrence))
             tier=tier
             component=component
             lifecycleRules=


### PR DESCRIPTION
I refactored the bucket support to use a couple of format routines for different bucket types and added s3 as a valid destination for a link.

I didn't add Cloudfront/Certificate support yet - figured I'd wait until we had a project that needed it.