### PR TITLE
Correct detection of unresolvable links

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -49,14 +49,19 @@
         [#list configuration.Links?values as link]
             [#if link?is_hash]
                 [#assign linkTarget = getLinkTarget(occurrence, link) ]
+
                 [@cfDebug listMode linkTarget false /]
+
+                [#if !linkTarget?has_content]
+                    [#continue]
+                [/#if]
 
                 [#assign linkTargetCore = linkTarget.Core ]
                 [#assign linkTargetConfiguration = linkTarget.Configuration ]
                 [#assign linkTargetResources = linkTarget.State.Resources ]
                 [#assign linkTargetAttributes = linkTarget.State.Attributes ]
 
-                [#switch linkTargetCore.Type!""]
+                [#switch linkTargetCore.Type]
                     [#case "alb"]
                         [#assign stageVariables +=
                             {

--- a/aws/templates/application/application_contentnode.ftl
+++ b/aws/templates/application/application_contentnode.ftl
@@ -20,11 +20,18 @@
         [#list configuration.Links?values as link]
             [#if link?is_hash]
                 [#assign linkTarget = getLinkTarget(occurrence, link) ]
+
+                [@cfDebug listMode linkTarget false /]
+
+                [#if !linkTarget?has_content]
+                    [#continue]
+                [/#if]
+
                 [#assign linkTargetCore = linkTarget.Core ]
                 [#assign linkTargetConfiguration = linkTarget.Configuration ]
                 [#assign linkTargetAttributes = linkTarget.State.Attributes ]
 
-                [#switch linkTargetCore.Type!""]
+                [#switch linkTargetCore.Type]
                     [#case "external"]
                     [#case "contenthub"]
                         [#if deploymentSubsetRequired("prologue", false)]

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -49,7 +49,7 @@
                     [#assign linkTargetRoles = linkTarget.State.Roles ]
                     [#assign linkDirection = linkTarget.Direction ]
 
-                    [#switch linkTargetCore.Type!""]
+                    [#switch linkTargetCore.Type]
                         [#case USERPOOL_COMPONENT_TYPE] 
                         [#case "apigateway"]
                             [#if linkTargetResources[(linkTargetCore.Type)].Deployed &&

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -521,7 +521,6 @@
                                 [/#if]
                             [/#list]
                         [/#list]
-
                         [#list subobjectKeys as subobjectKey ]
                             [#if subobjectKey == "Configuration" ]
                                 [#continue]
@@ -1115,28 +1114,20 @@
         "getLinkTarget"
         {
             "Occurrence" : occurrence,
-            "Link" : link
+            "Link" : link,
+            "EffectiveInstance" : instanceToMatch,
+            "EffectiveVersion" : versionToMatch
         }
         "Link not found" /]
 
-    [#return
-        {
-            "Core" : {},
-            "Configuration" : {},
-            "State" : {
-                "Resources" : {},
-                "Attributes" : {},
-                "Roles" : {}
-            },
-            "Direction" : ""
-        } ]
+    [#return {} ]
 [/#function]
 
 [#function getLinkTargets occurrence links={}]
     [#local result={} ]
     [#list (valueIfContent(links, links, occurrence.Configuration.Links!{}))?values as link]
         [#if link?is_hash]
-            [#local linkTarget = getLinkTarget(occurrence, link)!{} ]
+            [#local linkTarget = getLinkTarget(occurrence, link) ]
             [#local result +=
                 valueIfContent(
                     {

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -277,8 +277,8 @@
                     "Tier" : targetTierId,
                     "Component" : targetComponentId
                 } +
-                attributeIfContent("Instance", port.LB.Instance!core.Instance.Id) +
-                attributeIfContent("Version", port.LB.Version!core.Version.Id) ]
+                attributeIfContent("Instance", port.LB.Instance!"") +
+                attributeIfContent("Version", port.LB.Version!"") ]
 
             [@cfDebug listMode targetLink false /]
 
@@ -324,40 +324,39 @@
                 [/#if]
             [/#if]
 
-            [#local containerPortMappings +=
-                [
+            [#local containerPortMapping =
+                {
+                    "ContainerPort" :
+                        contentIfContent(
+                            port.Container!"",
+                            port.Id
+                        ),
+                    "HostPort" : port.Id,
+                    "DynamicHostPort" : port.DynamicHostPort
+                } ]
+            [#if targetLoadBalancer?has_content]
+                [#local containerPortMapping +=
                     {
-                        "ContainerPort" :
-                            contentIfContent(
-                                port.Container!"",
-                                port.Id
-                            ),
-                        "HostPort" : port.Id,
-                        "DynamicHostPort" : port.DynamicHostPort
-                    } +
-                    valueIfContent(
-                        {
-                            "LoadBalancer" :
+                        "LoadBalancer" :
+                            {
+                                "Tier" : targetTierId,
+                                "Component" : targetComponentId,
+                                "Instance" : targetLoadBalancer.Core.Instance.Id,
+                                "Version" : targetLoadBalancer.Core.Version.Id
+                            } +
+                            valueIfContent(
                                 {
-                                    "Tier" : targetTierId,
-                                    "Component" : targetComponentId,
-                                    "Instance" : targetLoadBalancer.Core.Instance.Id,
-                                    "Version" : targetLoadBalancer.Core.Version.Id
-                                } +
-                                valueIfContent(
-                                    {
-                                        "TargetGroup" : targetGroup,
-                                        "Port" : targetPort,
-                                        "Priority" : port.LB.Priority,
-                                        "Path" : targetPath
-                                    },
-                                    targetGroup
-                                )
-                        },
-                        targetLoadBalancer
-                    )
+                                    "TargetGroup" : targetGroup,
+                                    "Port" : targetPort,
+                                    "Priority" : port.LB.Priority,
+                                    "Path" : targetPath
+                                },
+                                targetGroup
+                            )
+                    }
                 ]
-            ]
+            [/#if]
+            [#local containerPortMappings += [containerPortMapping] ]
         [/#list]
 
         [#local logDriver =

--- a/aws/templates/solution/solution_s3.ftl
+++ b/aws/templates/solution/solution_s3.ftl
@@ -27,6 +27,10 @@
                             "Tier" : queue.Tier!tier,
                             "Component" : queue.Component!queue.Id
                         }) ]
+                [#if !linkTarget?has_content]
+                    [#continue]
+                [/#if]
+
                 [#assign sqsId = (linkTarget.State.Resources["queue"].Id)!"" ]
                 [#if sqsId?has_content]
                     [#assign sqsIds += [sqsId] ]

--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -108,14 +108,19 @@
 
         [#list configuration.Links?values as link]
             [#assign linkTarget = getLinkTarget(occurrence, link)]
+
             [@cfDebug listMode linkTarget false /]
+
+            [#if !linkTarget?has_content]
+                [#continue]
+            [/#if]
 
             [#assign linkTargetCore = linkTarget.Core]
             [#assign linkTargetConfiguration = linkTarget.Configuration]
             [#assign linkTargetResources = linkTarget.State.Resources]
             [#assign linkTargetAttributes = linkTarget.State.Attributes]
 
-            [#switch linkTargetCore.Type!""]
+            [#switch linkTargetCore.Type]
                 [#case LAMBDA_FUNCTION_COMPONENT_TYPE]
                     
                     [#if linkTargetResources[LAMBDA_FUNCTION_COMPONENT_TYPE].Deployed]


### PR DESCRIPTION
Fixes #220 

Change behaviour of getLinkTarget to return an empty object if a link
isn't matched, rather than a partially populated one.

Add code to detect situations where getLinkTarget may return an empty
object. An exception is generated in this case, so the aim is to have
the template complete successfully so the Exception detection logic can
then report the failure to match the link.