### PR TITLE
Roll back URL for RDS due to password encryption.

### DIFF
--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -50,31 +50,8 @@
     
 [#function getRDSState occurrence]
     [#local core = occurrence.Core]
+    [#local configuraton = occurrence.Configuration]
     [#local id = formatResourceId(RDS_RESOURCE_TYPE, core.Id) ]
-
-    [#local engine = occurrence.Configuration.Engine]
-    [#local fqdn = getExistingReference(id, DNS_ATTRIBUTE_TYPE)]
-    [#local port = getExistingReference(id, PORT_ATTRIBUTE_TYPE)]
-    [#local name = getExistingReference(id, DATABASENAME_ATTRIBUTE_TYPE)]
-
-    [#local login = {} ]
-    [#list
-        (
-            credentialsObject[formatComponentShortNameWithType(core.Tier, core.Component)]!
-            credentialsObject[formatComponentShortName(core.Tier, core.Component)]!
-            {
-                "Login" : {
-                    "Username" : "Not provided",
-                    "Password" : "Not provided"
-                }
-            }
-        ).Login as name,value]
-        [#local login +=
-            { 
-                name?upper_case : value 
-            }
-        ]
-    [/#list]
 
     [#local result =
         {
@@ -94,12 +71,10 @@
                 }
             },
             "Attributes" : {
-                "FQDN" : fqdn,
-                "PORT" : port,
-                "NAME" : name,
-                "USERNAME" : login.USERNAME,
-                "PASSWORD" : login.PASSWORD,
-                "URL" : engine + "://" + login.USERNAME + ":" + login.PASSWORD + "@" + fqdn + ":" + port + "/" + name 
+                "FQDN" : getExistingReference(id, DNS_ATTRIBUTE_TYPE),
+                "PORT" : getExistingReference(id, PORT_ATTRIBUTE_TYPE),
+                "NAME" : getExistingReference(id, DATABASENAME_ATTRIBUTE_TYPE),
+                "ENGINE" : configuration.Engine,
             },
             "Roles" : {
                 "Inbound" : {},
@@ -107,5 +82,22 @@
             }
         }
     ]
+    [#list
+        (
+            credentialsObject[formatComponentShortNameWithType(core.Tier, core.Component)]!
+            credentialsObject[formatComponentShortName(core.Tier, core.Component)]!
+            {
+                "Login" : {
+                    "Username" : "Not provided",
+                    "Password" : "Not provided"
+                }
+            }
+        ).Login as name,value]
+        [#local result +=
+            {
+              "Attributes" : result.Attributes + { name?upper_case : value }
+            }
+        ]
+    [/#list]
     [#return result ]
 [/#function]


### PR DESCRIPTION
Since we encrypt RDS passwords using KMS, passing the URL straight through to the application poses potential issues as the KMS decryption process is usually done as part of a dedicated app startup process.

Instead this PR adds the database engine as an attribute so that all of the components to build a database URL are available. 