### PR TITLE
Fix lambda security group description

### DIFF
--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -135,8 +135,7 @@
                         tier=tier
                         component=component
                         resourceId=fnId
-                        resourceName=fnName
-                        description=formatName("lambda", fnName) /]
+                        resourceName=fnName /]
                 [/#if]
 
                 [@createLambdaFunction


### PR DESCRIPTION
Revert code - macro does not have a description parameter