### PR TITLE
Be more specific when creating a target group for a version

### DIFF
--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -311,7 +311,10 @@
                                 [#local targetGroup = "default" ]
                             [/#if]
                         [#else]
-                            [#if core.Version.Name?has_content]
+                            [#-- Create target group for container if it --]
+                            [#-- is versioned and load balancer isn't    --]
+                            [#if core.Version.Name?has_content &&
+                                    !targetLoadBalancer.Core.Version.Name?has_content]
                                 [#local targetPath = "/" + core.Version.Name + "/*" ]
                                 [#local targetGroup = core.Version.Name ]
                             [#else]


### PR DESCRIPTION
Only create a specific target group for a versioned container if the match was against an unversioned load balancer i.e. create a target group per version.

This ensures that if the occurrence match has used instance and version, the default target group is used for the resolved load balancer.