### PR TITLE
Correct access to segment CIDR for ALB/self-hosted NAT

### DIFF
--- a/aws/templates/segment/segment_vpc.ftl
+++ b/aws/templates/segment/segment_vpc.ftl
@@ -596,7 +596,7 @@
                     [
                         {
                             "Port" : "all",
-                            "CIDR" : [segmentObject.CIDR.Address + "/" + segmentObject.CIDR.Mask]
+                            "CIDR" : [segmentObject.Network.CIDR.Address + "/" + segmentObject.Network.CIDR.Mask]
                         }
                     ]
                 vpcId=natInVpc?then(vpcId,"")

--- a/aws/templates/solution/solution_alb.ftl
+++ b/aws/templates/solution/solution_alb.ftl
@@ -68,7 +68,7 @@
                     cidr,
                     (tier.Network.RouteTable == "external")?then(
                         [],
-                        segmentObject.CIDR.Address + "/" +segmentObject.CIDR.Mask
+                        segmentObject.Network.CIDR.Address + "/" +segmentObject.Network.CIDR.Mask
                     )) ]
                         
             [@createSecurityGroupIngress


### PR DESCRIPTION
Correct access to segment CIDR - it in now in a separate Network object