### PR TITLE
Handle absence of cluster wide storage configuration for ecs cluster

### DIFF
--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -54,9 +54,11 @@
             name=formatComponentLogGroupName(tier, component) /]
     [/#if]
 
-    [#if deploymentSubsetRequired("efs", true) && ecsClusterWideStorage ]
+    [#assign ecsEFSVolumeId = formatEFSId(tier, component)]
+    [#if ecsClusterWideStorage &&
+        deploymentSubsetRequired("efs", true) &&
+        isPartOfCurrentDeploymentUnit(ecsEFSVolumeId) ]
 
-        [#assign ecsEFSVolumeId = formatEFSId(tier, component)]
         [#assign ecsEFSVolumeName = formatComponentFullName( tier, component )]
         [#assign ecsEFSSecurityGroupId = formatComponentSecurityGroupId( tier, component,"efs")]
         [#assign ecsEFSIngressSecurityGroupId = formatDependentSecurityGroupIngressId(ecsEFSSecurityGroupId) ]


### PR DESCRIPTION
* Move definition of ecsEFSVolumeId so its available for the entire template.
* add checking of the id in case we want to mange efs volume creation as a deployment unit in its own right - much like iam,lg etc.