### PR TITLE
Generate Encrypted Password on RDS creation

### DIFF
--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -34,6 +34,23 @@
                 "Name" : "Encrypted",
                 "Default" : false
             },
+            {
+                "Name" : "GenerateCredentials",
+                "Children" : [
+                    {
+                        "Name" : "Enabled",
+                        "Default" : false
+                    },
+                    {
+                        "Name" : "MasterUserName",
+                        "Default" : "root"
+                    }
+                    {
+                        "Name" : "CharacterLength",
+                        "Default" : 20
+                    }
+                ]
+            },
             { 
                 "Name" : "Size",
                 "Default" : "20"
@@ -66,23 +83,30 @@
     [#local name = getExistingReference(id, DATABASENAME_ATTRIBUTE_TYPE)]
 
     [#local login = {} ]
-    [#list
-        (
-            credentialsObject[formatComponentShortNameWithType(core.Tier, core.Component)]!
-            credentialsObject[formatComponentShortName(core.Tier, core.Component)]!
-            {
-                "Login" : {
-                    "Username" : "Not provided",
-                    "Password" : "Not provided"
+    [#if occurrence.Configuration.GenerateCredentials.Enabled ]
+        [#local login += {
+            "USERNAME" : occurrence.Configuration.GenerateCredentials.MasterUserName,
+            "PASSWORD" : getExistingReference(id, GENERATEDPASSWORD_ATTRIBUTE_TYPE)
+        }]
+    [#else]
+        [#list
+            (
+                credentialsObject[formatComponentShortNameWithType(core.Tier, core.Component)]!
+                credentialsObject[formatComponentShortName(core.Tier, core.Component)]!
+                {
+                    "Login" : {
+                        "Username" : "Not provided",
+                        "Password" : "Not provided"
+                    }
                 }
-            }
-        ).Login as name,value]
-        [#local login +=
-            { 
-                name?upper_case : value 
-            }
-        ]
-    [/#list]
+            ).Login as name,value]
+            [#local login +=
+                { 
+                    name?upper_case : value 
+                }
+            ]
+        [/#list]
+    [/#if]
 
     [#local result =
         {

--- a/aws/templates/id/start.ftl
+++ b/aws/templates/id/start.ftl
@@ -113,6 +113,7 @@
 [#assign PORT_ATTRIBUTE_TYPE = "port" ]
 [#assign USERNAME_ATTRIBUTE_TYPE = "username" ]
 [#assign PASSWORD_ATTRIBUTE_TYPE = "password" ]
+[#assign GENERATEDPASSWORD_ATTRIBUTE_TYPE = "generatedpassword" ]
 [#assign DATABASENAME_ATTRIBUTE_TYPE = "databasename" ]
 [#assign TOPICNAME_ATTRIBUTE_TYPE = "topicname" ]
 [#assign REPOSITORY_ATTRIBUTE_TYPE = "repository" ]


### PR DESCRIPTION
Adds support for a generated password to be created for an RDS instance. With this configuration the password is always encrypted and stored as a stack output.

When generateCredentials is enabled a dummy password is supplied to cloudformation and on the initial creation of the instance a password is generated, encrypted and set on the RDS instance as an epilogue script.

Since cloudformation resets the password to a dummy password each time on each deploy the password will be retrieved decrypted and reset as part of the deployment process

**This process will create some downtime during the deployment as the password will be set to the dummy password in between the cloudformation deployment and the epilogue script reseting the password back to the generated password**

Credentials are encrypted using the the segment KMS key. 

Configuration ( under rds solution configuration ) 

```
{
   "GenerateCredentials" : {
              "Enabled" : true|false,
              "CharacterLength" : Int (defaults to 20),
              "MasterUserName" : string (defaults to root)
   }
}
```
Username moves into config as the credentials will now be a state based configuration. 

To reset a password the epilogue pseudo stack can be removed. 

Fixes #207