### PR TITLE
Increase default ECS instance size to a t2.medium

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -940,7 +940,7 @@
         "Processor": "t2.micro"
       },
       "ECS": {
-        "Processor": "t2.micro",
+        "Processor": "t2.medium",
         "MinPerZone": 1,
         "MaxPerZone": 1,
         "DesiredPerZone": 1


### PR DESCRIPTION
Fixes #194 