### PR TITLE
Error Specific Custom SPA CloudFront Pages

### DIFF
--- a/aws/templates/id/id_spa.ftl
+++ b/aws/templates/id/id_spa.ftl
@@ -44,6 +44,14 @@
                     {
                         "Name" : "ErrorPage",
                         "Default" : "/index.html"
+                    },
+                    {
+                        "Name" : "DeniedPage",
+                        "Default" : ""
+                    },
+                    {
+                        "Name" : "NotFoundPage",
+                        "Default" : ""
                     }
                 ]
             },

--- a/aws/templates/solution/solution_spa.ftl
+++ b/aws/templates/solution/solution_spa.ftl
@@ -84,16 +84,14 @@
             customErrorResponses=getErrorResponse(
                                         404, 
                                         200,
-                                        cvalueIfContent(
-                                            configuration.CloudFront.NotFoundPage,
+                                        (configuration.CloudFront.NotFoundPage)?has_content?then(
                                             configuration.CloudFront.NotFoundPage,
                                             configuration.CloudFront.ErrorPage
                                         )) + 
                                 getErrorResponse(
                                         403, 
                                         200,
-                                        valueIfContent(
-                                            configuration.CloudFront.DeniedPage,
+                                        (configuration.CloudFront.DeniedPage)?has_content?then(
                                             configuration.CloudFront.DeniedPage,
                                             configuration.CloudFront.ErrorPage
                                         ))

--- a/aws/templates/solution/solution_spa.ftl
+++ b/aws/templates/solution/solution_spa.ftl
@@ -84,11 +84,19 @@
             customErrorResponses=getErrorResponse(
                                         404, 
                                         200,
-                                        configuration.CloudFront.ErrorPage) + 
+                                        cvalueIfContent(
+                                            configuration.CloudFront.NotFoundPage,
+                                            configuration.CloudFront.NotFoundPage,
+                                            configuration.CloudFront.ErrorPage
+                                        )) + 
                                 getErrorResponse(
                                         403, 
                                         200,
-                                        configuration.CloudFront.ErrorPage)
+                                        valueIfContent(
+                                            configuration.CloudFront.DeniedPage,
+                                            configuration.CloudFront.DeniedPage,
+                                            configuration.CloudFront.ErrorPage
+                                        ))
             defaultCacheBehaviour=spaCacheBehaviour
             defaultRootObject="index.html"
             logging=valueIfTrue(


### PR DESCRIPTION
Allow for Error Specific Error pages for CloudFront responses. 

Adds two parameters to the SPA CloudFront Configuration
   DeniedPage - for 403 responses
   NotFoundPage - for 404 responses

If either of these these are set the default ErrorPage is overridden with the value set in the parameter. 

If they aren't set, default to the generic ErrorPage