### PR TITLE
Add Default Role state to State Objects

### DIFF
--- a/aws/templates/id/id_contenthub.ftl
+++ b/aws/templates/id/id_contenthub.ftl
@@ -127,6 +127,10 @@
             },
             "Attributes" : {
                 "PATH" : getContentPath(occurrence)
+            },
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
             }
         }
     ]

--- a/aws/templates/id/id_efs.ftl
+++ b/aws/templates/id/id_efs.ftl
@@ -28,7 +28,11 @@
     [#return
         {
             "Resources" : {},
-            "Attributes" : {}
+            "Attributes" : {},
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
         }
     ]
 [/#function]

--- a/aws/templates/id/id_spa.ftl
+++ b/aws/templates/id/id_spa.ftl
@@ -124,6 +124,10 @@
             "Attributes" : {
                 "FQDN" : fqdn,
                 "URL" : "https://" + fqdn
+            },
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
             }
         }
     ]


### PR DESCRIPTION
Some state objects are missing the Role Properties within their state configuration. This adds a default Role object to each of the states. 