### PR TITLE
Reduce use of global variables

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -641,7 +641,8 @@
                         } ]
                     [/#if]
                 [/#list]
-                [#list ((credentialsObject[core.Tier.Name + "-" + core.Component.Name])!{})?values as credential]
+
+                [#list ((credentialsObject[formatName(core.Tier, core.Component)])!{})?values as credential]
                     [#list credential as name,value]
                         [#local result +=
                             {
@@ -929,6 +930,7 @@
     [#list getOccurrences(
                 getTier(link.Tier),
                 getComponent(link.Tier, link.Component)) as targetOccurrence]
+
         [@cfDebug listMode targetOccurrence false /]
 
         [#local core = targetOccurrence.Core ]

--- a/aws/templates/createBlueprint.ftl
+++ b/aws/templates/createBlueprint.ftl
@@ -92,13 +92,7 @@
     [#if component?is_hash]
       [#assign componentTemplates = {} ]
       [#assign componentId = getComponentId(component)]
-      [#assign componentName = getComponentName(component)]
       [#assign componentType = getComponentType(component)]
-      [#assign componentIdStem = formatComponentId(tier, component)]
-      [#assign componentShortName = formatComponentShortName(tier, component)]
-      [#assign componentShortNameWithType = formatComponentShortNameWithType(tier, component)]
-      [#assign componentShortFullName = formatComponentShortFullName(tier, component)]
-      [#assign componentFullName = formatComponentFullName(tier, component)]
 
       [#local result +=
         [

--- a/aws/templates/resource/start.ftl
+++ b/aws/templates/resource/start.ftl
@@ -512,37 +512,29 @@
     [#list tiers as tier]
         [#assign tierId = tier.Id]
         [#assign tierName = tier.Name]
-        [#if tier.Components??]
-            [#list tier.Components?values as component]
-                [#if deploymentRequired(component, deploymentUnit)]
-                    [#assign componentTemplates = {} ]
-                    [#assign componentId = getComponentId(component)]
-                    [#assign componentName = getComponentName(component)]
-                    [#assign componentType = getComponentType(component)]
-                    [#assign componentIdStem = formatComponentId(tier, component)]
-                    [#assign componentShortName = formatComponentShortName(tier, component)]
-                    [#assign componentShortNameWithType = formatComponentShortNameWithType(tier, component)]
-                    [#assign componentShortFullName = formatComponentShortFullName(tier, component)]
-                    [#assign componentFullName = formatComponentFullName(tier, component)]
-                    [#assign dashboardRows = []]
-                    [#assign multiAZ = component.MultiAZ!solnMultiAZ]
-                    [#list asArray(compositeLists) as compositeList]
-                        [#include compositeList?ensure_starts_with("/")]
-                    [/#list]
-                    [#if dashboardRows?has_content]
-                        [#assign dashboardComponents += [
-                                {
-                                    "Title" : component.Title?has_content?then(
-                                                component.Title,
-                                                formatComponentName(tier, component)),
-                                    "Rows" : dashboardRows
-                                }
-                            ]
+        [#list (tier.Components!{})?values as component]
+            [#if deploymentRequired(component, deploymentUnit)]
+                [#assign componentTemplates = {} ]
+                [#assign componentId = getComponentId(component)]
+                [#assign componentType = getComponentType(component)]
+                [#assign dashboardRows = []]
+                [#assign multiAZ = component.MultiAZ!solnMultiAZ]
+                [#list asArray(compositeLists) as compositeList]
+                    [#include compositeList?ensure_starts_with("/")]
+                [/#list]
+                [#if dashboardRows?has_content]
+                    [#assign dashboardComponents += [
+                            {
+                                "Title" : component.Title?has_content?then(
+                                            component.Title,
+                                            formatComponentName(tier, component)),
+                                "Rows" : dashboardRows
+                            }
                         ]
-                    [/#if]
+                    ]
                 [/#if]
-            [/#list]
-        [/#if]
+            [/#if]
+        [/#list]
     [/#list]
 [/#macro]
 

--- a/aws/templates/solution/solution_cache.ftl
+++ b/aws/templates/solution/solution_cache.ftl
@@ -32,7 +32,7 @@
     [#assign cacheId = formatCacheId(
                         tier,
                         component)]
-    [#assign cacheFullName = componentFullName]
+    [#assign cacheFullName = formatComponentFullName(tier, component) ]
     [#assign cacheSubnetGroupId = formatCacheSubnetGroupId(tier, component)]
     [#assign cacheParameterGroupId = formatCacheParameterGroupId(tier, component)]
 

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -5,7 +5,7 @@
     [#assign loadBalanced = ec2.LoadBalanced!false]
     [#assign dockerHost = ec2.DockerHost!false]
 
-    [#assign ec2FullName = formatName(tenantId, componentFullName) ]
+    [#assign ec2FullName = formatName(tenantId, formatComponentFullName(tier, component)) ]
     [#assign ec2SecurityGroupId = formatEC2SecurityGroupId(tier, component)]
     [#assign ec2RoleId = formatEC2RoleId(tier, component)]
     [#assign ec2InstanceProfileId = formatEC2InstanceProfileId(tier, component)]

--- a/aws/templates/solution/solution_efs.ftl
+++ b/aws/templates/solution/solution_efs.ftl
@@ -12,7 +12,7 @@
                             component,
                             occurrence)]
         
-        [#assign efsFullName = componentFullName]
+        [#assign efsFullName = formatComponentFullName(tier, component) ]
 
         [#assign efsMountTargetId = formatDependentEFSMountTargetId(
                                         efsId)]

--- a/aws/templates/solution/solution_elb.ftl
+++ b/aws/templates/solution/solution_elb.ftl
@@ -3,8 +3,8 @@
     [#assign elb = component.ELB]
 
     [#assign elbId = formatELBId(tier, component)]
-    [#assign elbFullName = componentFullName]
-    [#assign elbShortFullName = componentShortFullName]
+    [#assign elbFullName = formatComponentFullName(tier, component) ]
+    [#assign elbShortFullName = formatComponentShortFullName(tier, component)]
     [#assign securityGroupId = formatComponentSecurityGroupId(tier, component) ]
     [#assign healthCheckDestination = ports[portMappings[elb.PortMappings[0]].Destination] ]
 

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -51,8 +51,8 @@
         [#assign rdsParameterGroupId = formatRDSParameterGroupId(tier, component, occurrence)]
         [#assign rdsOptionGroupId = formatRDSOptionGroupId(tier, component, occurrence)]
         [#assign rdsCredentials =
-            credentialsObject[componentShortNameWithType]!
-            credentialsObject[componentShortName]!
+            credentialsObject[formatComponentShortNameWithType(tier, component)]!
+            credentialsObject[formatComponentShortName(tier, component)]!
             {
                 "Login" : {
                     "Username" : "Not provided",


### PR DESCRIPTION
Fixes #145 

With the move to use occurrences more heavily, the global component level
variables can be phased out.

This is a first cut at this - componentId and componentType are still
used in quite a number of places but other variables can be removed
in preparation for a more general move to use of occurrences.

There are also a few other minor code style improvements as well.