### PR TITLE
Add userpool lookup based on Account

### DIFF
--- a/aws/templates/createBlueprint.ftl
+++ b/aws/templates/createBlueprint.ftl
@@ -106,12 +106,17 @@
       [#local deployedOccurrences = [] ]
 
       [#list getOccurrences(tier, component) as occurrence ]
+        [#local deployed = false]
         [#list occurrence.State.Resources?values as resource ]
           [#if resource.Deployed ]
-            [#local deployedOccurrences += [ occurrence ] ]
-            [#continue]
+              [#local deployed = true]
+              [#continue]
           [/#if]
         [/#list]
+        
+        [#if deployed ]
+          [#local deployedOccurrences += [ occurrence ] ]
+        [/#if]
       [/#list]
 
       [#local cleanedOccurrences = [] ]

--- a/aws/templates/createBlueprint.ftl
+++ b/aws/templates/createBlueprint.ftl
@@ -94,11 +94,30 @@
         [/#list]
       [/#list]
 
+      [#local cleanedOccurrences = []]
+      [#list deployedOccurrences as occurrence ] 
+        [#list occurrence.State.Attributes as key, value ]
+          [#if key?lower_case == "password" || key?lower_case?contains("key") ]
+              [#local cleanAttributes += 
+                {
+                  key : "***"
+                }
+              ]
+            [#else]
+              [#local cleanAttributes += 
+                {
+                  key : value
+                }
+              ]
+          [/#if]
+        [/#list]
+      [/#list]
+
       [#local result +=
         [
           {
             "Id" : id,
-            "Occurrences" : deployedOccurrences
+            "Occurrences" : cleanedOccurrences
         }]]
     [/#if]
   [/#list]

--- a/aws/templates/createSwaggerExtensions.ftl
+++ b/aws/templates/createSwaggerExtensions.ftl
@@ -295,19 +295,23 @@
           "in": "header",
           "x-amazon-apigateway-authtype": "awsSigv4"
         }
-        [#if integrationsObject.userPoolArn?has_content ]
-            ,"${defaultCognitoPoolName}": {
-                "type": "apiKey",
-                "name": "${defaultCognitoAuthHeader}",
-                "in": "header",
-                "x-amazon-apigateway-authtype": "cognito_user_pools",
-                "x-amazon-apigateway-authorizer": {
-                    "type": "cognito_user_pools",
-                    "providerARNs": [
-                            "${integrationsObject.userPoolArn}"
-                    ]
-                }
-            }
+        [#if integrationsObject.userPoolArns?has_content ]
+            [#list integrationsObject.userPoolArns?keys as key]
+                [#if key == account ]
+                    ,"${defaultCognitoPoolName}": {
+                        "type": "apiKey",
+                        "name": "${defaultCognitoAuthHeader}",
+                        "in": "header",
+                        "x-amazon-apigateway-authtype": "cognito_user_pools",
+                        "x-amazon-apigateway-authorizer": {
+                            "type": "cognito_user_pools",
+                            "providerARNs": [
+                                    "${key}"
+                            ]
+                        }
+                    }
+                [/#if]
+            [/#list]
         [/#if]
 
     },

--- a/aws/templates/createSwaggerExtensions.ftl
+++ b/aws/templates/createSwaggerExtensions.ftl
@@ -296,7 +296,7 @@
           "x-amazon-apigateway-authtype": "awsSigv4"
         }
         [#if integrationsObject.userPoolArns?has_content ]
-            [#list integrationsObject.userPoolArns?keys as key]
+            [#list integrationsObject.userPoolArns?keys as key, value]
                 [#if key == account ]
                     ,"${defaultCognitoPoolName}": {
                         "type": "apiKey",
@@ -306,7 +306,7 @@
                         "x-amazon-apigateway-authorizer": {
                             "type": "cognito_user_pools",
                             "providerARNs": [
-                                    "${key}"
+                                    "${value}"
                             ]
                         }
                     }


### PR DESCRIPTION
To support userpool authorisation on api Gateway the ARN needs to be configured as part of the authoriser configuration. 

This needs to be updated for each account so instead of a sinlge value for userPoolARN it is now expected to have userPoolARNs hash which contains a key value pair with the account name as the key and the value as the ARN