### PR TITLE
Save correct value for database name

### DIFF
--- a/aws/templates/resource/resource_rds.ftl
+++ b/aws/templates/resource/resource_rds.ftl
@@ -97,7 +97,7 @@ outputs=
     RDS_OUTPUT_MAPPINGS +
     {
         DATABASENAME_ATTRIBUTE_TYPE : { 
-            "Value" : productName
+            "Value" : databaseName
         }
     } +
     attributeIfContent(


### PR DESCRIPTION
Database was hardcoded to be the product name rather than the passed database name value