### PR TITLE
Contenthub Path Naming Fixes and Link Lookup

### DIFF
--- a/aws/templates/application/application_contentnode.ftl
+++ b/aws/templates/application/application_contentnode.ftl
@@ -25,6 +25,7 @@
                 [#assign linkTargetAttributes = linkTarget.State.Attributes ]
 
                 [#switch linkTargetCore.Type!""]
+                    [#case "external"]
                     [#case "contenthub"]
                         [#if linkTargetAttributes.ENGINE == "git" ]
                             [#assign branch = linkTargetAttributes.BRANCH!""]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1028,22 +1028,31 @@
     [#local pathObject = occurrence.Configuration.Path ]
     [#local includes = pathObject.IncludeInPath]
 
-    [#return
-        valueIfTrue(
-            pathObject.Host,
+    [#local path =  valueIfTrue(
+            [
+                pathObject.Host
+            ],
             pathObject.Host?has_content && (!(includes.Host)),
-            formatName(
-                valueIfTrue(pathObject.Host, includes.Host),
+            [
+                valueIfTrue(productName!"", includes.Product),
+                valueIfTrue(solutionObject.Id!"", includes.Solution),
+                valueIfTrue(environmentName!"", includes.Environment),
+                valueIfTrue(segmentName!"", includes.Segment),
                 valueIfTrue(getTierName(tier), includes.Tier),
                 valueIfTrue(getComponentName(component), includes.Component),
                 valueIfTrue(occurrence.Core.Instance.Name!"", includes.Instance),
                 valueIfTrue(occurrence.Core.Version.Name!"", includes.Version),
-                valueIfTrue(segmentName!"", includes.Segment),
-                valueIfTrue(environmentName!"", includes.Environment),
-                valueIfTrue(productName!"", includes.Product)
-            )
+                valueIfTrue(pathObject.Host, includes.Host)
+            ]
         )
     ]
+    
+    [#if pathObject.Style = "Single" ] 
+        [#return formatName(path) ]
+    [#else]
+        [#return formatRelativePath(path)]
+    [/#if]
+
 [/#function]
 
 [#-- Output object as JSON --]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1047,7 +1047,7 @@
         )
     ]
     
-    [#if pathObject.Style = "Single" ] 
+    [#if pathObject.Style = "single" ] 
         [#return formatName(path) ]
     [#else]
         [#return formatRelativePath(path)]

--- a/aws/templates/id/id_contenthub.ftl
+++ b/aws/templates/id/id_contenthub.ftl
@@ -77,7 +77,7 @@
                     },
                     {
                         "Name" : "Style",
-                        "Default" : "Single"
+                        "Default" : "single"
                     },
                     {
                         "Name" : "IncludeInPath",

--- a/aws/templates/id/id_contenthub.ftl
+++ b/aws/templates/id/id_contenthub.ftl
@@ -76,11 +76,28 @@
                         "Default" : ""
                     },
                     {
+                        "Name" : "Style",
+                        "Default" : "Single"
+                    },
+                    {
                         "Name" : "IncludeInPath",
                         "Children" : [
+
                             {
-                                "Name" : "Host",
-                                "Default": false
+                                "Name" : "Product",
+                                "Default" : true
+                            },
+                            {
+                                "Name" : "Environment",
+                                "Default" : false
+                            },
+                            {
+                                "Name" : "Solution",
+                                "Default" : false
+                            },
+                            {
+                                "Name" : "Segment",
+                                "Default" : true
                             },
                             {
                                 "Name" : "Tier",
@@ -99,16 +116,8 @@
                                 "Default" : false
                             },
                             {
-                                "Name" : "Segment",
-                                "Default" : true
-                            },
-                            {
-                                "Name" : "Environment",
-                                "Default" : false
-                            },
-                            {
-                                "Name" : "Product",
-                                "Default" : true
+                                "Name" : "Host",
+                                "Default": false
                             }
                         ]
                     }


### PR DESCRIPTION
Reorder pathing to follow least specific to more specific flow.

Fix link lookup to use external lookup as the type instead of contenthub 

Added Path styling, allowing for the use of a nested folder structure or single folder containing each of the included properties 