### PR TITLE
Set Subcomponent to Name for Environment Variables

### DIFF
--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -238,7 +238,7 @@
             "APPSETTINGS_PREFIX" : getAppSettingsFilePrefix(),
             "CREDENTIALS_PREFIX" : getCredentialsFilePrefix()
         } +
-        attributeIfContent("SUBCOMPONENT", core.SubComponent!"") +
+        attributeIfContent("SUBCOMPONENT", core.SubComponent.Name!"") +
         attributeIfContent("APP_RUN_MODE", mode) +
         attributeIfContent("BUILD_REFERENCE", buildCommit!"") +
         attributeIfContent("APP_REFERENCE", appReference!"") +


### PR DESCRIPTION
Subcomponent definition now has Id and Name listed instead of a single value. Environment Variables only accept a string as a value and at the moment the template is receiving a hash. 

