### PR TITLE
Control paths in URLs for API Gateway

### DIFF
--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -136,6 +136,10 @@
                         "Default" : []
                     }
                 ]
+            },
+            {
+                "Name" : "IncludePathInUrls",
+                "Default" : true
             }
         ]
     }]
@@ -165,6 +169,19 @@
             [#local signingFqdn = internalFqdn]
     [/#if]
 
+    [#-- Paths are tricky as sometimes the API gateway "consumes" version path. --]
+    [#-- So the caller needs to provide it but the implementer doesn't see it.  --]
+    [#local versionPath =
+        valueIfTrue(
+            "/" + core.Version.Id,
+            configuration.IncludePathInUrls,
+            ""
+        ) ]
+
+    [#-- For now assume the path is seen by the implementation --]
+    [#-- A later change will refine this once behaviour of the --]
+    [#-- API Gateway is confirmed                              --]
+    [#local internalPath = core.Version.Id ]
     [#return
         {
             "Resources" : {
@@ -175,12 +192,13 @@
             },
             "Attributes" : {
                 "FQDN" : fqdn,
-                "URL" : "https://" + fqdn,
+                "URL" : "https://" + fqdn + versionPath,
                 "DOCS_URL" : "http://docs." + fqdn,
                 "SIGNING_FQDN" : signingFqdn,
-                "SIGNING_URL" : "https://" + signingFqdn,
+                "SIGNING_URL" : "https://" + signingFqdn + versionPath,
                 "INTERNAL_FQDN" : internalFqdn,
-                "INTERNAL_URL" : "https://" + internalFqdn
+                "INTERNAL_URL" : "https://" + internalFqdn + versionPath,
+                "INTERNAL_PATH" : internalPath
             },
             "Roles" : {
                 "Outbound" : {


### PR DESCRIPTION
Fixes #203 

@roleyfoley this will likely affect smallcraft and IPC. Before merging this change, you can set the "IncludePathInUrls configuration option to false for the APIs to inhibit the new behaviour, while the code gets changed to not have to control this. Note there is a separate attribute for the implementation code to know what path it will see - basically INTERNAL_PATH = basepath in swagger

Include the version path in URL attributes - selection of version can
then be controlled via the links in the solution.

Provide an ability to turn this off for backwards compatability.

Also provide an attribute with the path that the implementation (e.g.
lambda) will see. The suspicion is that this varies depending on the
configuraiotn of custom domains. As the gateway knows its configuration,
this seems the best default place to control this information.