### PR TITLE
Support for credentials in Content Hub Git pulls

### DIFF
--- a/aws/manageStack.sh
+++ b/aws/manageStack.sh
@@ -136,7 +136,7 @@ function copy_config_file() {
 function copy_contentnode_file() { 
   local files="$1"; shift
   local engine="$1"; shift
-  local url="$1"; shift
+  local path="$1"; shift
   local prefix="$1"; shift
   local nodepath="$1"; shift
   local branch="$1"; 
@@ -149,7 +149,7 @@ function copy_contentnode_file() {
   if [[ -f "${files}" ]]; then 
 
     case ${engine} in 
-      git) 
+      github) 
 
         # Copy files locally so we can synch with git
         for file in "${files[@]}" ; do
@@ -166,7 +166,8 @@ function copy_contentnode_file() {
         done
 
         # Clone the Repo
-        clone_git_repo "${url}" "${branch}" "${contenthubdir}" || return $?
+        local host="github.com"
+        clone_git_repo "${engine}" "${host}" "${path}" "${branch}" "${contenthubdir}" || return $?
 
         case ${STACK_OPERATION} in 
 
@@ -191,7 +192,7 @@ function copy_contentnode_file() {
         esac
 
         # Commit Repo
-        push_git_repo "${url}" "${branch}" "origin" \
+        push_git_repo "${host}/${path}" "${branch}" "origin" \
             "ContentNodeDeployment-${PRODUCT}-${SEGMENT}-${DEPLOYMENT_UNIT}" \
             "${GIT_USER}" "${GIT_EMAIL}" || return $?
 

--- a/aws/templates/application/application_contentnode.ftl
+++ b/aws/templates/application/application_contentnode.ftl
@@ -27,10 +27,6 @@
                 [#switch linkTargetCore.Type!""]
                     [#case "external"]
                     [#case "contenthub"]
-                        [#if linkTargetAttributes.ENGINE == "git" ]
-                            [#assign branch = linkTargetAttributes.BRANCH!""]
-                            [#assign url = linkTargetAttributes.URL!""]
-                        [/#if]
                         [#if deploymentSubsetRequired("prologue", false)]
                             [@cfScript
                                 mode=listMode
@@ -52,7 +48,7 @@
                                     "  # Sync with the operations bucket",
                                     "  copy_contentnode_file \"$\{tmpdir}/contentnode.zip\" " + 
                                             "\"" + linkTargetAttributes.ENGINE + "\" " +
-                                            "\"" +    linkTargetAttributes.URL + "\" " + 
+                                            "\"" +    linkTargetAttributes.REPOSITORY + "\" " + 
                                             "\"" +    linkTargetAttributes.PREFIX + "\" " +
                                             "\"" +    pathObject + "\" " +
                                             "\"" +    linkTargetAttributes.BRANCH + "\" ",

--- a/aws/templates/id/id_contenthub.ftl
+++ b/aws/templates/id/id_contenthub.ftl
@@ -34,7 +34,7 @@
                 "Default" : "master"
             },
             {
-                "Name" : "Repoistory",
+                "Name" : "Repository",
                 "Default" : ""
             }
         ]

--- a/aws/templates/id/id_contenthub.ftl
+++ b/aws/templates/id/id_contenthub.ftl
@@ -27,14 +27,14 @@
             "Prefix",
             {
                 "Name" : "Engine",
-                "Default" : "git"
+                "Default" : "github"
             },
             {
                 "Name" : "Branch",
                 "Default" : "master"
             },
             {
-                "Name" : "URL",
+                "Name" : "Repoistory",
                 "Default" : ""
             }
         ]
@@ -56,7 +56,7 @@
             },
             "Attributes" : {
                 "ENGINE" : getExistingReference(id, ENGINE_ATTRIBUTE_TYPE),
-                "URL"    : getExistingReference(id, URL_ATTRIBUTE_TYPE),
+                "REPOSITORY" : getExistingReference(id, REPOSITORY_ATTRIBUTE_TYPE),
                 "BRANCH" : getExistingReference(id, BRANCH_ATTRIBUTE_TYPE),
                 "PREFIX" : getExistingReference(id, PREFIX_ATTRIBUTE_TYPE)
             }

--- a/aws/templates/id/start.ftl
+++ b/aws/templates/id/start.ftl
@@ -115,7 +115,7 @@
 [#assign PASSWORD_ATTRIBUTE_TYPE = "password" ]
 [#assign DATABASENAME_ATTRIBUTE_TYPE = "databasename" ]
 [#assign TOPICNAME_ATTRIBUTE_TYPE = "topicname" ]
-[#assign ENGINE_ATTRIBUTE_TYPE = "engine" ]
+[#assign REPOSITORY_ATTRIBUTE_TYPE = "repository" ]
 [#assign BRANCH_ATTRIBUTE_TYPE = "branch" ]
 [#assign PREFIX_ATTRIBUTE_TYPE = "prefix" ]
 

--- a/aws/templates/solution/solution_contenthub.ftl
+++ b/aws/templates/solution/solution_contenthub.ftl
@@ -11,17 +11,7 @@
         [#assign configuration = occurrence.Configuration ]
 
         [#assign contentHubId = formatContentHubHubId(tier, component, occurrence)]
-        [#assign contentHubEngine = configuration.Engine ]
         [#assign contentHubPrefix = configuration.Prefix ]
-
-        [#-- Engine Specifc Configuration --]
-        [#if configuration.Engine == "git" ]
-            [#assign contentHubBranch = configuration.Branch ]
-            [#assign contentHubURL = configuration.URL]
-        [#else]
-            [#assign contentHubBranch = "" ]
-            [#assign contentHubURL = ""]
-        [/#if]
 
         [#if deploymentSubsetRequired("prologue", false)]
             [@cfScript
@@ -33,10 +23,10 @@
                         "create_pseudo_stack" + " " + 
                         "\"Content Hub Deployment\"" + " " +
                         "\"$\{pseudo_stack_file}\"" + " " +
-                        "\"" + contentHubId + "Xengine\" \"" + contentHubEngine + "\" " +  
-                        "\"" + contentHubId + "Xurl\" \"" + contentHubURL + "\" " +
+                        "\"" + contentHubId + "Xengine\" \"" + configuration.Engine + "\" " +  
+                        "\"" + contentHubId + "Xrepository\" \"" + configuration.Repository + "\" " +
                         "\"" + contentHubId + "Xprefix\" \"" + contentHubPrefix + "\" " +
-                        "\"" + contentHubId + "Xbranch\" \"" + contentHubBranch + "\" " +
+                        "\"" + contentHubId + "Xbranch\" \"" + configuration.Branch + "\" " +
                         "|| return $?", 
                     "}",
                     "pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-pseudo-stack.json\" ",

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -727,10 +727,10 @@ function clone_git_repo() {
       (-z "${repo_branch}") ||
       (-z "${local_dir}") ]] && fatalMandatory && return 1
 
-  trace "Cloning the ${repo_url} repo and checking out the ${repo_branch} branch ..."
-
   local credentials_var="${repo_provider^^}_CREDENTIALS"
-  local repo_url="https://${!credentials_var}@${repo_host}/${repo_path} ${INTEGRATOR_DIR}"
+  local repo_url="https://${!credentials_var}@${repo_host}/${repo_path}"
+
+  trace "Cloning the ${repo_url} repo and checking out the ${repo_branch} branch ..."
 
   git clone -b "${repo_branch}" "${repo_url}" "${local_dir}"
   RESULT=$? && [[ ${RESULT} -ne 0 ]] && fatal "Can't clone ${repo_url} repo" && return 1

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -715,15 +715,22 @@ function create_snapshot() {
 
 # -- Git Repo Management -- 
 function clone_git_repo() {
-  local repo_url="$1"; shift
+  local repo_provider="$1"; shift
+  local repo_host="$1"; shift
+  local repo_path="$1"; shift
   local repo_branch="$1"; shift
   local local_dir="$1"; 
 
-  [[ (-z "${repo_url}") ||
+  [[  (-z "${repo_provider}") ||
+      (-z "${repo_host}") ||
+      (-z "${repo_path}") ||
       (-z "${repo_branch}") ||
       (-z "${local_dir}") ]] && fatalMandatory && return 1
 
   trace "Cloning the ${repo_url} repo and checking out the ${repo_branch} branch ..."
+
+  local credentials_var="${repo_provider^^}_CREDENTIALS"
+  local repo_url="https://${!credentials_var}@${repo_host}/${repo_path} ${INTEGRATOR_DIR}"
 
   git clone -b "${repo_branch}" "${repo_url}" "${local_dir}"
   RESULT=$? && [[ ${RESULT} -ne 0 ]] && fatal "Can't clone ${repo_url} repo" && return 1


### PR DESCRIPTION
In order to push changes to Github credentials need to be provided when the repo is pulled. 

This adds the ability to lookup the github credentials using the env variable set by the Jenkins server.