### PR TITLE
Feature getoccurrence ecsservice ecstask lambdafunction support

### DIFF
--- a/aws/templates/application/application_contentnode.ftl
+++ b/aws/templates/application/application_contentnode.ftl
@@ -1,7 +1,7 @@
 [#if componentType = "contentnode"]
 
     [#list requiredOccurrences(
-            getOccurrences(component, tier, component),
+            getOccurrences(tier, component),
             deploymentUnit) as occurrence]
 
         [@cfDebug listMode occurrence false /]

--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -1,245 +1,217 @@
 [#if componentType == "ecs"]
-    [#assign ecs = component.ECS]
-    [#assign fixedIP = ecs.FixedIP?? && ecs.FixedIP]
-    [#assign ecsId = formatECSId(tier, component)]
-    [#assign ecsSecurityGroupId = formatECSSecurityGroupId(tier, component)]
-    [#assign ecsServiceRoleId = formatECSServiceRoleId(tier, component)]
+    [#list getOccurrences(tier, component) as occurrence ]
 
-    [#assign serviceOccurrences=[] ]
-    [#list (ecs.Services!{})?values as service]
-        [#if service?is_hash]
-            [#assign serviceOccurrences +=
-                requiredOccurrences(
-                    getOccurrences(service, tier, component, "service"),
-                    deploymentUnit)]
-        [/#if]
-    [/#list]
+        [@cfDebug listMode occurrence false /]
 
-    [#assign taskOccurrences=[] ]
-    [#list (ecs.Tasks!{})?values as task]
-        [#if task?is_hash]
-            [#assign taskOccurrences +=
-                requiredOccurrences(
-                    getOccurrences(task, tier, component, "task"),
-                    deploymentUnit)]
-        [/#if]
-    [/#list]
+        [#assign resources = occurrence.State.Resources]
+        [#assign ecsId = resources["cluster"].Id!"" ]
+        [#assign ecsSecurityGroupId = resources["securityGroup"].Id!"" ]
+        [#assign ecsServiceRoleId = resources["serviceRole"].Id!"" ]
 
-    [#list serviceOccurrences as occurrence]
-        [#assign core = occurrence.Core ]
-        [#assign configuration = occurrence.Configuration ]
+        [#list requiredOccurrences(
+                occurrence.Occurrences![],
+                deploymentUnit) as subOccurrence]
+            [#assign core = subOccurrence.Core ]
+            [#assign configuration = subOccurrence.Configuration ]
+            [#assign resources = subOccurrence.State.Resources]
 
-        [#assign serviceDependencies = []]
-        [#assign serviceId = formatECSServiceId(
-                                tier,
-                                component,
-                                occurrence)]
-        [#assign taskId    = formatECSTaskId(
-                                tier,
-                                component,
-                                occurrence)]
+            [#assign taskId = resources["task"].Id ]
+            [#assign containers = getTaskContainers(subOccurrence) ]
+
+            [#if core.Type == SERVICE_COMPONENT_TYPE]
         
-        [#if deploymentSubsetRequired("ecs", true)]
-
-            [#assign containers = getTaskContainers(tier, component, occurrence) ]
-
-            [#assign loadBalancers = [] ]
-            [#assign dependencies = [] ]
-            [#list containers as container]
-                [#list container.PortMappings![] as portMapping]
-                    [#if portMapping.LoadBalancer?has_content]
-                        [#assign loadBalancer = portMapping.LoadBalancer]
-                        [#assign loadBalancerId = 
-                            loadBalancer.TargetGroup?has_content?then(
-                                formatALBTargetGroupId(
-                                    loadBalancer.Tier,
-                                    loadBalancer.Component,
-                                    ports[loadBalancer.Port],
-                                    loadBalancer.TargetGroup,
-                                    loadBalancer.Instance,
-                                    loadBalancer.Version
-                                ),
-                                formatELBId(
-                                    loadBalancer.Tier,
-                                    loadBalancer.Component,
-                                    loadBalancer.Instance,
-                                    loadBalancer.Version
-                                )
-                            )
-                        ]
-                        [#assign loadBalancers +=
-                            [
-                                {
-                                    "ContainerName" : container.Name,
-                                    "ContainerPort" : ports[portMapping.ContainerPort].Port
-                                } +
-                                loadBalancer.TargetGroup?has_content?then(
-                                    {
-                                        "TargetGroupArn" :
-                                            getReference(loadBalancerId, ARN_ATTRIBUTE_TYPE)
-                                    },
-                                    {
-                                        "LoadBalancerName" :
-                                            getReference(loadBalancerId)
-                                    }
-                                )
-                            ]
-                        ]
-                        [#assign dependencies += [loadBalancerId] ]
-
-                        [#assign loadBalancerSecurityGroupId = 
-                                    formatComponentSecurityGroupId(
-                                        loadBalancer.Tier,
-                                        loadBalancer.Component,
-                                        loadBalancer.Instance,
-                                        loadBalancer.Version) ]
-                                        
-                        [@createSecurityGroupIngress
-                            mode=listMode
-                            id=
-                                formatContainerSecurityGroupIngressId(
-                                    ecsSecurityGroupId,
-                                    container,
-                                    portMapping.DynamicHostPort?then(
-                                        "dynamic",
-                                        ports[portMapping.HostPort].Port
-                                    )
-                                )
-                            port=portMapping.DynamicHostPort?then(0, portMapping.HostPort)
-                            cidr="0.0.0.0/0"
-                            groupId=ecsSecurityGroupId
-                        /]
-
-                        [#if (loadBalancer.TargetGroup?has_content) &&
-                                isPartOfCurrentDeploymentUnit(loadBalancerId)]
-
-                            [@createTargetGroup
-                                mode=listMode
-                                id=loadBalancerId
-                                name=loadBalancer.TargetGroup
-                                tier=loadBalancer.Tier
-                                component=loadBalancer.Component
-                                source=ports[loadBalancer.Port]
-                                destination=ports[portMapping.HostPort]
-                            /]
-                            [#assign listenerRuleId = 
-                                formatALBListenerRuleId(
-                                    loadBalancer.Tier,
-                                    loadBalancer.Component,
-                                    ports[loadBalancer.Port],
-                                    loadBalancer.TargetGroup,
-                                    loadBalancer.Instance,
-                                    loadBalancer.Version
-                                )]
-                            [@createListenerRule
-                                mode=listMode
-                                id=listenerRuleId
-                                listenerId=
-                                    formatALBListenerId(
-                                        loadBalancer.Tier,
-                                        loadBalancer.Component,
-                                        ports[loadBalancer.Port],
-                                        loadBalancer.Instance,
-                                        loadBalancer.Version
-                                    )
-                                actions=getListenerRuleForwardAction(loadBalancerId)
-                                conditions=getListenerRulePathCondition(loadBalancer.Path)
-                                priority=loadBalancer.Priority!100
-                                dependencies=loadBalancerId
-                            /]
-                        [#assign dependencies += [listenerRuleId] ]
-                        [/#if]    
-                    [/#if]
-                [/#list]
-            [/#list]
-
-            [@createECSService
-                mode=listMode
-                id=serviceId
-                ecsId=ecsId
-                desiredCount=
-                    (configuration.DesiredCount >= 0)?then(
-                        configuration.DesiredCount,
-                        multiAZ?then(zones?size,1)
-                    )
-                taskId=taskId
-                loadBalancers=loadBalancers
-                roleId=ecsServiceRoleId
-                dependencies=dependencies
-            /]
-        [/#if]
-    [/#list]
-    
-    [#list (serviceOccurrences + taskOccurrences) as occurrence]
-        [#assign core = occurrence.Core ]
-        [#assign configuration = occurrence.Configuration ]
-
-        [#assign taskId    = formatECSTaskId(
-                                tier,
-                                component,
-                                occurrence)?replace("-","X")]
-                                
-        [#assign containers = getTaskContainers(tier, component, occurrence) ]
-
-        [#assign dependencies = [] ]
-
-        [#if configuration.UseTaskRole]
-            [#assign roleId = formatDependentRoleId(taskId) ]
-            [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(roleId)]
-                [@createRole 
-                    mode=listMode
-                    id=roleId
-                    trustedServices=["ecs-tasks.amazonaws.com"]
-                /]
+                [#assign serviceId = resources["service"].Id  ]
+                [#assign serviceDependencies = []]
                 
-                [#list containers as container]
-                    [#if container.Policy?has_content]
-                        [#assign policyId = formatDependentPolicyId(taskId, container.Id) ]
-                        [@createPolicy
-                            mode=listMode
-                            id=policyId
-                            name=container.Name
-                            statements=container.Policy
-                            roles=roleId
-                        /]
-                        [#assign dependencies += [policyId] ]
-                    [/#if]
-
-                    [#assign linkPolicies = getLinkTargetsOutboundRoles(container.Links) ]
-
-                    [#if linkPolicies?has_content]
-                        [#assign policyId = formatDependentPolicyId(taskId, container.Id, "links")]
-                        [@createPolicy
-                            mode=listMode
-                            id=policyId
-                            name="links"
-                            statements=linkPolicies
-                            roles=roleId
-                        /]
-                        [#assign dependencies += [policyId] ]
-                    [/#if]
+                [#if deploymentSubsetRequired("ecs", true)]
+               
+                    [#assign loadBalancers = [] ]
+                    [#assign dependencies = [] ]
+                    [#list containers as container]
+                        [#list container.PortMappings![] as portMapping]
+                            [#if portMapping.LoadBalancer?has_content]
+                                [#assign loadBalancer = portMapping.LoadBalancer]
+                                [#assign loadBalancerId = 
+                                    loadBalancer.TargetGroup?has_content?then(
+                                        formatALBTargetGroupId(
+                                            loadBalancer.Tier,
+                                            loadBalancer.Component,
+                                            ports[loadBalancer.Port],
+                                            loadBalancer.TargetGroup,
+                                            loadBalancer.Instance,
+                                            loadBalancer.Version
+                                        ),
+                                        formatELBId(
+                                            loadBalancer.Tier,
+                                            loadBalancer.Component,
+                                            loadBalancer.Instance,
+                                            loadBalancer.Version
+                                        )
+                                    )
+                                ]
+                                [#assign loadBalancers +=
+                                    [
+                                        {
+                                            "ContainerName" : container.Name,
+                                            "ContainerPort" : ports[portMapping.ContainerPort].Port
+                                        } +
+                                        loadBalancer.TargetGroup?has_content?then(
+                                            {
+                                                "TargetGroupArn" :
+                                                    getReference(loadBalancerId, ARN_ATTRIBUTE_TYPE)
+                                            },
+                                            {
+                                                "LoadBalancerName" :
+                                                    getReference(loadBalancerId)
+                                            }
+                                        )
+                                    ]
+                                ]
+                                [#assign dependencies += [loadBalancerId] ]
+        
+                                [#assign loadBalancerSecurityGroupId = 
+                                            formatComponentSecurityGroupId(
+                                                loadBalancer.Tier,
+                                                loadBalancer.Component,
+                                                loadBalancer.Instance,
+                                                loadBalancer.Version) ]
+                                                
+                                [@createSecurityGroupIngress
+                                    mode=listMode
+                                    id=
+                                        formatContainerSecurityGroupIngressId(
+                                            ecsSecurityGroupId,
+                                            container,
+                                            portMapping.DynamicHostPort?then(
+                                                "dynamic",
+                                                ports[portMapping.HostPort].Port
+                                            )
+                                        )
+                                    port=portMapping.DynamicHostPort?then(0, portMapping.HostPort)
+                                    cidr="0.0.0.0/0"
+                                    groupId=ecsSecurityGroupId
+                                /]
+        
+                                [#if (loadBalancer.TargetGroup?has_content) &&
+                                        isPartOfCurrentDeploymentUnit(loadBalancerId)]
+        
+                                    [@createTargetGroup
+                                        mode=listMode
+                                        id=loadBalancerId
+                                        name=loadBalancer.TargetGroup
+                                        tier=loadBalancer.Tier
+                                        component=loadBalancer.Component
+                                        source=ports[loadBalancer.Port]
+                                        destination=ports[portMapping.HostPort]
+                                    /]
+                                    [#assign listenerRuleId = 
+                                        formatALBListenerRuleId(
+                                            loadBalancer.Tier,
+                                            loadBalancer.Component,
+                                            ports[loadBalancer.Port],
+                                            loadBalancer.TargetGroup,
+                                            loadBalancer.Instance,
+                                            loadBalancer.Version
+                                        )]
+                                    [@createListenerRule
+                                        mode=listMode
+                                        id=listenerRuleId
+                                        listenerId=
+                                            formatALBListenerId(
+                                                loadBalancer.Tier,
+                                                loadBalancer.Component,
+                                                ports[loadBalancer.Port],
+                                                loadBalancer.Instance,
+                                                loadBalancer.Version
+                                            )
+                                        actions=getListenerRuleForwardAction(loadBalancerId)
+                                        conditions=getListenerRulePathCondition(loadBalancer.Path)
+                                        priority=loadBalancer.Priority!100
+                                        dependencies=loadBalancerId
+                                    /]
+                                [#assign dependencies += [listenerRuleId] ]
+                                [/#if]    
+                            [/#if]
+                        [/#list]
+                    [/#list]
+        
+                    [@createECSService
+                        mode=listMode
+                        id=serviceId
+                        ecsId=ecsId
+                        desiredCount=
+                            (configuration.DesiredCount >= 0)?then(
+                                configuration.DesiredCount,
+                                multiAZ?then(zones?size,1)
+                            )
+                        taskId=taskId
+                        loadBalancers=loadBalancers
+                        roleId=ecsServiceRoleId
+                        dependencies=dependencies
+                    /]
+                [/#if]
+            [/#if]
+    
+            [#assign dependencies = [] ]
+    
+            [#if configuration.UseTaskRole]
+                [#assign roleId = formatDependentRoleId(taskId) ]
+                [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(roleId)]
+                    [@createRole 
+                        mode=listMode
+                        id=roleId
+                        trustedServices=["ecs-tasks.amazonaws.com"]
+                    /]
+                    
+                    [#list containers as container]
+                        [#if container.Policy?has_content]
+                            [#assign policyId = formatDependentPolicyId(taskId, container.Id) ]
+                            [@createPolicy
+                                mode=listMode
+                                id=policyId
+                                name=container.Name
+                                statements=container.Policy
+                                roles=roleId
+                            /]
+                            [#assign dependencies += [policyId] ]
+                        [/#if]
+    
+                        [#assign linkPolicies = getLinkTargetsOutboundRoles(container.Links) ]
+    
+                        [#if linkPolicies?has_content]
+                            [#assign policyId = formatDependentPolicyId(taskId, container.Id, "links")]
+                            [@createPolicy
+                                mode=listMode
+                                id=policyId
+                                name="links"
+                                statements=linkPolicies
+                                roles=roleId
+                            /]
+                            [#assign dependencies += [policyId] ]
+                        [/#if]
+                    [/#list]
+                [/#if]
+            [#else]
+                [#assign roleId = "" ]
+            [/#if]
+    
+            [#if deploymentSubsetRequired("ecs", true)]
+                [@createECSTask
+                    mode=listMode
+                    id=taskId
+                    containers=containers
+                    role=roleId
+                    dependencies=dependencies
+                /]
+    
+                [#-- Pick any extra macros in the container fragments --]
+                [#list (configuration.Containers!{})?values as container]
+                    [#assign containerListMode = listMode]
+                    [#assign containerId = formatContainerFragmentId(occurrence, container)]
+                    [#include containerList?ensure_starts_with("/")]
                 [/#list]
             [/#if]
-        [#else]
-            [#assign roleId = "" ]
-        [/#if]
-
-        [#if deploymentSubsetRequired("ecs", true)]
-            [@createECSTask
-                mode=listMode
-                id=taskId
-                containers=containers
-                role=roleId
-                dependencies=dependencies
-            /]
-
-            [#-- Pick any extra macros in the container fragments --]
-            [#list (configuration.Containers!{})?values as container]
-                [#assign containerListMode = listMode]
-                [#assign containerId = formatContainerFragmentId(occurrence, container)]
-                [#include containerList?ensure_starts_with("/")]
-            [/#list]
-        [/#if]
+        [/#list]
     [/#list]
 [/#if]
 

--- a/aws/templates/application/application_spa.ftl
+++ b/aws/templates/application/application_spa.ftl
@@ -1,7 +1,7 @@
 [#if componentType = "spa"]
 
     [#list requiredOccurrences(
-            getOccurrences(component, tier, component),
+            getOccurrences(tier, component),
             deploymentUnit) as occurrence]
 
         [@cfDebug listMode occurrence false /]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -275,7 +275,16 @@
         [#local tierId = tier ]
     [/#if]
 
-    [#return (blueprintObject.Tiers[tierId])!{} ]
+    [#-- Special processing for the "all" tier --]
+    [#if tierId == "all"]
+        [#return
+          {
+              "Id" : "all",
+              "Name" : "all"
+          } ]
+    [#else]
+        [#return (blueprintObject.Tiers[tierId])!{} ]
+    [/#if]
 [/#function]
 
 [#-- Get the id for a tier --]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -577,7 +577,14 @@
 [/#function]
 
 [#function getOccurrenceState occurrence]
-    [#local result = {} ]
+    [#local result =
+        {
+            "Resources" : {},
+            "Attributes" : {
+                "NOATTRIBUTES" : "Attributes not found"
+            }
+        }
+    ]
 
     [#if occurrence?has_content]
         [#local core = occurrence.Core ]
@@ -675,15 +682,6 @@
                 [#local result = getUserPoolState(occurrence)]
                 [#break]
         [/#switch]
-    [#else]
-        [#local result = 
-            {
-                "Resources" : {},
-                "Attributes" : {
-                    "NOATTRIBUTES" : "Attributes not found"
-                }
-            }
-        ]
     [/#if]
 
     [#-- Update resource deployment status --]

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -67,8 +67,8 @@
     [/#if]
 [/#macro]
 
-[#function getLinkResourceId link]
-    [#return (context.Links[link].State.Resources["primary"].Id)!"" ]
+[#function getLinkResourceId link alias]
+    [#return (context.Links[link].State.Resources[alias].Id)!"" ]
 [/#function]
 
 [#function addLinkVariablesToContext context name link attributes rawName=false]
@@ -243,12 +243,15 @@
     ]
 [/#function]
 
-[#function getTaskContainers tier component task]
-    
-    [#local containers = [] ]
-    
+[#function getTaskContainers task]
+
     [#local core = task.Core ]
     [#local configuration = task.Configuration ]
+
+    [#local tier = core.Tier ]
+    [#local component = core.Component ]
+
+    [#local containers = [] ]
 
     [#list (configuration.Containers!{})?values as container]
         [#if container?is_hash]
@@ -273,7 +276,7 @@
                         [#local instanceAndVersionMatch = {}]
                         [#local instanceMatch = {}]
                         [#if targetComponent?has_content]
-                            [#list getOccurrences(targetComponent, targetTierId, targetComponentId) as targetOccurrence]
+                            [#list getOccurrences(getTier(targetTierId), targetComponent) as targetOccurrence]
                                 [#if core.Instance.Id == targetOccurrence.Core.Instance.Id]
                                     [#if core.Version.Id == targetOccurrence.Core.Version.Id]
                                         [#local instanceAndVersionMatch = targetOccurrence]

--- a/aws/templates/createBlueprint.ftl
+++ b/aws/templates/createBlueprint.ftl
@@ -103,7 +103,7 @@
         [
           {
               "Id" : id,
-              "Occurrences" : getOccurrences(component, tier, component)
+              "Occurrences" : getOccurrences(tier, component)
           }]]
     [/#if]
   [/#list]

--- a/aws/templates/id/id_alb.ftl
+++ b/aws/templates/id/id_alb.ftl
@@ -108,7 +108,7 @@
     [#return
         {
             "Resources" : {
-                "primary" : {
+                "lb" : {
                     "Id" : id
                 }
             },

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -61,16 +61,6 @@
                 extensions)]
 [/#function]
 
-[#function formatAPIGatewayLambdaPermissionId tier component link fn extensions...]
-    [#return formatComponentResourceId(
-                "apiLambdaPermission",
-                tier,
-                component,
-                extensions,
-                fn,
-                link)]
-[/#function]
-
 [#assign componentConfiguration +=
     {
         "apigateway" : [
@@ -178,7 +168,7 @@
     [#return
         {
             "Resources" : {
-                "primary" : {
+                "gateway" : {
                     "Id" : id,
                     "Name" : name
                 }

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -130,7 +130,7 @@
     [#return
         {
             "Resources" : {
-                "primary" : {
+                "pool" : {
                     "Id" : id
                 }
             },

--- a/aws/templates/id/id_contenthub.ftl
+++ b/aws/templates/id/id_contenthub.ftl
@@ -50,7 +50,7 @@
     [#return
         {
             "Resources" : {
-                "primary" : {
+                "hub" : {
                     "Id" : id
                 }
             },
@@ -140,7 +140,7 @@
     [#return
         {
             "Resources" : {
-                "primary" : {
+                "node" : {
                     "Id" : id
                 }
             },

--- a/aws/templates/id/id_event.ftl
+++ b/aws/templates/id/id_event.ftl
@@ -1,28 +1,10 @@
 [#-- Event --]
 
-[#assign EVENT_RESOURCE_TYPE = "event" ]
 [#assign EVENT_RULE_RESOURCE_TYPE = "event" ]
 
-[#function formatEventId tier component extensions...]
-    [#return formatComponentResourceId(
-                EVENT_RESOURCE_TYPE,
-                tier,
-                component,
-                extensions)]
-[/#function]
-
-[#function formatEventRuleId tier component fn extensions...]
-    [#return formatComponentResourceId(
+[#function formatEventRuleId occurrence extensions...]
+    [#return formatResourceId(
                 EVENT_RULE_RESOURCE_TYPE,
-                tier,
-                component,
-                extensions,
-                fn)]
-[/#function]
-
-[#function formatEventRuleArn ruleId account={ "Ref" : "AWS::AccountId" }]
-    [#return
-        formatRegionalArn(
-            "event",
-            getReference(ruleId))]
+                occurrence.Core.Id,
+                extensions)]
 [/#function]

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -4,30 +4,14 @@
 [#assign LAMBDA_FUNCTION_RESOURCE_TYPE = "lambda" ]
 [#assign LAMBDA_PERMISSION_RESOURCE_TYPE = "permission" ]
 
-[#function formatLambdaId tier component extensions...]
-    [#return formatComponentResourceId(
-                LAMBDA_RESOURCE_TYPE,
-                tier,
-                component,
-                extensions)]
-[/#function]
+[#assign LAMBDA_COMPONENT_TYPE = "lambda" ]
+[#assign LAMBDA_FUNCTION_COMPONENT_TYPE = "function" ]
 
-[#function formatLambdaFunctionId tier component fn extensions...]
-    [#return formatComponentResourceId(
-                LAMBDA_FUNCTION_RESOURCE_TYPE,
-                tier,
-                component,
-                extensions,
-                fn)]
-[/#function]
-
-[#function formatLambdaPermissionId tier component fn extensions...]
-    [#return formatComponentResourceId(
+[#function formatLambdaPermissionId occurrence extensions...]
+    [#return formatResourceId(
                 LAMBDA_PERMISSION_RESOURCE_TYPE,
-                tier,
-                component,
-                extensions,
-                fn)]
+                occurrence.Core.Id,
+                extensions)]
 [/#function]
 
 [#function formatLambdaArn lambdaId account={ "Ref" : "AWS::AccountId" }]
@@ -39,7 +23,17 @@
 
 [#assign componentConfiguration +=
     {
-        "lambda" : [
+        LAMBDA_COMPONENT_TYPE : {
+            "Attributes" : [],
+            "Components" : [
+                {
+                    "Type" : LAMBDA_FUNCTION_COMPONENT_TYPE,
+                    "Component" : "Functions",
+                    "Link" : "Function"
+                }
+            ]
+        },
+        LAMBDA_FUNCTION_COMPONENT_TYPE : [
             "RunTime",
             "Container",
             "Handler",
@@ -52,6 +46,10 @@
                 "Default" : 0
             },
             {
+                "Name" : "Schedules",
+                "Default" : {}
+            },
+            {
                 "Name" : "Timeout",
                 "Default" : 0
             },
@@ -60,26 +58,44 @@
                 "Default" : true
             },
             {
-                "Name" : "Functions",
-                "Default" : {}
-            },
-            {
                 "Name" : "UseSegmentKey",
                 "Default" : false
             }
         ]
-    }]
+    }
+]
     
 [#function getLambdaState occurrence]
     [#local core = occurrence.Core]
 
-    [#local id = formatLambdaId(core.Tier, core.Component, occurrence)]
+    [#return
+        {
+            "Resources" : {
+                "lambda" : {
+                    "Id" : formatResourceId(LAMBDA_RESOURCE_TYPE, core.Id),
+                    "Name" : formatSegmentFullName(core.Name)
+                }
+            },
+            "Attributes" : {
+                "REGION" : regionId
+            },
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#function]
+
+[#function getFunctionState occurrence]
+    [#local core = occurrence.Core]
 
     [#return
         {
             "Resources" : {
-                "primary" : {
-                    "Id" : id
+                "function" : {
+                    "Id" : formatResourceId(LAMBDA_FUNCTION_RESOURCE_TYPE, core.Id),
+                    "Name" : formatSegmentFullName(core.Name)
                 }
             },
             "Attributes" : {

--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -82,7 +82,7 @@
     [#local result =
         {
             "Resources" : {
-                "primary" : {
+                "db" : {
                     "Id" : id
                 }
             },

--- a/aws/templates/id/id_s3.ftl
+++ b/aws/templates/id/id_s3.ftl
@@ -108,7 +108,7 @@
     [#return
         {
             "Resources" : {
-                "primary" : {
+                "bucket" : {
                     "Id" : id,
                     "Name" :
                         firstContent(

--- a/aws/templates/id/id_sqs.ftl
+++ b/aws/templates/id/id_sqs.ftl
@@ -51,7 +51,7 @@
     [#return
         {
             "Resources" : {
-                "primary" : {
+                "queue" : {
                     "Id" : id,
                     "Name" : name
                 },

--- a/aws/templates/resource/resource_lambda.ftl
+++ b/aws/templates/resource/resource_lambda.ftl
@@ -21,12 +21,7 @@
 
 [#assign outputMappings +=
     {
-        LAMBDA_FUNCTION_RESOURCE_TYPE : LAMBDA_FUNCTION_OUTPUT_MAPPINGS
-    }
-]
-
-[#assign outputMappings +=
-    {
+        LAMBDA_FUNCTION_RESOURCE_TYPE : LAMBDA_FUNCTION_OUTPUT_MAPPINGS,
         LAMBDA_PERMISSION_RESOURCE_TYPE : LAMBDA_PERMISSION_OUTPUT_MAPPINGS
     }
 ]
@@ -66,7 +61,7 @@
     /]
 [/#macro]
 
-[#macro createLambdaPermission mode id targetId sourcePrincipal sourceId dependencies=""]
+[#macro createLambdaPermission mode id targetId source={} sourcePrincipal="" sourceId="" dependencies=""]
     [@cfResource
         mode=mode
         id=id
@@ -74,10 +69,16 @@
         properties=
             {
                 "FunctionName" : getReference(targetId),
-                "Action" : "lambda:InvokeFunction",
-                "Principal" : sourcePrincipal,
-                "SourceArn" : getReference(sourceId, ARN_ATTRIBUTE_TYPE)
-            }
+                "Action" : "lambda:InvokeFunction"
+            } +
+            valueIfContent(
+                source,
+                source,
+                {
+                    "Principal" : sourcePrincipal,
+                    "SourceArn" : getReference(sourceId, ARN_ATTRIBUTE_TYPE)
+                }
+            )
         outputs=LAMBDA_PERMISSION_OUTPUT_MAPPINGS
         dependencies=dependencies
     /]

--- a/aws/templates/resource/start.ftl
+++ b/aws/templates/resource/start.ftl
@@ -221,45 +221,45 @@
         ) +
         [
             { "Key" : "cot:configuration", "Value" : configurationReference },
-            { "Key" : "cot:tenant", "Value" : tenantId },
-            { "Key" : "cot:account", "Value" : accountId }
+            { "Key" : "cot:tenant", "Value" : tenantName },
+            { "Key" : "cot:account", "Value" : accountName }
         ] +
         productId?has_content?then(
             [
-                { "Key" : "cot:product", "Value" : productId }
+                { "Key" : "cot:product", "Value" : productName }
             ],
             []
         ) +
         segmentId?has_content?then(
             [
-                { "Key" : "cot:segment", "Value" : segmentId }
+                { "Key" : "cot:segment", "Value" : segmentName }
             ],
             []
         ) +
         environmentId?has_content?then(
             [
-                { "Key" : "cot:environment", "Value" : environmentId }
+                { "Key" : "cot:environment", "Value" : environmentName }
             ],
             []
         ) +
         [
-            { "Key" : "cot:category", "Value" : categoryId }
+            { "Key" : "cot:category", "Value" : categoryName }
         ] +
         tier?has_content?then(
             [
-                { "Key" : "cot:tier", "Value" : getTierId(tier) }
+                { "Key" : "cot:tier", "Value" : getTierName(tier) }
             ],
             []
         ) +
         component?has_content?then(
             [
-                { "Key" : "cot:component", "Value" : getComponentId(component) }
+                { "Key" : "cot:component", "Value" : getComponentName(component) }
             ],
             []
         ) +
         zone?has_content?then(
             [
-                { "Key" : "cot:zone", "Value" : getZoneId(zone) }
+                { "Key" : "cot:zone", "Value" : getZoneName(zone) }
             ],
             []
         ) + 

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -144,6 +144,7 @@
         [#assign environmentObject = environments[environmentId]]
         [#assign environmentName = environmentObject.Name]
         [#assign categoryId = segmentObject.Category!environmentObject.Category]
+        [#assign categoryName = segmentObject.Category!environmentObject.Category]
         [#assign categoryObject = categories[categoryId]]
     [/#if]
 

--- a/aws/templates/solution/solution_alb.ftl
+++ b/aws/templates/solution/solution_alb.ftl
@@ -2,7 +2,7 @@
 [#if (componentType == "alb") && deploymentSubsetRequired("alb", true)]
 
     [#list requiredOccurrences(
-            getOccurrences(component, tier, component),
+            getOccurrences(tier, component),
             deploymentUnit) as occurrence]
 
         [@cfDebug listMode occurrence false /]

--- a/aws/templates/solution/solution_contenthub.ftl
+++ b/aws/templates/solution/solution_contenthub.ftl
@@ -1,8 +1,7 @@
 [#if (componentType == "contenthub") ]
-    [#assign contenthub = component.contenthub]
 
     [#list requiredOccurrences(
-        getOccurrences(component, tier, component),
+        getOccurrences(tier, component),
         deploymentUnit) as occurrence]
 
         [@cfDebug listMode occurrence false /]

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -1,363 +1,374 @@
 [#-- ECS --]
 [#if componentType == "ecs"]
-    [#assign ecs = component.ECS]
-    [#assign ecsId = formatECSId(tier, component)]
-    [#assign ecsFullName = componentFullName]
-    [#assign ecsRoleId = formatECSRoleId(tier, component)]
-    [#assign ecsServiceRoleId = formatECSServiceRoleId(tier, component)]
-    [#assign ecsInstanceProfileId = formatEC2InstanceProfileId(tier, component)]
-    [#assign ecsAutoScaleGroupId = formatEC2AutoScaleGroupId(tier, component)]
-    [#assign ecsLaunchConfigId = formatEC2LaunchConfigId(tier, component)]
-    [#assign ecsSecurityGroupId = formatComponentSecurityGroupId(tier, component)]
-    [#assign ecsLogGroupId = formatComponentLogGroupId(tier, component)]
-    [#assign fixedIP = ecs.FixedIP!false]
-    [#assign ecsClusterWideStorage = ecs.ClusterWideStorage!false]
 
-    [#if deploymentSubsetRequired("iam", true) &&
-            isPartOfCurrentDeploymentUnit(ecsRoleId)]
-        [@createRole
-            mode=listMode
-            id=ecsRoleId
-            trustedServices=["ec2.amazonaws.com" ]
-            managedArns=["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"]
-            policies=
-                [
-                    getPolicyDocument(
-                        s3ListPermission(codeBucket) +
-                            s3ReadPermission(credentialsBucket, accountId + "/alm/docker") +
-                            fixedIP?then(
-                                ec2IPAddressUpdatePermission(),
-                                []
-                            ) +                            
-                            s3ReadPermission(codeBucket) +
-                            s3ListPermission(operationsBucket) +
-                            s3WritePermission(operationsBucket, getSegmentBackupsFilePrefix()) +
-                            s3WritePermission(operationsBucket, "DOCKERLogs"),
-                        "docker")
-                ]
-        /]
+    [#list requiredOccurrences(
+            getOccurrences(tier, component),
+            deploymentUnit) as occurrence]
 
-        [@createRole
-            mode=listMode
-            id=ecsServiceRoleId
-            trustedServices=["ecs.amazonaws.com" ]
-            managedArns=["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"]
-        /]
+        [@cfDebug listMode occurrence false /]
+
+        [#assign core = occurrence.Core ]
+        [#assign configuration = occurrence.Configuration ]
+        [#assign resources = occurrence.State.Resources ]
+
+        [#assign ecsId = resources["cluster"].Id ]
+        [#assign ecsName = resources["cluster"].Name ]
+        [#assign ecsRoleId = resources["role"].Id ]
+        [#assign ecsServiceRoleId = resources["serviceRole"].Id ]
+        [#assign ecsInstanceProfileId = resources["instanceProfile"].Id ]
+        [#assign ecsAutoScaleGroupId = resources["autoScaleGroup"].Id ]
+        [#assign ecsLaunchConfigId = resources["launchConfig"].Id ]
+        [#assign ecsSecurityGroupId = resources["securityGroup"].Id ]
+        [#assign ecsLogGroupId = resources["logGroup"].Id ]
+        [#assign defaultLogDriver = configuration.LogDriver ]
+        [#assign fixedIP = configuration.FixedIP ]
+        [#assign ecsClusterWideStorage = configuration.ClusterWideStorage ]
     
-    [/#if]
-
-    [#if deploymentSubsetRequired("lg", true) &&
-            isPartOfCurrentDeploymentUnit(ecsLogGroupId)]
-        [@createLogGroup 
-            mode=listMode
-            id=ecsLogGroupId
-            name=formatComponentLogGroupName(tier, component) /]
-    [/#if]
-
-    [#assign ecsEFSVolumeId = formatEFSId(tier, component)]
-    [#if ecsClusterWideStorage &&
-        deploymentSubsetRequired("efs", true) &&
-        isPartOfCurrentDeploymentUnit(ecsEFSVolumeId) ]
-
-        [#assign ecsEFSVolumeName = formatComponentFullName( tier, component )]
-        [#assign ecsEFSSecurityGroupId = formatComponentSecurityGroupId( tier, component,"efs")]
-        [#assign ecsEFSIngressSecurityGroupId = formatDependentSecurityGroupIngressId(ecsEFSSecurityGroupId) ]
-
-        [@createComponentSecurityGroup
-            mode=listMode
-            tier=tier
-            component=component 
-            extensions="efs"
+        [#if deploymentSubsetRequired("iam", true) &&
+                isPartOfCurrentDeploymentUnit(ecsRoleId)]
+            [@createRole
+                mode=listMode
+                id=ecsRoleId
+                trustedServices=["ec2.amazonaws.com" ]
+                managedArns=["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"]
+                policies=
+                    [
+                        getPolicyDocument(
+                            s3ListPermission(codeBucket) +
+                                s3ReadPermission(credentialsBucket, accountId + "/alm/docker") +
+                                fixedIP?then(
+                                    ec2IPAddressUpdatePermission(),
+                                    []
+                                ) +                            
+                                s3ReadPermission(codeBucket) +
+                                s3ListPermission(operationsBucket) +
+                                s3WritePermission(operationsBucket, getSegmentBackupsFilePrefix()) +
+                                s3WritePermission(operationsBucket, "DOCKERLogs"),
+                            "docker")
+                    ]
+            /]
+    
+            [@createRole
+                mode=listMode
+                id=ecsServiceRoleId
+                trustedServices=["ecs.amazonaws.com" ]
+                managedArns=["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"]
             /]
         
-        [@createSecurityGroupIngress
-            mode=listMode
-            id=ecsEFSIngressSecurityGroupId
-            port="any"
-            cidr=ecsSecurityGroupId
-            groupId=ecsEFSSecurityGroupId
-        /]
-
-        [@createEFS 
-            mode=listMode
-            tier=tier
-            id=ecsEFSVolumeId
-            name=ecsEFSVolumeName
-            component=component
-        /]
-
-        [@createEFSMountTarget
-            mode=listMode
-            tier=tier
-            efsId=ecsEFSVolumeId
-            securityGroups=ecsEFSSecurityGroupId
-        /]
-    
-    [/#if]
-        
-    [#if deploymentSubsetRequired("ecs", true)]
-
-        [@createComponentSecurityGroup
-            mode=listMode
-            tier=tier
-            component=component /]
-
-        [#assign processorProfile = getProcessor(tier, component, "ECS")]
-        [#assign maxSize = processorProfile.MaxPerZone]
-        [#if multiAZ]
-            [#assign maxSize = maxSize * zones?size]
         [/#if]
-        [#assign storageProfile = getStorage(tier, component, "ECS")]
-        [#assign defaultLogDriver = ecs.LogDriver!"awslogs"]
-        
-        [@cfResource
-            mode=listMode
-            id=ecsId
-            type="AWS::ECS::Cluster"
-        /]
-        
-        [@cfResource
-            mode=listMode
-            id=ecsInstanceProfileId
-            type="AWS::IAM::InstanceProfile"
-            properties=
-                {
-                    "Path" : "/",
-                    "Roles" : [getReference(ecsRoleId)]
-                }
-            outputs={}
-        /]
     
-        [#assign allocationIds = [] ]
-        [#if fixedIP]
-            [#list 1..maxSize as index]
-                [@createEIP
-                    mode=listMode
-                    id=formatComponentEIPId(tier, component, index)
+        [#if deploymentSubsetRequired("lg", true) &&
+                isPartOfCurrentDeploymentUnit(ecsLogGroupId)]
+            [@createLogGroup 
+                mode=listMode
+                id=ecsLogGroupId
+                name=formatComponentLogGroupName(tier, component) /]
+        [/#if]
+    
+        [#assign ecsEFSVolumeId = formatEFSId(tier, component)]
+        [#if ecsClusterWideStorage &&
+            deploymentSubsetRequired("efs", true) &&
+            isPartOfCurrentDeploymentUnit(ecsEFSVolumeId) ]
+    
+            [#assign ecsEFSVolumeName = formatComponentFullName( tier, component )]
+            [#assign ecsEFSSecurityGroupId = formatComponentSecurityGroupId( tier, component,"efs")]
+            [#assign ecsEFSIngressSecurityGroupId = formatDependentSecurityGroupIngressId(ecsEFSSecurityGroupId) ]
+    
+            [@createComponentSecurityGroup
+                mode=listMode
+                tier=tier
+                component=component 
+                extensions="efs"
                 /]
-                [#assign allocationIds +=
-                    [
-                        getReference(formatComponentEIPId(tier, component, index), ALLOCATION_ATTRIBUTE_TYPE)
-                    ]
-                ]
-            [/#list]
-        [/#if]
+            
+            [@createSecurityGroupIngress
+                mode=listMode
+                id=ecsEFSIngressSecurityGroupId
+                port="any"
+                cidr=ecsSecurityGroupId
+                groupId=ecsEFSSecurityGroupId
+            /]
     
-        [@cfResource
-            mode=listMode
-            id=ecsAutoScaleGroupId
-            type="AWS::AutoScaling::AutoScalingGroup"
-            metadata=
-                {
-                    "AWS::CloudFormation::Init": {
-                        "configSets" : {
-                            "ecs" : ["dirs", "bootstrap", "ecs"]
-                        },
-                        "dirs": {
-                            "commands": {
-                                "01Directories" : {
-                                    "command" : "mkdir --parents --mode=0755 /etc/codeontap && mkdir --parents --mode=0755 /opt/codeontap/bootstrap && mkdir --parents --mode=0755 /var/log/codeontap",
-                                    "ignoreErrors" : "false"
-                                }
-                            }
-                        },
-                        "bootstrap": {
-                            "packages" : {
-                                "yum" : {
-                                    "aws-cli" : [],
-                                    "nfs-utils" : []
-                                }
+            [@createEFS 
+                mode=listMode
+                tier=tier
+                id=ecsEFSVolumeId
+                name=ecsEFSVolumeName
+                component=component
+            /]
+    
+            [@createEFSMountTarget
+                mode=listMode
+                tier=tier
+                efsId=ecsEFSVolumeId
+                securityGroups=ecsEFSSecurityGroupId
+            /]
+        
+        [/#if]
+            
+        [#if deploymentSubsetRequired("ecs", true)]
+    
+            [@createComponentSecurityGroup
+                mode=listMode
+                tier=tier
+                component=component /]
+    
+            [#assign processorProfile = getProcessor(tier, component, "ECS")]
+            [#assign maxSize = processorProfile.MaxPerZone]
+            [#if multiAZ]
+                [#assign maxSize = maxSize * zones?size]
+            [/#if]
+            [#assign storageProfile = getStorage(tier, component, "ECS")]
+            
+            [@cfResource
+                mode=listMode
+                id=ecsId
+                type="AWS::ECS::Cluster"
+            /]
+            
+            [@cfResource
+                mode=listMode
+                id=ecsInstanceProfileId
+                type="AWS::IAM::InstanceProfile"
+                properties=
+                    {
+                        "Path" : "/",
+                        "Roles" : [getReference(ecsRoleId)]
+                    }
+                outputs={}
+            /]
+        
+            [#assign allocationIds = [] ]
+            [#if fixedIP]
+                [#list 1..maxSize as index]
+                    [@createEIP
+                        mode=listMode
+                        id=formatComponentEIPId(tier, component, index)
+                    /]
+                    [#assign allocationIds +=
+                        [
+                            getReference(formatComponentEIPId(tier, component, index), ALLOCATION_ATTRIBUTE_TYPE)
+                        ]
+                    ]
+                [/#list]
+            [/#if]
+        
+            [@cfResource
+                mode=listMode
+                id=ecsAutoScaleGroupId
+                type="AWS::AutoScaling::AutoScalingGroup"
+                metadata=
+                    {
+                        "AWS::CloudFormation::Init": {
+                            "configSets" : {
+                                "ecs" : ["dirs", "bootstrap", "ecs"]
                             },
-                            "files" : {
-                                "/etc/codeontap/facts.sh" : {
-                                    "content" : {
-                                        "Fn::Join" : [
-                                            "",
-                                            [
-                                                "#!/bin/bash\\n",
-                                                "echo \\\"cot:request="       + requestReference       + "\\\"\\n",
-                                                "echo \\\"cot:configuration=" + configurationReference + "\\\"\\n",
-                                                "echo \\\"cot:accountRegion=" + accountRegionId        + "\\\"\\n",
-                                                "echo \\\"cot:tenant="        + tenantId               + "\\\"\\n",
-                                                "echo \\\"cot:account="       + accountId              + "\\\"\\n",
-                                                "echo \\\"cot:product="       + productId              + "\\\"\\n",
-                                                "echo \\\"cot:region="        + regionId               + "\\\"\\n",
-                                                "echo \\\"cot:segment="       + segmentId              + "\\\"\\n",
-                                                "echo \\\"cot:environment="   + environmentId          + "\\\"\\n",
-                                                "echo \\\"cot:tier="          + tierId                 + "\\\"\\n",
-                                                "echo \\\"cot:component="     + componentId            + "\\\"\\n",
-                                                "echo \\\"cot:role="          + component.Role         + "\\\"\\n",
-                                                "echo \\\"cot:credentials="   + credentialsBucket      + "\\\"\\n",
-                                                "echo \\\"cot:code="          + codeBucket             + "\\\"\\n",
-                                                "echo \\\"cot:logs="          + operationsBucket       + "\\\"\\n",
-                                                "echo \\\"cot:backups="       + dataBucket             + "\\\"\\n"
-                                            ]
-                                        ]
-                                    },
-                                    "mode" : "000755"
-                                },
-                                "/opt/codeontap/bootstrap/fetch.sh" : {
-                                    "content" : {
-                                        "Fn::Join" : [
-                                            "",
-                                            [
-                                                "#!/bin/bash -ex\\n",
-                                                "exec > >(tee /var/log/codeontap/fetch.log|logger -t codeontap-fetch -s 2>/dev/console) 2>&1\\n",
-                                                "REGION=$(/etc/codeontap/facts.sh | grep cot:accountRegion | cut -d '=' -f 2)\\n",
-                                                "CODE=$(/etc/codeontap/facts.sh | grep cot:code | cut -d '=' -f 2)\\n",
-                                                "aws --region " + r"${REGION}" + " s3 sync s3://" + r"${CODE}" + "/bootstrap/centos/ /opt/codeontap/bootstrap && chmod 0500 /opt/codeontap/bootstrap/*.sh\\n"
-                                            ]
-                                        ]
-                                    },
-                                    "mode" : "000755"
-                                }
-                            },
-                            "commands": {
-                                "01Fetch" : {
-                                    "command" : "/opt/codeontap/bootstrap/fetch.sh",
-                                    "ignoreErrors" : "false"
-                                },
-                                "02Initialise" : {
-                                    "command" : "/opt/codeontap/bootstrap/init.sh",
-                                    "ignoreErrors" : "false"
-                                }
-                            } +
-                            attributeIfContent(
-                                "03AssignIP",
-                                allocationIds,
-                                {
-                                    "command" : "/opt/codeontap/bootstrap/eip.sh",
-                                    "env" : {
-                                        "EIP_ALLOCID" : {
-                                            "Fn::Join" : [
-                                                " ",
-                                                allocationIds
-                                            ]
-                                        }
-                                    },
-                                    "ignoreErrors" : "false"
-                                })
-                        },
-                        "ecs": {
-                            "commands":
-                                attributeIfTrue(
-                                    "01Fluentd",
-                                    defaultLogDriver == "fluentd",
-                                    {
-                                        "command" : "/opt/codeontap/bootstrap/fluentd.sh",
-                                        "ignoreErrors" : "false"
-                                    }) +
-                                attributeIfTrue(
-                                    "02ConfigureEFSClusterWide",
-                                    ecsClusterWideStorage,
-                                    {
-                                        "command" : "/opt/codeontap/bootstrap/efs.sh",
-                                        "env" : { 
-                                            "EFS_FILE_SYSTEM_ID" : getReference(ecsEFSVolumeId),
-                                            "EFS_MOUNT_PATH" : "/",
-                                            "EFS_OS_MOUNT_PATH" : "/efs/clusterstorage"
-                                        }
-                                    }) +
-                                {
-                                    "03ConfigureCluster" : {
-                                        "command" : "/opt/codeontap/bootstrap/ecs.sh",
-                                        "env" : {
-                                            "ECS_CLUSTER" : getReference(ecsId),
-                                            "ECS_LOG_DRIVER" : defaultLogDriver
-                                        },
+                            "dirs": {
+                                "commands": {
+                                    "01Directories" : {
+                                        "command" : "mkdir --parents --mode=0755 /etc/codeontap && mkdir --parents --mode=0755 /opt/codeontap/bootstrap && mkdir --parents --mode=0755 /var/log/codeontap",
                                         "ignoreErrors" : "false"
                                     }
                                 }
+                            },
+                            "bootstrap": {
+                                "packages" : {
+                                    "yum" : {
+                                        "aws-cli" : [],
+                                        "nfs-utils" : []
+                                    }
+                                },
+                                "files" : {
+                                    "/etc/codeontap/facts.sh" : {
+                                        "content" : {
+                                            "Fn::Join" : [
+                                                "",
+                                                [
+                                                    "#!/bin/bash\\n",
+                                                    "echo \\\"cot:request="       + requestReference       + "\\\"\\n",
+                                                    "echo \\\"cot:configuration=" + configurationReference + "\\\"\\n",
+                                                    "echo \\\"cot:accountRegion=" + accountRegionId        + "\\\"\\n",
+                                                    "echo \\\"cot:tenant="        + tenantId               + "\\\"\\n",
+                                                    "echo \\\"cot:account="       + accountId              + "\\\"\\n",
+                                                    "echo \\\"cot:product="       + productId              + "\\\"\\n",
+                                                    "echo \\\"cot:region="        + regionId               + "\\\"\\n",
+                                                    "echo \\\"cot:segment="       + segmentId              + "\\\"\\n",
+                                                    "echo \\\"cot:environment="   + environmentId          + "\\\"\\n",
+                                                    "echo \\\"cot:tier="          + tierId                 + "\\\"\\n",
+                                                    "echo \\\"cot:component="     + componentId            + "\\\"\\n",
+                                                    "echo \\\"cot:role="          + component.Role         + "\\\"\\n",
+                                                    "echo \\\"cot:credentials="   + credentialsBucket      + "\\\"\\n",
+                                                    "echo \\\"cot:code="          + codeBucket             + "\\\"\\n",
+                                                    "echo \\\"cot:logs="          + operationsBucket       + "\\\"\\n",
+                                                    "echo \\\"cot:backups="       + dataBucket             + "\\\"\\n"
+                                                ]
+                                            ]
+                                        },
+                                        "mode" : "000755"
+                                    },
+                                    "/opt/codeontap/bootstrap/fetch.sh" : {
+                                        "content" : {
+                                            "Fn::Join" : [
+                                                "",
+                                                [
+                                                    "#!/bin/bash -ex\\n",
+                                                    "exec > >(tee /var/log/codeontap/fetch.log|logger -t codeontap-fetch -s 2>/dev/console) 2>&1\\n",
+                                                    "REGION=$(/etc/codeontap/facts.sh | grep cot:accountRegion | cut -d '=' -f 2)\\n",
+                                                    "CODE=$(/etc/codeontap/facts.sh | grep cot:code | cut -d '=' -f 2)\\n",
+                                                    "aws --region " + r"${REGION}" + " s3 sync s3://" + r"${CODE}" + "/bootstrap/centos/ /opt/codeontap/bootstrap && chmod 0500 /opt/codeontap/bootstrap/*.sh\\n"
+                                                ]
+                                            ]
+                                        },
+                                        "mode" : "000755"
+                                    }
+                                },
+                                "commands": {
+                                    "01Fetch" : {
+                                        "command" : "/opt/codeontap/bootstrap/fetch.sh",
+                                        "ignoreErrors" : "false"
+                                    },
+                                    "02Initialise" : {
+                                        "command" : "/opt/codeontap/bootstrap/init.sh",
+                                        "ignoreErrors" : "false"
+                                    }
+                                } +
+                                attributeIfContent(
+                                    "03AssignIP",
+                                    allocationIds,
+                                    {
+                                        "command" : "/opt/codeontap/bootstrap/eip.sh",
+                                        "env" : {
+                                            "EIP_ALLOCID" : {
+                                                "Fn::Join" : [
+                                                    " ",
+                                                    allocationIds
+                                                ]
+                                            }
+                                        },
+                                        "ignoreErrors" : "false"
+                                    })
+                            },
+                            "ecs": {
+                                "commands":
+                                    attributeIfTrue(
+                                        "01Fluentd",
+                                        defaultLogDriver == "fluentd",
+                                        {
+                                            "command" : "/opt/codeontap/bootstrap/fluentd.sh",
+                                            "ignoreErrors" : "false"
+                                        }) +
+                                    attributeIfTrue(
+                                        "02ConfigureEFSClusterWide",
+                                        ecsClusterWideStorage,
+                                        {
+                                            "command" : "/opt/codeontap/bootstrap/efs.sh",
+                                            "env" : { 
+                                                "EFS_FILE_SYSTEM_ID" : getReference(ecsEFSVolumeId),
+                                                "EFS_MOUNT_PATH" : "/",
+                                                "EFS_OS_MOUNT_PATH" : "/efs/clusterstorage"
+                                            }
+                                        }) +
+                                    {
+                                        "03ConfigureCluster" : {
+                                            "command" : "/opt/codeontap/bootstrap/ecs.sh",
+                                            "env" : {
+                                                "ECS_CLUSTER" : getReference(ecsId),
+                                                "ECS_LOG_DRIVER" : defaultLogDriver
+                                            },
+                                            "ignoreErrors" : "false"
+                                        }
+                                    }
+                            }
                         }
                     }
-                }
-            properties=
-                {
-                    "Cooldown" : "30",
-                    "LaunchConfigurationName": getReference(ecsLaunchConfigId)
-                } +
-                multiAZ?then(
+                properties=
                     {
-                        "MinSize": processorProfile.MinPerZone * zones?size,
-                        "MaxSize": maxSize,
-                        "DesiredCapacity": processorProfile.DesiredPerZone * zones?size,
-                        "VPCZoneIdentifier": getSubnets(tier)
-                    },
-                    {
-                        "MinSize": processorProfile.MinPerZone,
-                        "MaxSize": maxSize,
-                        "DesiredCapacity": processorProfile.DesiredPerZone,
-                        "VPCZoneIdentifier" : getSubnets(tier)[0..0]
-                    }
-                )
-            tags=
-                getCfTemplateCoreTags(
-                    ecsFullName,
-                    tier,
-                    component,
-                    "",
-                    true)
-            outputs={}
-        /]
-                
-        [#if (processorProfile.ConfigSet)?has_content]
-            [#assign configSet = processorProfile.ConfigSet]
-        [#else]
-            [#assign configSet = "ecs"]
-        [/#if]
+                        "Cooldown" : "30",
+                        "LaunchConfigurationName": getReference(ecsLaunchConfigId)
+                    } +
+                    multiAZ?then(
+                        {
+                            "MinSize": processorProfile.MinPerZone * zones?size,
+                            "MaxSize": maxSize,
+                            "DesiredCapacity": processorProfile.DesiredPerZone * zones?size,
+                            "VPCZoneIdentifier": getSubnets(tier)
+                        },
+                        {
+                            "MinSize": processorProfile.MinPerZone,
+                            "MaxSize": maxSize,
+                            "DesiredCapacity": processorProfile.DesiredPerZone,
+                            "VPCZoneIdentifier" : getSubnets(tier)[0..0]
+                        }
+                    )
+                tags=
+                    getCfTemplateCoreTags(
+                        ecsName,
+                        tier,
+                        component,
+                        "",
+                        true)
+                outputs={}
+            /]
+                    
+            [#if (processorProfile.ConfigSet)?has_content]
+                [#assign configSet = processorProfile.ConfigSet]
+            [#else]
+                [#assign configSet = "ecs"]
+            [/#if]
+            
+            [#assign updateCommand = "yum clean all && yum -y update"]
+            [#assign dailyUpdateCron = 'echo \\"59 13 * * * ${updateCommand} >> /var/log/update.log 2>&1\\" >crontab.txt && crontab crontab.txt']
+            [#if environmentId == "prod"]
+                [#-- for production update only security packages --]
+                [#assign updateCommand += " --security"]
+                [#assign dailyUpdateCron = 'echo \\"29 13 * * 6 ${updateCommand} >> /var/log/update.log 2>&1\\" >crontab.txt && crontab crontab.txt']
+            [/#if]
         
-        [#assign updateCommand = "yum clean all && yum -y update"]
-        [#assign dailyUpdateCron = 'echo \\"59 13 * * * ${updateCommand} >> /var/log/update.log 2>&1\\" >crontab.txt && crontab crontab.txt']
-        [#if environmentId == "prod"]
-            [#-- for production update only security packages --]
-            [#assign updateCommand += " --security"]
-            [#assign dailyUpdateCron = 'echo \\"29 13 * * 6 ${updateCommand} >> /var/log/update.log 2>&1\\" >crontab.txt && crontab crontab.txt']
-        [/#if]
-    
-        [@cfResource
-            mode=listMode
-            id=ecsLaunchConfigId
-            type="AWS::AutoScaling::LaunchConfiguration"
-            properties=
-                getBlockDevices(storageProfile) +
-                {
-                    "KeyName": productName + sshPerSegment?then("-" + segmentName,""),
-                    "ImageId": regionObject.AMIs.Centos.ECS,
-                    "InstanceType": processorProfile.Processor,
-                    "SecurityGroups" : 
-                        [
-                            getReference(ecsSecurityGroupId)
-                        ] +
-                        sshFromProxySecurityGroup?has_content?then(
+            [@cfResource
+                mode=listMode
+                id=ecsLaunchConfigId
+                type="AWS::AutoScaling::LaunchConfiguration"
+                properties=
+                    getBlockDevices(storageProfile) +
+                    {
+                        "KeyName": productName + sshPerSegment?then("-" + segmentName,""),
+                        "ImageId": regionObject.AMIs.Centos.ECS,
+                        "InstanceType": processorProfile.Processor,
+                        "SecurityGroups" : 
                             [
-                                sshFromProxySecurityGroup
-                            ],
-                            []
-                        ),
-                    "IamInstanceProfile" : getReference(ecsInstanceProfileId),
-                    "AssociatePublicIpAddress" : (tier.RouteTable == "external"),
-                    "UserData" : {
-                        "Fn::Base64" : {
-                            "Fn::Join" : [
-                                "",
+                                getReference(ecsSecurityGroupId)
+                            ] +
+                            sshFromProxySecurityGroup?has_content?then(
                                 [
-                                    "#!/bin/bash -ex\\n",
-                                    "exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1\\n",
-                                    "# Install updates\\n",
-                                    updateCommand, "\\n",
-                                    dailyUpdateCron, "\\n",
-                                    "yum install -y aws-cfn-bootstrap\\n",
-                                    "# Remainder of configuration via metadata\\n",
-                                    "/opt/aws/bin/cfn-init -v",
-                                    "         --stack ", { "Ref" : "AWS::StackName" },
-                                    "         --resource ", ecsAutoScaleGroupId,
-                                    "         --region ", regionId, " --configsets ", configSet, "\\n"
+                                    sshFromProxySecurityGroup
+                                ],
+                                []
+                            ),
+                        "IamInstanceProfile" : getReference(ecsInstanceProfileId),
+                        "AssociatePublicIpAddress" : (tier.RouteTable == "external"),
+                        "UserData" : {
+                            "Fn::Base64" : {
+                                "Fn::Join" : [
+                                    "",
+                                    [
+                                        "#!/bin/bash -ex\\n",
+                                        "exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1\\n",
+                                        "# Install updates\\n",
+                                        updateCommand, "\\n",
+                                        dailyUpdateCron, "\\n",
+                                        "yum install -y aws-cfn-bootstrap\\n",
+                                        "# Remainder of configuration via metadata\\n",
+                                        "/opt/aws/bin/cfn-init -v",
+                                        "         --stack ", { "Ref" : "AWS::StackName" },
+                                        "         --resource ", ecsAutoScaleGroupId,
+                                        "         --region ", regionId, " --configsets ", configSet, "\\n"
+                                    ]
                                 ]
-                            ]
+                            }
                         }
                     }
-                }
-            outputs={}
-        /]
-    [/#if]
+                outputs={}
+            /]
+        [/#if]
+    [/#list]
 [/#if]

--- a/aws/templates/solution/solution_efs.ftl
+++ b/aws/templates/solution/solution_efs.ftl
@@ -1,9 +1,8 @@
 [#-- EFS --]
 [#if componentType == "efs" && deploymentSubsetRequired("efs", true) ]
-    [#assign efs = component.EFS]
 
     [#list requiredOccurrences(
-            getOccurrences(component, tier, component),
+            getOccurrences(tier, component),
             deploymentUnit) as occurrence]
 
         [@cfDebug listMode occurrence false /]

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -1,10 +1,8 @@
 [#-- RDS --]
 [#if (componentType == "rds") ]
 
-    [#assign db = component.RDS]
-    
     [#list requiredOccurrences(
-            getOccurrences(component, tier, component),
+            getOccurrences(tier, component),
             deploymentUnit) as occurrence]
 
         [@cfDebug listMode occurrence false /]

--- a/aws/templates/solution/solution_s3.ftl
+++ b/aws/templates/solution/solution_s3.ftl
@@ -1,10 +1,9 @@
 [#-- S3 --]
 
 [#if (componentType == "s3") && deploymentSubsetRequired("s3", true)]
-    [#assign s3 = component.S3]
 
     [#list requiredOccurrences(
-            getOccurrences(component, tier, component),
+            getOccurrences(tier, component),
             deploymentUnit) as occurrence]
 
         [@cfDebug listMode occurrence false /]
@@ -13,8 +12,8 @@
         [#assign configuration = occurrence.Configuration ]
         [#assign resources = occurrence.State.Resources ]
 
-        [#assign s3Id = resources["primary"].Id ]
-        [#assign s3Name = resources["primary"].Name ]
+        [#assign s3Id = resources["bucket"].Id ]
+        [#assign s3Name = resources["bucket"].Name ]
 
         [#assign sqsIds = [] ]
         [#assign sqsNotifications = [] ]
@@ -28,7 +27,7 @@
                             "Tier" : queue.Tier!tier,
                             "Component" : queue.Component!queue.Id
                         }) ]
-                [#assign sqsId = (linkTarget.State.Resources["primary"].Id)!"" ]
+                [#assign sqsId = (linkTarget.State.Resources["queue"].Id)!"" ]
                 [#if sqsId?has_content]
                     [#assign sqsIds += [sqsId] ]
                     [#assign sqsNotifications +=

--- a/aws/templates/solution/solution_spa.ftl
+++ b/aws/templates/solution/solution_spa.ftl
@@ -1,10 +1,9 @@
 [#-- Single Page App --]
 
 [#if (componentType == "spa") && deploymentSubsetRequired("spa", true)]
-    [#assign spa = component.SPA]
 
     [#list requiredOccurrences(
-            getOccurrences(component, tier, component),
+            getOccurrences(tier, component),
             deploymentUnit) as occurrence]
 
         [@cfDebug listMode occurrence false /]

--- a/aws/templates/solution/solution_sqs.ftl
+++ b/aws/templates/solution/solution_sqs.ftl
@@ -1,9 +1,8 @@
 [#-- SQS --]
 [#if (componentType == "sqs") && deploymentSubsetRequired("sqs", true)]
-    [#assign sqs = component.SQS]
 
     [#list requiredOccurrences(
-            getOccurrences(component, tier, component),
+            getOccurrences(tier, component),
             deploymentUnit) as occurrence]
 
         [@cfDebug listMode occurrence false /]
@@ -12,8 +11,8 @@
         [#assign configuration = occurrence.Configuration ]
         [#assign resources = occurrence.State.Resources ]
 
-        [#assign sqsId = resources["primary"].Id ]
-        [#assign sqsName = resources["primary"].Name ]
+        [#assign sqsId = resources["queue"].Id ]
+        [#assign sqsName = resources["queue"].Name ]
         [#assign dlqId = resources["dlq"].Id ]
         [#assign dlqName = resources["dlq"].Name ]
 


### PR DESCRIPTION
This feature uses getOccurrences to handle subcomponents, so we can more cleanly support ECS services/tasks and lambda functions.

With the increased use of links (and getOccurrences under the hood), I've also started moving the details of resource id creation into the getXXXState routines. This localises the definition of ids and means we need fewer format routines, because the ids can instead be obtained via occurrence.State.Resources[alias], where alias is the logical purpose of the id for the component. I have taken this approach in refactoring ECS and lambda, but we should use this approach more generally as it centralises id definition.

I've also added an "Id" and "Name" attribute to the core attributes of an occurrence. These are very often used in generating ids and names - indeed much of the id code can use this as occurrence.Core.Id.  (They include Tier and Component). Again, it means more consistency of naming and less code as we don't need to pass tier and component around - they are on every occurrence.

It's a fairly hefty refactor so will need further testing different scenarios, but overall, I like the way the code base is going as a result of links.

There's a couple of other tweaks in this PR - use of names for tags rather than ids - they are easier to use in wtmg. Also, use of runId in API Gateway generation.