### PR TITLE
Updates to Blueprint Generation

### DIFF
--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -170,6 +170,7 @@ function process_template() {
   case "${level}" in
     blueprint)
       cf_dir="${PRODUCT_INFRASTRUCTURE_DIR}/cot/${SEGMENT}/bp"
+      pass_list=("template")
       template_composites+=("SEGMENT" "SOLUTION" "APPLICATION" "CONTAINER" )
 
       # Blueprint applies across accounts and regions

--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -171,6 +171,7 @@ function process_template() {
     blueprint)
       cf_dir="${PRODUCT_INFRASTRUCTURE_DIR}/cot/${SEGMENT}/bp"
       pass_list=("template")
+      passes=("template")
       template_composites+=("SEGMENT" "SOLUTION" "APPLICATION" "CONTAINER" )
 
       # Blueprint applies across accounts and regions

--- a/aws/templates/createBlueprint.ftl
+++ b/aws/templates/createBlueprint.ftl
@@ -36,21 +36,10 @@
       {
         "Id" : environmentObject.Id,
         "Configuration" : environmentObject,
-        "Solutions" : getSolutionBlueprint()
+        "Segments" : getSegmentBlueprint()
       }
   ]]
   [#return result ]
-[/#function]
-
-[#function getSolutionBlueprint]
-  [#local result= [
-      {
-        "Id" : solutionObject.Id,
-        "Configuration" : solutionObject,
-        "Segments" : getSegmentBlueprint()
-      }
-    ]]
-    [#return result ]
 [/#function]
 
 [#function getSegmentBlueprint ]
@@ -59,6 +48,7 @@
         "Id" : segmentObject.Id,
         "Configuration" : segmentObject,
         "Account" : accountObject,
+        "Solution" : solutionObject,
         "Tiers" : getTierBlueprint() 
       } 
     ]]
@@ -90,16 +80,26 @@
   [#local result=[] ]
   [#list tier.Components!{} as id,component]
     [#if component?is_hash]
-      [#assign componentTemplates = {} ]
-      [#assign componentId = getComponentId(component)]
-      [#assign componentType = getComponentType(component)]
+
+      [#-- Only include deployed Occurrences --]
+      [#local occurrences = getOccurrences(tier, component) ]
+      [#local deployedOccurrences = [] ]
+
+      [#list getOccurrences(tier, component) as occurrence ]
+        [#list occurrence.State.Resources?values as resource ]
+          [#if resource.Deployed ]
+            [#local deployedOccurrences += [ occurrence ]]
+            [#continue]
+          [/#if]
+        [/#list]
+      [/#list]
 
       [#local result +=
         [
           {
-              "Id" : id,
-              "Occurrences" : getOccurrences(tier, component)
-          }]]
+            "Id" : id,
+            "Occurrences" : deployedOccurrences
+        }]]
     [/#if]
   [/#list]
   [#return  result ]


### PR DESCRIPTION
Couple of changes to support the continuous generation of blueprints 

- Update template generation to only perform a template pass ( no prologue, epilogue or config) 
- Remove Solution from nesting in template and move to segment property 
- Only include occurrences where one resource has been deployed