### PR TITLE
Move Blueprint Generation location to dedicated infrastructure folder

### DIFF
--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -265,6 +265,15 @@ function findGen3TenantDir() {
     "tenant.json"
 }
 
+function findGen3TenantInfrastructureDir() {
+  local root_dir="$1"; shift
+  local tenant="$1"; shift
+
+  findDir "${root_dir}" \
+    "infrastructure/**/${tenant}" \
+    "${tenant}/infrastructure"
+}
+
 function findGen3AccountDir() {
   local root_dir="$1"; shift
   local account="$1"; shift

--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -169,6 +169,7 @@ function process_template() {
 
   case "${level}" in
     blueprint)
+      cf_dir="${PRODUCT_INFRASTRUCTURE_DIR}/cot/${SEGMENT}/bp"
       template_composites+=("SEGMENT" "SOLUTION" "APPLICATION" "CONTAINER" )
 
       # Blueprint applies across accounts and regions


### PR DESCRIPTION
Fixes #222 

As part of #133 blueprint files will be generated as part of the manageUnit Process when a deployment is completed. This moves the blueprint output location to a dedicated infrastructure folder. 

Also adding in a find for Tenant Infrastructure to align gen3 and gen3-automation contextTrees 