### PR TITLE
Remove Passwords and Keys from Blueprint generation

### DIFF
--- a/aws/templates/createBlueprint.ftl
+++ b/aws/templates/createBlueprint.ftl
@@ -115,20 +115,15 @@
         [/#list]
         
         [#if deployed ]
-          [#local deployedOccurrences += [ occurrence ] ]
+          [#local deployedOccurrences += [ getCleanedOccurrence(occurrence) ] ]
         [/#if]
-      [/#list]
-
-      [#local cleanedOccurrences = [] ]
-      [#list deployedOccurrences as occurrence ] 
-        [#local cleanedOccurrences += [ getCleanedOccurrence(occurrence)]]
       [/#list]
 
       [#local result += [
         {
           "Id" : id,
           "Type" : componentType,
-          "Occurrences" : cleanedOccurrences
+          "Occurrences" : deployedOccurrences
         } ] ]
 
     [/#if]

--- a/aws/templates/createBlueprint.ftl
+++ b/aws/templates/createBlueprint.ftl
@@ -106,12 +106,17 @@
       [#local deployedOccurrences = [] ]
 
       [#list getOccurrences(tier, component) as occurrence ]
+        [#local deployed = false]
         [#list occurrence.State.Resources?values as resource ]
           [#if resource.Deployed ]
-            [#local deployedOccurrences += [ occurrence ] ]
-            [#continue]
+              [#local deployed = true]
+              [#continue]
           [/#if]
         [/#list]
+        
+        [#if deployed ]
+          [#local deployedOccurrences += [ occurrence ] ]
+        [/#if]
       [/#list]
 
       [#local cleanedOccurrences = [] ]

--- a/aws/templates/createBlueprint.ftl
+++ b/aws/templates/createBlueprint.ftl
@@ -94,11 +94,30 @@
         [/#list]
       [/#list]
 
+      [#local cleanedOccurrences = []]
+      [#list deployedOccurrences as occurrence ] 
+        [#list occurrence.State.Attributes as key, value ]
+          [#if key?lower_case == "password" || key?lower_case?contains("key") ]
+              [#local cleanAttributes += 
+                {
+                  key : "***"
+                }
+              ]
+            [#else]
+              [#local cleanAttributes += 
+                {
+                  key : value
+                }
+              ]
+          [/#if]
+        [/#list]
+      [/#list]
+
       [#local result +=
         [
           {
             "Id" : id,
-            "Occurrences" : deployedOccurrences
+            "Occurrences" : cleanedOccurrences
         }]]
     [/#if]
   [/#list]


### PR DESCRIPTION
Since the blueprint generation is currently used for documentation purposes, passwords and keys should not be provided. 

Instead the attribute should still be displayed but the contents hashed out using ***. This means that existence of the attribute is known but the content isn't
 