### PR TITLE
Add Better error handling for Stack management

### DIFF
--- a/aws/manageStack.sh
+++ b/aws/manageStack.sh
@@ -324,10 +324,7 @@ function wait_for_stack_execution() {
       # Watch for roll backs 
       egrep "*ROLLBACK_COMPLETE\"" "${stack_status_file}" >/dev/null 2>&1 && \
         { warning "Stack ${STACK_NAME} could not complete and a rollback was performed"; exit_status=1; break;}
-
-      egrep "ROLLBACK_COMPLETE\"" "${stack_status_file}" >/dev/null 2>&1 && \
-        { warning "Stack ${STACK_NAME} could not complete and a rollback was performed"; exit_status=1; break;}
-
+        
       # Watch for failures
       egrep "*FAILED\"" "${stack_status_file}" >/dev/null 2>&1 && \
         { fatal "Stack ${STACK_NAME} failed, fix stack before retrying"; exit_status=255; break;}

--- a/aws/manageStack.sh
+++ b/aws/manageStack.sh
@@ -321,6 +321,17 @@ function wait_for_stack_execution() {
       grep "${status_attribute}" "${STACK}" > "${stack_status_file}"
       cat "${stack_status_file}"
 
+      # Watch for roll backs 
+      egrep "*ROLLBACK_COMPLETE\"" "${stack_status_file}" >/dev/null 2>&1 && \
+        { warning "Stack ${STACK_NAME} could not complete and a rollback was performed"; exit_status=1; break;}
+
+      egrep "ROLLBACK_COMPLETE\"" "${stack_status_file}" >/dev/null 2>&1 && \
+        { warning "Stack ${STACK_NAME} could not complete and a rollback was performed"; exit_status=1; break;}
+
+      # Watch for failures
+      egrep "*FAILED\"" "${stack_status_file}" >/dev/null 2>&1 && \
+        { fatal "Stack ${STACK_NAME} failed, fix stack before retrying"; exit_status=255; break;}
+
       # Finished if complete
       egrep "(${operation_to_check})_COMPLETE\"" "${stack_status_file}" >/dev/null 2>&1 && \
         { [[ -f "${potential_change_file}" ]] && cp "${potential_change_file}" "${CHANGE}"; break; }
@@ -342,7 +353,7 @@ function wait_for_stack_execution() {
         grep -q "No updates are to be performed" < "${stack_status_file}" &&
           warning "No updates needed for stack ${STACK_NAME}. Treating as successful.\n"; break ||
           { cat "${stack_status_file}"; return ${exit_status}; }
-        ;;
+      ;;
       *) 
       return ${exit_status} ;;
     esac
@@ -517,8 +528,22 @@ function main() {
   [[ -f "${CONFIG}" ]] && \
     { info "Copying config file ..." && copy_config_file "${CONFIG}" || return $?; }
 
+  process_stack_status=0
   # Process the stack
-  [[ -f "${TEMPLATE}" ]] && { process_stack || return $?; }
+  if [[ -f "${TEMPLATE}" ]]; then 
+     process_stack || process_stack_status=$?
+  fi
+
+    # Check to see if the work has already been completed
+    case ${process_stack_status} in
+      0) 
+        info "${STACK_OPERATION} completed for ${STACK_NAME}"
+      ;;
+      *) 
+        fatal "Change set for ${STACK_NAME} did not complete"
+        return ${process_stack_status} 
+      ;;
+    esac
   
   # Run the epilogue script if present
   # Refresh the stack outputs in case something from the just created stack is needed


### PR DESCRIPTION
Cloudformation stacks can behave in a large number of different ways. This PR adds some extra handling error conditions to make sure we know if an issue has occurred

Stack status will have the following results
- *FAILED - throw 255 error code and fatal message
- ROLLBACK*COMPLETE - throw 127 error code and a warning message - the world should continue but it won't have updated 
- *COMPLETE - return ok and notify the stack has completed 

This would cover CREATE,UPDATE, and DELETE actions

Fixes #152 