### PR TITLE
Add Cogntio event lambda triggers

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -17,8 +17,8 @@
             [#break]
         [/#if]
 
-        [#assign apiId    = resources["gateway"].Id]
-        [#assign apiName  = resources["gateway"].Name]
+        [#assign apiId    = resources["apigateway"].Id]
+        [#assign apiName  = resources["apigateway"].Name]
 
         [#-- Use runId to ensure deploy happens every time --]
         [#assign deployId = formatAPIGatewayDeployId(

--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -76,7 +76,7 @@
                         ]
                         [#break]
 
-                    [#case "userpool"] 
+                    [#case USERPOOL_COMPONENT_TYPE] 
                         [#if deploymentSubsetRequired("apigateway", true)]
         
                             [#assign policyId = formatDependentPolicyId(
@@ -88,8 +88,7 @@
                                 id=policyId
                                 name=apiName
                                 statements=asFlattenedArray(roles.Outbound["invoke"])
-                                roles=formatDependentIdentityPoolAuthRoleId(
-                                        formatIdentityPoolId(linkTargetCore.Tier, linkTargetCore.Component))
+                                roles=linkTargetResources["authrole"].Id
                             /]
                         [/#if]
                         [#break]

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -51,17 +51,16 @@
 
                     [#switch linkTargetCore.Type!""]
                         [#case "userpool"] 
-                            [@createPolicy 
-                                mode=listMode
-                                id=formatDependentPolicyId(fnId, "link", linkName)
-                                name=fnName
-                                statements=[getPolicyStatement(
-                                                "lambda:InvokeFunction",
-                                                formatLambdaArn(fnId))]
-                                roles=formatDependentIdentityPoolAuthRoleId(
-                                        formatIdentityPoolId(linkTargetCore.Tier, linkTargetCore.Component))
-                            /]
-                            [#break]
+                            [#if linkTargetResources["userpool"].Deployed &&
+                                    (linkDirection == "inbound")]
+                                [@createLambdaPermission
+                                    mode=listMode
+                                    id=formatLambdaPermissionId(fn, "link", linkName)
+                                    targetId=fnId
+                                    source=linkTargetRoles.Inbound["invoke"]
+                                /]
+                            [/#if]
+                        [#break]
 
                         [#case "apigateway" ]
                             [#if linkTargetResources["gateway"].Deployed &&
@@ -73,7 +72,7 @@
                                     source=linkTargetRoles.Inbound["invoke"]
                                 /]
                             [/#if]
-                            [#break]
+                        [#break]
                     [/#switch]    
                 [/#list]
             [/#if]

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -51,7 +51,9 @@
 
                     [#switch linkTargetCore.Type!""]
                         [#case USERPOOL_COMPONENT_TYPE] 
-                            [#if linkTargetResources[USERPOOL_COMPONENT_TYPE].Deployed &&
+                        [#case "apigateway"]
+                        [@cfDebug listMode  linkTargetResources true /]
+                            [#if linkTargetResources[(linkTargetCore.Type)].Deployed &&
                                     (linkDirection == "inbound")]
                                 [@createLambdaPermission
                                     mode=listMode
@@ -60,19 +62,7 @@
                                     source=linkTargetRoles.Inbound["invoke"]
                                 /]
                             [/#if]
-                        [#break]
-
-                        [#case "apigateway" ]
-                            [#if linkTargetResources["gateway"].Deployed &&
-                                    (linkDirection == "inbound")]
-                                [@createLambdaPermission
-                                    mode=listMode
-                                    id=formatLambdaPermissionId(fn, "link", linkName)
-                                    targetId=fnId
-                                    source=linkTargetRoles.Inbound["invoke"]
-                                /]
-                            [/#if]
-                        [#break]
+                            [#break]
                     [/#switch]    
                 [/#list]
             [/#if]

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -52,7 +52,6 @@
                     [#switch linkTargetCore.Type!""]
                         [#case USERPOOL_COMPONENT_TYPE] 
                         [#case "apigateway"]
-                        [@cfDebug listMode  linkTargetResources true /]
                             [#if linkTargetResources[(linkTargetCore.Type)].Deployed &&
                                     (linkDirection == "inbound")]
                                 [@createLambdaPermission

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -50,8 +50,8 @@
                     [#assign linkDirection = linkTarget.Direction ]
 
                     [#switch linkTargetCore.Type!""]
-                        [#case "userpool"] 
-                            [#if linkTargetResources["userpool"].Deployed &&
+                        [#case USERPOOL_COMPONENT_TYPE] 
+                            [#if linkTargetResources[USERPOOL_COMPONENT_TYPE].Deployed &&
                                     (linkDirection == "inbound")]
                                 [@createLambdaPermission
                                     mode=listMode

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -979,7 +979,7 @@
     [#return getOccurrencesInternal(component, tier) ]
 [/#function]
 
-[#function getLinkTarget occurrence link ]
+[#function getLinkTarget occurrence link]
 
     [#if link.Tier?lower_case == "external"]
         [#local targetOccurrence =

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -979,7 +979,7 @@
     [#return getOccurrencesInternal(component, tier) ]
 [/#function]
 
-[#function getLinkTarget occurrence link allowNotFound=false ]
+[#function getLinkTarget occurrence link ]
 
     [#if link.Tier?lower_case == "external"]
         [#local targetOccurrence =
@@ -1081,16 +1081,14 @@
         [/#list]
     [/#list]
 
-    [#if !allowNotFound ]
-        [@cfPostconditionFailed
-            listMode
-            "getLinkTarget"
-            {
-                "Occurrence" : occurrence,
-                "Link" : link
-            }
-            "Link not found" /]
-    [/#if]
+    [@cfPostconditionFailed
+        listMode
+        "getLinkTarget"
+        {
+            "Occurrence" : occurrence,
+            "Link" : link
+        }
+        "Link not found" /]
 
     [#return
         {

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -979,7 +979,7 @@
     [#return getOccurrencesInternal(component, tier) ]
 [/#function]
 
-[#function getLinkTarget occurrence link]
+[#function getLinkTarget occurrence link allowNotFound=false ]
 
     [#if link.Tier?lower_case == "external"]
         [#local targetOccurrence =
@@ -1081,14 +1081,16 @@
         [/#list]
     [/#list]
 
-    [@cfPostconditionFailed
-        listMode
-        "getLinkTarget"
-        {
-            "Occurrence" : occurrence,
-            "Link" : link
-        }
-        "Link not found" /]
+    [#if !allowNotFound ]
+        [@cfPostconditionFailed
+            listMode
+            "getLinkTarget"
+            {
+                "Occurrence" : occurrence,
+                "Link" : link
+            }
+            "Link not found" /]
+    [/#if]
 
     [#return
         {

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -168,7 +168,7 @@
     [#return
         {
             "Resources" : {
-                "gateway" : {
+                "apigateway" : {
                     "Id" : id,
                     "Name" : name
                 }

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -100,15 +100,15 @@
                        "Default" : "10"
                     },
                     {
-                        "Name" : "Lowercase",
+                        "Name" : "lowercase",
                         "Default" : true
                     },
                     {
-                        "Name" : "Uppercase",
+                        "Name" : "uppercase",
                         "Default" : true
                     },
                     {
-                        "Name" : "Numbers",
+                        "Name" : "numbers",
                         "Default" : true
                     },
                     {

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -1,8 +1,8 @@
 [#-- Cognito UserPool --]
 
 [#assign USERPOOL_RESOURCE_TYPE = "userpool"]
-[#assign USERPOOL_CLIENT_RESOURCE_TYPE = "userpoolclient" ]
-[#assign IDENTITYPOOL_RESOURCE_TYPE = "identitypool" ]
+[#assign USERPOOL_CLIENT_RESOURCE_TYPE = "userpoolclient"]
+[#assign IDENTITYPOOL_RESOURCE_TYPE = "identitypool"]
 
 [#assign USERPOOL_COMPONENT_TYPE = "userpool"]
 
@@ -15,7 +15,7 @@
             extensions)]
 [/#function]
 
-[#function formatUserPoolClientId occurrence extensions... ]
+[#function formatUserPoolClientId occurrence extensions...]
     [#return formatComponentResourceId(
             USERPOOL_CLIENT_RESOURCE_TYPE,
             occurrence.Core.Tier,
@@ -24,7 +24,7 @@
             extensions)]
 [/#function]
 
-[#function formatIdentityPoolId occurrence extensions... ]
+[#function formatIdentityPoolId occurrence extensions...]
     [#return formatComponentResourceId(
             IDENTITYPOOL_RESOURCE_TYPE,
             occurrence.Core.Tier,
@@ -40,7 +40,7 @@
             extensions)]
 [/#function]
 
-[#function formatDependentIdentityPoolUnAuthRoleId resourceId extensions... ]
+[#function formatDependentIdentityPoolUnAuthRoleId resourceId extensions...]
     [#return 
         formatDependentRoleId(
             resourceId,
@@ -49,7 +49,7 @@
     ]
 [/#function]
 
-[#function formatDependentIdentityPoolAuthRoleId resourceId extensions... ]
+[#function formatDependentIdentityPoolAuthRoleId resourceId extensions...]
     [#return 
         formatDependentRoleId(
                 resourceId,
@@ -143,7 +143,7 @@
     [#assign identityPoolRoleMappingId = formatDependentIdentityPoolRoleMappingId(identityPoolId)]
     [#assign userPoolName = formatUserPoolName(occurrence)]
     [#assign identityPoolName = formatIdentityPoolName(occurrence)]
-    [#assign userPoolClientName = formatUserPoolClientName(occurrence) ]
+    [#assign userPoolClientName = formatUserPoolClientName(occurrence)]
     
     [#return
         {

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -120,7 +120,8 @@
             },
             {
                 "Name" : "Links",
-                "Default" : {}
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
             }
         ]
     }]

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -4,6 +4,8 @@
 [#assign USERPOOL_CLIENT_RESOURCE_TYPE = "userpoolclient" ]
 [#assign IDENTITYPOOL_RESOURCE_TYPE = "identitypool" ]
 
+[#assign USERPOOL_COMPONENT_TYPE = "userpool"]
+
 [#function formatUserPoolId tier component extensions...]
     [#return formatComponentResourceId(
                 USERPOOL_RESOURCE_TYPE,
@@ -55,7 +57,7 @@
 
 [#assign componentConfiguration +=
     {
-        "userpool" : [
+        USERPOOL_COMPONENT_TYPE : [
             { 
                 "Name" : "MFA",
                 "Default" : false
@@ -90,33 +92,37 @@
                 "Default" : 30
             },
             {
-                "Name" : "allowUnauthIds",
+                "Name" : "allowUnauthenticatedIds",
                 "Default" : false
             }
             {
                 "Name" : "passwordPolicy",
                 "Children" : [
                     {
-                       "Name" : "MinimumLength",
-                       "Default" : "8"
+                       "Name" : "minimumLength",
+                       "Default" : "10"
                     },
                     {
-                        "Name" : "Lowercase",
+                        "Name" : "lowercase",
                         "Default" : true
                     },
                     {
-                        "Name" : "Uppercase",
+                        "Name" : "uppercase",
                         "Default" : true
                     },
                     {
-                        "Name" : "Numbers",
+                        "Name" : "numbers",
                         "Default" : true
                     },
                     {
-                        "Name" : "SpecialCharacters",
-                        "Default" : false
+                        "Name" : "specialCharacters",
+                        "Default" : true
                     }
                 ] 
+            },
+            {
+                "Name" : "Links",
+                "Default" : {}
             }
         ]
     }]
@@ -141,7 +147,12 @@
                 "REGION" : regionId
             },
             "Roles" : {
-                "Inbound" : {},
+                "Inbound" : {
+                    "invoke" : {
+                        "Principal" : "cognito-idp.amazonaws.com",
+                        "SourceArn" : getReference(id,ARN_ATTRIBUTE_TYPE)
+                    }
+                },
                 "Outbound" : {}
             }
         }

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -106,15 +106,15 @@
                        "Default" : "10"
                     },
                     {
-                        "Name" : "Lowercase",
+                        "Name" : "lowercase",
                         "Default" : true
                     },
                     {
-                        "Name" : "Uppercase",
+                        "Name" : "uppercase",
                         "Default" : true
                     },
                     {
-                        "Name" : "Numbers",
+                        "Name" : "numbers",
                         "Default" : true
                     },
                     {

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -106,15 +106,15 @@
                        "Default" : "10"
                     },
                     {
-                        "Name" : "lowercase",
+                        "Name" : "Lowercase",
                         "Default" : true
                     },
                     {
-                        "Name" : "uppercase",
+                        "Name" : "Uppercase",
                         "Default" : true
                     },
                     {
-                        "Name" : "numbers",
+                        "Name" : "Numbers",
                         "Default" : true
                     },
                     {

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -64,7 +64,8 @@
                 "Default" : true
             },
             {
-                "Name" : "UnusedAccountTimeout"
+                "Name" : "UnusedAccountTimeout",
+                "Default" : 7
             },
             {
                 "Name" : "VerifyEmail",
@@ -91,7 +92,7 @@
             {
                 "Name" : "AllowUnauthenticatedIds",
                 "Default" : false
-            }
+            },
             {
                 "Name" : "PasswordPolicy",
                 "Children" : [
@@ -119,8 +120,7 @@
             },
             {
                 "Name" : "Links",
-                "Subobjects" : true,
-                "Children" : linkChildrenConfiguration
+                "Default" : {}
             }
         ]
     }]

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -100,15 +100,15 @@
                        "Default" : "10"
                     },
                     {
-                        "Name" : "lowercase",
+                        "Name" : "Lowercase",
                         "Default" : true
                     },
                     {
-                        "Name" : "uppercase",
+                        "Name" : "Uppercase",
                         "Default" : true
                     },
                     {
-                        "Name" : "numbers",
+                        "Name" : "Numbers",
                         "Default" : true
                     },
                     {

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -7,30 +7,24 @@
 [#assign USERPOOL_COMPONENT_TYPE = "userpool"]
 
 [#function formatUserPoolId occurrence extensions...]
-    [#return formatComponentResourceId(
-            USERPOOL_RESOURCE_TYPE,
-            occurrence.Core.Tier,
-            occurrence.Core.Component,
-            occurrence
-            extensions)]
+    [#return formatResourceId(
+        USERPOOL_RESOURCE_TYPE,
+        occurrence.Core.Id, 
+        extensions)]
 [/#function]
 
 [#function formatUserPoolClientId occurrence extensions...]
-    [#return formatComponentResourceId(
-            USERPOOL_CLIENT_RESOURCE_TYPE,
-            occurrence.Core.Tier,
-            occurrence.Core.Component,
-            occurrence
-            extensions)]
+    [#return formatResourceId(
+        USERPOOL_CLIENT_RESOURCE_TYPE,
+        occurrence.Core.Id, 
+        extensions)]
 [/#function]
 
 [#function formatIdentityPoolId occurrence extensions...]
-    [#return formatComponentResourceId(
-            IDENTITYPOOL_RESOURCE_TYPE,
-            occurrence.Core.Tier,
-            occurrence.Core.Component,
-            occurrence
-            extensions)]
+    [#return formatResourceId(
+        IDENTITYPOOL_RESOURCE_TYPE,
+        occurrence.Core.Id, 
+        extensions)]
 [/#function]
 
 [#function formatDependentIdentityPoolRoleMappingId resourceId extensions...]

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -111,6 +111,8 @@
 [#function getFunctionState occurrence]
     [#local core = occurrence.Core]
 
+    [#assign id = formatResourceId(LAMBDA_FUNCTION_RESOURCE_TYPE, core.Id) ]
+
     [#return
         {
             "Resources" : {
@@ -120,7 +122,9 @@
                 }
             },
             "Attributes" : {
-                "REGION" : regionId
+                "REGION" : regionId,
+                "ARN" : getExistingReference("id",ARN_ATTRIBUTE_TYPE)!"",
+                "NAME" : getExistingReference("id",NAME_ATTRIBUTE_TYPE)!""
             },
             "Roles" : {
                 "Inbound" : {},

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -1,11 +1,11 @@
 [#-- Lambda --]
 
-[#assign LAMBDA_RESOURCE_TYPE = "lambda" ]
-[#assign LAMBDA_FUNCTION_RESOURCE_TYPE = "lambda" ]
-[#assign LAMBDA_PERMISSION_RESOURCE_TYPE = "permission" ]
+[#assign LAMBDA_RESOURCE_TYPE = "lambda"]
+[#assign LAMBDA_FUNCTION_RESOURCE_TYPE = "lambda"]
+[#assign LAMBDA_PERMISSION_RESOURCE_TYPE = "permission"]
 
-[#assign LAMBDA_COMPONENT_TYPE = "lambda" ]
-[#assign LAMBDA_FUNCTION_COMPONENT_TYPE = "function" ]
+[#assign LAMBDA_COMPONENT_TYPE = "lambda"]
+[#assign LAMBDA_FUNCTION_COMPONENT_TYPE = "function"]
 
 [#function formatLambdaPermissionId occurrence extensions...]
     [#return formatResourceId(
@@ -111,7 +111,7 @@
 [#function getFunctionState occurrence]
     [#local core = occurrence.Core]
 
-    [#assign id = formatResourceId(LAMBDA_FUNCTION_RESOURCE_TYPE, core.Id) ]
+    [#assign id = formatResourceId(LAMBDA_FUNCTION_RESOURCE_TYPE, core.Id)]
 
     [#return
         {

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -123,8 +123,8 @@
             },
             "Attributes" : {
                 "REGION" : regionId,
-                "ARN" : getExistingReference("id",ARN_ATTRIBUTE_TYPE)!"",
-                "NAME" : getExistingReference("id",NAME_ATTRIBUTE_TYPE)!""
+                "ARN" : getExistingReference(id,ARN_ATTRIBUTE_TYPE),
+                "NAME" : getExistingReference(id,NAME_ATTRIBUTE_TYPE)
             },
             "Roles" : {
                 "Inbound" : {},

--- a/aws/templates/name/name_cognito.ftl
+++ b/aws/templates/name/name_cognito.ftl
@@ -1,6 +1,6 @@
 [#-- Cognito User Pool --]
 
-[#function formatUserPoolName occurrence extensions... ]
+[#function formatUserPoolName occurrence extensions...]
     [#return formatName(
         formatComponentFullName(
             occurrence.Core.Tier,
@@ -9,7 +9,7 @@
             extensions))]
 [/#function]
 
-[#function formatUserPoolClientName occurrence extensions... ]
+[#function formatUserPoolClientName occurrence extensions...]
     [#return formatName( 
         formatComponentFullName(
             occurrence.Core.Tier,
@@ -18,7 +18,7 @@
             extensions))]
 [/#function]
 
-[#function formatIdentityPoolName occurrence extensions... ]
+[#function formatIdentityPoolName occurrence extensions...]
     [#return formatId(
         productName,
         segmentName,

--- a/aws/templates/name/name_cognito.ftl
+++ b/aws/templates/name/name_cognito.ftl
@@ -1,24 +1,28 @@
 [#-- Cognito User Pool --]
 
-[#function formatUserPoolName tier component extensions... ]
+[#function formatUserPoolName occurrence extensions... ]
     [#return formatName(
         formatComponentFullName(
-            tier,
-            component))]
+            occurrence.Core.Tier,
+            occurrence.Core.Component,
+            occurrence,
+            extensions))]
 [/#function]
 
-[#function formatUserPoolClientName tier component extensions... ]
+[#function formatUserPoolClientName occurrence extensions... ]
     [#return formatName( 
         formatComponentFullName(
-            tier,
-            component))]
+            occurrence.Core.Tier,
+            occurrence.Core.Component,
+            occurrence,
+            extensions))]
 [/#function]
 
-[#function formatIdentityPoolName tier component extensions... ]
+[#function formatIdentityPoolName occurrence extensions... ]
     [#return formatId(
         productName,
         segmentName,
-        getTierId(tier),
-        getComponentId(component)
-    )]
+        occurrence.Core.Tier,
+        occurrence.Core.Component,
+        extensions)]
 [/#function]

--- a/aws/templates/name/name_cognito.ftl
+++ b/aws/templates/name/name_cognito.ftl
@@ -9,5 +9,5 @@
 [/#function]
 
 [#function formatIdentityPoolName occurrence extensions...]
-    [#return formatSegmentFullName(occurrence.Core.Name, extensions) ]
+    [#return formatSegmentFullName(occurrence.Core.Name, extensions)?replace("-","X") ]
 [/#function]

--- a/aws/templates/name/name_cognito.ftl
+++ b/aws/templates/name/name_cognito.ftl
@@ -1,28 +1,13 @@
 [#-- Cognito User Pool --]
 
 [#function formatUserPoolName occurrence extensions...]
-    [#return formatName(
-        formatComponentFullName(
-            occurrence.Core.Tier,
-            occurrence.Core.Component,
-            occurrence,
-            extensions))]
+    [#return formatSegmentFullName(occurrence.Core.Name, extensions) ]
 [/#function]
 
 [#function formatUserPoolClientName occurrence extensions...]
-    [#return formatName( 
-        formatComponentFullName(
-            occurrence.Core.Tier,
-            occurrence.Core.Component,
-            occurrence,
-            extensions))]
+    [#return formatSegmentFullName(occurrence.Core.Name, extensions) ]
 [/#function]
 
 [#function formatIdentityPoolName occurrence extensions...]
-    [#return formatId(
-        productName,
-        segmentName,
-        occurrence.Core.Tier,
-        occurrence.Core.Component,
-        extensions)]
+    [#return formatSegmentFullName(occurrence.Core.Name, extensions) ]
 [/#function]

--- a/aws/templates/name/name_cognito.ftl
+++ b/aws/templates/name/name_cognito.ftl
@@ -1,20 +1,20 @@
 [#-- Cognito User Pool --]
 
-[#function formatUserPoolName tier component ]
+[#function formatUserPoolName tier component extensions... ]
     [#return formatName(
         formatComponentFullName(
             tier,
             component))]
 [/#function]
 
-[#function formatUserPoolClientName tier component ]
+[#function formatUserPoolClientName tier component extensions... ]
     [#return formatName( 
         formatComponentFullName(
             tier,
             component))]
 [/#function]
 
-[#function formatIdentityPoolName tier component ]
+[#function formatIdentityPoolName tier component extensions... ]
     [#return formatId(
         productName,
         segmentName,

--- a/aws/templates/resource/resource_cognito.ftl
+++ b/aws/templates/resource/resource_cognito.ftl
@@ -159,7 +159,8 @@
     autoVerify=[]
     schema=[]
     smsConfiguration={}
-    passwordPolicy={}  
+    passwordPolicy={}
+    lambdaTriggers={}  
     dependencies="" 
     outputId=""
 ]
@@ -218,8 +219,12 @@
                 emailVerificationSubject
              ) + 
              attributeIfContent ( 
-                 "SmsVerificationMessage",
-                 smsVerificationMessage
+                "SmsVerificationMessage",
+                smsVerificationMessage
+             ) + 
+             attributeIfContent (
+                "LambdaConfig",
+                lambdaTriggers
              )
         outputs=USERPOOL_OUTPUT_MAPPINGS
         outputId=outputId

--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -128,7 +128,7 @@
                                         linkTargetAttributes.ARN
                                     )
                                 ]
-                            [#break]
+                                [#break]
                             [#case "custommessage"]
                                 [#assign userPoolTriggerConfig = userPoolTriggerConfig +
                                     attributeIfContent (
@@ -136,7 +136,7 @@
                                         linkTargetAttributes.ARN
                                     )
                                 ]
-                            [#break]
+                                [#break]
                             [#case "defineauthchallenge"]
                                 [#assign userPoolTriggerConfig = userPoolTriggerConfig +
                                     attributeIfContent (
@@ -144,7 +144,7 @@
                                         linkTargetAttributes.ARN
                                     )
                                 ]
-                            [#break]
+                                [#break]
                             [#case "postauthentication"]
                                 [#assign userPoolTriggerConfig = userPoolTriggerConfig +
                                     attributeIfContent (
@@ -152,7 +152,7 @@
                                         linkTargetAttributes.ARN
                                     )
                                 ]
-                            [#break]
+                                [#break]
                             [#case "postconfirmation"]
                                 [#assign userPoolTriggerConfig = userPoolTriggerConfig +
                                     attributeIfContent (
@@ -160,7 +160,7 @@
                                         linkTargetAttributes.ARN
                                     )
                                 ]
-                            [#break]
+                                [#break]
                             [#case "preauthentication"]
                                 [#assign userPoolTriggerConfig =  userPoolTriggerConfig +
                                     attributeIfContent (
@@ -168,7 +168,7 @@
                                         linkTargetAttributes.ARN
                                     )
                                 ]
-                            [#break]
+                                [#break]
                             [#case "presignup"]
                                 [#assign userPoolTriggerConfig = userPoolTriggerConfig + 
                                     attributeIfContent (
@@ -176,7 +176,7 @@
                                         linkTargetAttributes.ARN
                                     )
                                 ]
-                            [#break]
+                                [#break]
                             [#case "verifyauthchallengeresponse"]
                                 [#assign userPoolTriggerConfig = userPoolTriggerConfig + 
                                     attributeIfContent (
@@ -184,10 +184,10 @@
                                         linkTargetAttributes.ARN
                                     )
                                 ]
-                            [#break]
+                                [#break]
                         [/#switch]
                     [/#if]
-                [#break]
+                    [#break]
             [/#switch]
         [/#list]
 

--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -7,25 +7,25 @@
 
         [@cfDebug listMode occurrence false /]
 
-        [#assign core = occurrence.Core ]
-        [#assign configuration = occurrence.Configuration ]
-        [#assign resources = occurrence.State.Resources ]
+        [#assign core = occurrence.Core]
+        [#assign configuration = occurrence.Configuration]
+        [#assign resources = occurrence.State.Resources]
 
-        [#assign userPoolId = resources["userpool"].Id ]
-        [#assign userPoolName = resources["userpool"].Name ]
-        [#assign userPoolClientId = resources["client"].Id ]
-        [#assign userPoolClientName = resources["client"].Name ]
-        [#assign userPoolRoleId = resources["userpoolrole"].Id ]
-        [#assign identityPoolId = resources["identitypool"].Id ]
-        [#assign identityPoolName = resources["identitypool"].Name ]
-        [#assign identityPoolUnAuthRoleId = resources["unauthrole"].Id ]
-        [#assign identityPoolAuthRoleId = resources["authrole"].Id ]
-        [#assign identityPoolRoleMappingId = resources["rolemapping"].Id ]
+        [#assign userPoolId = resources["userpool"].Id]
+        [#assign userPoolName = resources["userpool"].Name]
+        [#assign userPoolClientId = resources["client"].Id]
+        [#assign userPoolClientName = resources["client"].Name]
+        [#assign userPoolRoleId = resources["userpoolrole"].Id]
+        [#assign identityPoolId = resources["identitypool"].Id]
+        [#assign identityPoolName = resources["identitypool"].Name]
+        [#assign identityPoolUnAuthRoleId = resources["unauthrole"].Id]
+        [#assign identityPoolAuthRoleId = resources["authrole"].Id]
+        [#assign identityPoolRoleMappingId = resources["rolemapping"].Id]
 
-        [#assign dependencies = [] ]
+        [#assign dependencies = []]
         [#assign smsVerification = false]
-        [#assign schema = [] ]
-        [#assign userPoolTriggerConfig = {} ]
+        [#assign schema = []]
+        [#assign userPoolTriggerConfig = {}]
 
         [@cfDebug listMode appSettingsObject false /]
 
@@ -33,47 +33,47 @@
             valueIfContent(
             appSettingsObject.UserPool.EmailVerificationMessage!"",
             appSettingsObject.UserPool.EmailVerificationMessage!"",
-            "") ]
+            "")]
 
             
         [#assign emailVerificationSubject =
             valueIfContent(
             appSettingsObject.UserPool.EmailVerificationSubject!"",
             appSettingsObject.UserPool.EmailVerificationSubject!"",
-            "") ]
+            "")]
 
         [#assign smsVerificationMessage =
             valueIfContent(
             appSettingsObject.UserPool.SMSVerificationMessage!"",
             appSettingsObject.UserPool.SMSVerificationMessage!"",
-            "") ]
+            "")]
 
         [#assign emailInviteMessage =
             valueIfContent(
             appSettingsObject.UserPool.EmailInviteMessage!"",
             appSettingsObject.UserPool.EmailInviteMessage!"",
-            "") ]
+            "")]
 
         [#assign emailInviteSubject =
             valueIfContent(
             appSettingsObject.UserPool.EmailInviteSubject!"",
             appSettingsObject.UserPool.EmailInviteSubject!"",
-            "") ]
+            "")]
 
         [#assign smsInviteMessage =
             valueIfContent(
             appSettingsObject.UserPool.SMSInviteMessage!"",
             appSettingsObject.UserPool.SMSInviteMessage!"",
-            "") ]
+            "")]
 
-        [#if ( (configuration.MFA) || ( configuration.VerifyPhone)) ]
+        [#if ((configuration.MFA) || ( configuration.VerifyPhone))]
             [#if deploymentSubsetRequired("iam", true) &&
-            isPartOfCurrentDeploymentUnit(userPoolId) ]
+            isPartOfCurrentDeploymentUnit(userPoolId)]
 
                 [@createRole
                     mode=listMode
                     id=userPoolRoleId
-                    trustedServices=["cognito-idp.amazonaws.com" ]
+                    trustedServices=["cognito-idp.amazonaws.com"]
                     policies=
                         [
                             getPolicyDocument(
@@ -89,8 +89,7 @@
                                             true,
                                             true)]
                 [#assign schema = schema + [ phoneSchema ]]
-
-                )]
+            )]
 
             [/#if]
 
@@ -98,7 +97,7 @@
             [#assign smsVerification = true]
         [/#if]
 
-        [#if configuration.VerifyEmail || ( configuration.LoginAliases.seq_contains("email") ) ]
+        [#if configuration.VerifyEmail || ( configuration.LoginAliases.seq_contains("email"))]
                 [#assign emailSchema = getUserPoolSchemaObject( 
                                             "email",
                                             "String",
@@ -108,21 +107,21 @@
         [/#if]
 
         [#list configuration.Links?values as link]
-            [#assign linkTarget = getLinkTarget(occurrence, link) ]
+            [#assign linkTarget = getLinkTarget(occurrence, link)]
             [@cfDebug listMode linkTarget false /]
 
-            [#assign linkTargetCore = linkTarget.Core ]
-            [#assign linkTargetConfiguration = linkTarget.Configuration ]
-            [#assign linkTargetResources = linkTarget.State.Resources ]
-            [#assign linkTargetAttributes = linkTarget.State.Attributes ]
+            [#assign linkTargetCore = linkTarget.Core]
+            [#assign linkTargetConfiguration = linkTarget.Configuration]
+            [#assign linkTargetResources = linkTarget.State.Resources]
+            [#assign linkTargetAttributes = linkTarget.State.Attributes]
 
             [#switch linkTargetCore.Type!""]
-                [#case LAMBDA_FUNCTION_COMPONENT_TYPE ]
+                [#case LAMBDA_FUNCTION_COMPONENT_TYPE]
                     
-                    [#if linkTargetResources[LAMBDA_FUNCTION_COMPONENT_TYPE].Deployed ]
+                    [#if linkTargetResources[LAMBDA_FUNCTION_COMPONENT_TYPE].Deployed]
                         [#-- Cognito Userpool Event Triggers --]
-                        [#switch link.Name?lower_case ]
-                            [#case "createauthchallenge" ]
+                        [#switch link.Name?lower_case]
+                            [#case "createauthchallenge"]
                                 [#assign userPoolTriggerConfig =  userPoolTriggerConfig +
                                     attributeIfContent (
                                         "CreateAuthChallenge",
@@ -130,7 +129,7 @@
                                     )
                                 ]
                             [#break]
-                            [#case "custommessage" ]
+                            [#case "custommessage"]
                                 [#assign userPoolTriggerConfig = userPoolTriggerConfig +
                                     attributeIfContent (
                                         "CustomMessage",
@@ -138,7 +137,7 @@
                                     )
                                 ]
                             [#break]
-                            [#case "defineauthchallenge" ]
+                            [#case "defineauthchallenge"]
                                 [#assign userPoolTriggerConfig = userPoolTriggerConfig +
                                     attributeIfContent (
                                         "DefineAuthChallenge",
@@ -146,7 +145,7 @@
                                     )
                                 ]
                             [#break]
-                            [#case "postauthentication" ]
+                            [#case "postauthentication"]
                                 [#assign userPoolTriggerConfig = userPoolTriggerConfig +
                                     attributeIfContent (
                                         "PostAuthentication",
@@ -154,7 +153,7 @@
                                     )
                                 ]
                             [#break]
-                            [#case "postconfirmation" ]
+                            [#case "postconfirmation"]
                                 [#assign userPoolTriggerConfig = userPoolTriggerConfig +
                                     attributeIfContent (
                                         "PostConfirmation",
@@ -162,7 +161,7 @@
                                     )
                                 ]
                             [#break]
-                            [#case "preauthentication" ]
+                            [#case "preauthentication"]
                                 [#assign userPoolTriggerConfig =  userPoolTriggerConfig +
                                     attributeIfContent (
                                         "PreAuthentication",
@@ -170,7 +169,7 @@
                                     )
                                 ]
                             [#break]
-                            [#case "presignup" ]
+                            [#case "presignup"]
                                 [#assign userPoolTriggerConfig = userPoolTriggerConfig + 
                                     attributeIfContent (
                                         "PreSignUp",
@@ -178,7 +177,7 @@
                                     )
                                 ]
                             [#break]
-                            [#case "verifyauthchallengeresponse" ]
+                            [#case "verifyauthchallengeresponse"]
                                 [#assign userPoolTriggerConfig = userPoolTriggerConfig + 
                                     attributeIfContent (
                                         "VerifyAuthChallengeResponse",


### PR DESCRIPTION
Issue #162 
- Converted userpool solution to an occurrence based component
- Fixed some configuration properties casing so that they worked with the occurrence default settings
- Added Trigger links to user pool. When a lambda is linked from a user pool using one of the named actions for userpool event, the specified function will be set in the LambdaConfig section of the user pool template 
- Added inbound link properties to allow the lambda function to grant permission for the userpool to invoke it using the standard linking methods 
- Added ARN and Name attributes to lambda functions so that they can be looked up easily as part of a link 
- Added option to stop an error if a link is not found, because lambda functions are created during the application level deployment phase they aren't available for the initial creation of the userpool. So the user pool actually needs to be deployed initially as a solution, then lambda, then the userpool needs to be updated to get it working completely. This means that the link will fail on the first round, adding allowNotFound on the getLinkTarget stops the preconditionException being raised. 
