### PR TITLE
RDS updates for snapshot management and at rest encryption

### DIFF
--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -14,6 +14,13 @@
                 extensions)]
 [/#function]
 
+[#function formatDependentRDSManualSnapshotId resourceId extensions... ]
+    [#return formatDependentResourceId(
+                "manualsnapshot",
+                resourceId,
+                extensions)]
+[/#function]
+
 [#assign componentConfiguration +=
     {
         RDS_COMPONENT_TYPE : [
@@ -25,7 +32,7 @@
             "Port",
             {
                 "Name" : "Encrypted",
-                "Default" : false
+                "Default" : true
             },
             { 
                 "Name" : "Size",
@@ -40,7 +47,7 @@
                     },
                     {
                         "Name" : "SnapshotOnDeploy",
-                        "Default" : false
+                        "Default" : true
                     }
                 ]
             },

--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -32,7 +32,7 @@
             "Port",
             {
                 "Name" : "Encrypted",
-                "Default" : true
+                "Default" : false
             },
             { 
                 "Name" : "Size",

--- a/aws/templates/resource/resource_rds.ftl
+++ b/aws/templates/resource/resource_rds.ftl
@@ -70,7 +70,7 @@
                 "AvailabilityZone" : zones[0].AWSZone
             }
         ) + 
-        encrypted?then(
+        (!(snapshotId?has_content) && encrypted)?then(
             {
                 "StorageEncrypted" : true,
                 "KmsKeyId" : getReference(formatSegmentCMKId(), ARN_ATTRIBUTE_TYPE)

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -114,7 +114,17 @@
                         "\"snapshotX" + rdsId + "Xname\" " + "\"" + rdsPreDeploySnapshotId + "\" || return $?", 
                         "}",
                         "pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-pseudo-stack.json\" ",
-                        "create_deploy_snapshot || return $?"
+                        "create_deploy_snapshot || return $?" + 
+                        
+                        (configuration.Encrypted)?then(
+                            "function encrypt_snapshot() {",
+                            "# Encrypt Snapshot",
+                            "info \"Encrypting Snapshot if required... \"",
+                            "encrypt_snapshot" + 
+                            " \"" + region + "\"
+                            
+                        )
+
                     ]
                 /]
             [/#if]

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -95,7 +95,7 @@
         [#assign processorProfile = getProcessor(tier, component, "RDS")]
 
         [#if deploymentSubsetRequired("prologue", false)]
-            [#-- If a manual snapshot has been added the pseudo stack has be replaced with an automated one --]
+            [#-- If a manual snapshot has been added the pseudo stack output should be replaced with an automated one --]
             [#if configuration.Backup.SnapshotOnDeploy || rdsManualSnapshot?has_content ]
                 [@cfScript
                     mode=listMode

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -727,11 +727,11 @@ function create_snapshot() {
   db_info=$(aws --region "${region}" rds describe-db-instances --db-instance-identifier ${db_identifier} )
 
   if [[ -n "${db_info}" ]]; then
-    aws --region "${region}" rds create-db-snapshot --db-snapshot-identifier "${db_snapshot_identifier}" --db-instance-identifier "${db_identifier}" > /dev/null 2>&1 || return $?
+    aws --region "${region}" rds create-db-snapshot --db-snapshot-identifier "${db_snapshot_identifier}" --db-instance-identifier "${db_identifier}" 1> /dev/null || return $?
     aws --region "${region}" rds wait db-snapshot-available --db-snapshot-identifier "${db_snapshot_identifier}"  || return $?
     db_snapshot=$(aws --region "${region}" rds describe-db-snapshots --db-snapshot-identifier "${db_snapshot_identifier}" || return $?)
   fi
-  echo -n "$(echo "${db_snapshot}" | jq -r '.DBSnapshots[0] | .DBSnapshotIdentifier + " " + .SnapshotCreateTime' )"
+  info "Snapshot Created - $(echo "${db_snapshot}" | jq -r '.DBSnapshots[0] | .DBSnapshotIdentifier + " " + .SnapshotCreateTime' )"
 }
 
 function encrypt_snapshot() { 
@@ -740,46 +740,61 @@ function encrypt_snapshot() {
   local kms_key_id="$1"; shift 
 
   # Check the snapshot status 
-  snapshot_info=$(aws --region "${region}" describe-db-snapshots --db-snapshot-identifier "${db_snapshot_identifier}" || return $? )
+  snapshot_info=$(aws --region "${region}" rds describe-db-snapshots --db-snapshot-identifier "${db_snapshot_identifier}" || return $? )
 
   if [[ -n "${snapshot_info}" ]]; then 
     if [[ $(echo "${snapshot_info}" | jq -r '.DBSnapshots[0].Status == "Available"') ]]; then
 
-      if [[ $(echo "${snapshot_info}" | jq -r '.DBSnapshots[0].Encrypted == false') ]]; then 
+      if [[ $(echo "${snapshot_info}" | jq -r '.DBSnapshots[0].Encrypted') == false ]]; then 
 
-        info "Creating encrypted snapshot of ${db_snapshot_identifier}"
+        info "Converting snapshot ${db_snapshot_identifier} to an encrypted snapshot"
+
         # create encrypted snapshot
         aws --region "${region}" rds copy-db-snapshot \
           --source-db-snapshot-identifier "${db_snapshot_identifier}" \
           --target-db-snapshot-identifier "encrypted-${db_snapshot_identifier}" \
-          --kms-key-id "${kms_key_id}" > /dev/null 2>&1 || return $?
-        aws --region "${region}" rds wait db-snapshot-available --db-snapshot-identifier "encrypted-${db_snapshot_identifier}" > /dev/null 2>&1  || return $?
+          --kms-key-id "${kms_key_id}" 1> /dev/null || return $?
 
+        info "Waiting for temp encrypted snapshot to become available..."
+        sleep 2
+        aws --region "${region}" rds wait db-snapshot-available --db-snapshot-identifier "encrypted-${db_snapshot_identifier}" || return $?
+
+        info "Removing plaintext snapshot..."
         # delete the original snapshot
-        aws --region "${region}" rds delete-db-snapshot --db-snapshot-identifier "${db_snapshot_identifier}"  > /dev/null 2>&1  || return $?
-        aws --region "${region}" rds wait db-snapshot-deleted --db-snapshot-identifier "${db_snapshot_identifier}" > /dev/null 2>&1  || return $? 
+        aws --region "${region}" rds delete-db-snapshot --db-snapshot-identifier "${db_snapshot_identifier}"  1> /dev/null || return $?
+        aws --region "${region}" rds wait db-snapshot-deleted --db-snapshot-identifier "${db_snapshot_identifier}"  || return $? 
 
         # Copy snapshot back to original identifier
+        info "Renaming encrypted snapshot..."
         aws --region "${region}" rds copy-db-snapshot \
           --source-db-snapshot-identifier "encrypted-${db_snapshot_identifier}" \
-          --target-db-snapshot-identifier "${db_snapshot_identifier}" > /dev/null 2>&1 || return $?
-        aws --region "${region}" rds wait db-snapshot-available --db-snapshot-identifier "${db_snapshot_identifier}" > /dev/null 2>&1  || return $?
+          --target-db-snapshot-identifier "${db_snapshot_identifier}" 1> /dev/null || return $?
+        
+        sleep 2
+        aws --region "${region}" rds wait db-snapshot-available --db-snapshot-identifier "${db_snapshot_identifier}"  || return $?
+        
+        # Remove the encrypted temp snapshot
+        aws --region "${region}" rds delete-db-snapshot --db-snapshot-identifier "encrypted-${db_snapshot_identifier}"  1> /dev/null || return $?
+        aws --region "${region}" rds wait db-snapshot-deleted --db-snapshot-identifier "encrypted-${db_snapshot_identifier}"  || return $? 
+
+        db_snapshot=$(aws --region "${region}" rds describe-db-snapshots --db-snapshot-identifier "${db_snapshot_identifier}" || return $?)
+        info "Snapshot Converted - $(echo "${db_snapshot}" | jq -r '.DBSnapshots[0] | .DBSnapshotIdentifier + " " + .SnapshotCreateTime + " Encrypted: " + (.Encrypted|tostring)' )"
 
         return 0
 
       else 
-        info "Snapshot ${db_snapshot_identifier} already encrypted"
-        return 128
+
+        echo "Snapshot ${db_snapshot_identifier} already encrypted"
+        return 0
         
       fi
-    s
+    
     else 
-      fatal "Snapshot had an issue $(echo "${snapshot_info}")"
+      echo "Snapshot not in a usuable state $(echo "${snapshot_info}")"
       return 255 
     fi
   fi
 }
-
 
 # -- Git Repo Management --
 function clone_git_repo() {


### PR DESCRIPTION
- Add support for manual snapshot restoration
- Enables snapshot on deploy by default 

To use manual snapshot restoration add a prologue pseudo stack with the an output: 
````json
                {
                    "OutputKey": "manualsnapshotX<RDSId>",
                    "OutputValue": "<snapshot Identifier>"
                }
````

- Adds Support for the conversion of an instance to a database encrypted at rest from one that hasn't been encrypted from the start
  - Requires SnapshotOnDeploy to be enabled