### PR TITLE
Increase keepalive frequency

### DIFF
--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -62,7 +62,7 @@
                     },
                     {
                         "Name" : "Expression",
-                        "Default" : "rate(30 minutes)"
+                        "Default" : "rate(6 minutes)"
                     },
                     {
                         "Name" : "InputPath",


### PR DESCRIPTION
It appears keepalives of 30 minutes are insufficient to keep lambda alive in ap-southeast-2.

Reducing to 6 mins for now.