### PR TITLE
Add default for ECS task maximum memory

### DIFF
--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -409,6 +409,7 @@
                             )
                         ),
                     "MemoryReservation" : container.Memory,
+                    "MaximumMemory" : container.MaximumMemory!container.MemoryReservation*2,
                     "LogDriver" : logDriver,
                     "LogOptions" : logOptions,
                     "Environment" :
@@ -425,7 +426,6 @@
                 } +
                 attributeIfContent("ImageVersion", container.Version!"") +
                 attributeIfContent("Cpu", container.Cpu!"") +
-                attributeIfContent("MaximumMemory", container.MaximumMemory!"") +
                 attributeIfContent("PortMappings", portMappings)
             ]
 


### PR DESCRIPTION
Fixed #176 

In order that memory leaks don't adversely affect an ECS instance, add a
default maximum if an explicit limit isn't provided.

This code is designed to be merged after #175 is merged