### PR TITLE
Use link routine for container load balancers

### DIFF
--- a/aws/templates/id/id_alb.ftl
+++ b/aws/templates/id/id_alb.ftl
@@ -85,7 +85,7 @@
     [#local internalFqdn = getExistingReference(id, DNS_ATTRIBUTE_TYPE) ]
 
     [#if (configuration.PortMappings![])?has_content]
-        [#local portMapping = configuration.PortMappings[0]?is_hash?then(
+        [#local mappingObject = configuration.PortMappings[0]?is_hash?then(
                 configuration.PortMappings[0],
                 {
                     "Mapping" : configuration.PortMappings[0]

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -72,6 +72,7 @@
                             "Name" : "Component",
                             "Mandatory" : true
                         },
+                        "Instance",
                         {
                             "Name" : "Path",
                             "Default" : ""
@@ -95,7 +96,8 @@
                         {
                             "Name" : "Tier",
                             "Mandatory" : true
-                        }
+                        },
+                        "Version"
                     ]
                 }
             ]


### PR DESCRIPTION
Fixes #210

* remove the custom matching code and replace with a call to getLinkTarget.
* support instance and version overrides in line general link processing