### PR TITLE
Add Support for epilogue based Lambda triggers in Cognito User Pools

### DIFF
--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -1,5 +1,5 @@
 [#-- Cognito User Pool --]
-[#if (componentType == USERPOOL_COMPONENT_TYPE) && deploymentSubsetRequired("userpool", true)]
+[#if (componentType == "userpool") ]
     
     [#list requiredOccurrences(
         getOccurrences(tier, component),
@@ -26,7 +26,8 @@
         [#assign smsVerification = false]
         [#assign schema = []]
         [#assign userPoolTriggerConfig = {}]
-
+        [#assign userPoolManualTriggerConfig = {}]
+                
         [@cfDebug listMode appSettingsObject false /]
 
         [#assign emailVerificationMessage =
@@ -67,43 +68,25 @@
             "")]
 
         [#if ((configuration.MFA) || ( configuration.VerifyPhone))]
-            [#if deploymentSubsetRequired("iam", true) &&
-            isPartOfCurrentDeploymentUnit(userPoolId)]
 
-                [@createRole
-                    mode=listMode
-                    id=userPoolRoleId
-                    trustedServices=["cognito-idp.amazonaws.com"]
-                    policies=
-                        [
-                            getPolicyDocument(
-                                snsPublishPermission(),
-                                "smsVerification" 
-                            )
-                        ]
-                /]
-
-                [#assign phoneSchema = getUserPoolSchemaObject( 
-                                            "phone_number",
-                                            "String",
-                                            true,
-                                            true)]
-                [#assign schema = schema + [ phoneSchema ]]
-            )]
-
-            [/#if]
+            [#assign phoneSchema = getUserPoolSchemaObject( 
+                                        "phone_number",
+                                        "String",
+                                        true,
+                                        true)]
+            [#assign schema = schema + [ phoneSchema ]]
 
             [#assign smsConfig = getUserPoolSMSConfiguration( getReference(userPoolRoleId, ARN_ATTRIBUTE_TYPE), userPoolName )]
             [#assign smsVerification = true]
         [/#if]
 
         [#if configuration.VerifyEmail || ( configuration.LoginAliases.seq_contains("email"))]
-                [#assign emailSchema = getUserPoolSchemaObject( 
-                                            "email",
-                                            "String",
-                                            true,
-                                            true)]
-                [#assign schema = schema +  [ emailSchema ]]
+                    [#assign emailSchema = getUserPoolSchemaObject( 
+                                                "email",
+                                                "String",
+                                                true,
+                                                true)]
+                    [#assign schema = schema +  [ emailSchema ]]
         [/#if]
 
         [#list configuration.Links?values as link]
@@ -190,125 +173,189 @@
                                     )
                                 ]
                                 [#break]
+                            [#case "pretokengeneration"]
+                                [#assign userPoolManualTriggerConfig = userPoolManualTriggerConfig +
+                                    attributeIfContent (
+                                        "PreTokenGeneration",
+                                        linkTargetAttributes.ARN
+                                    )
+                                ]
+                                [#break]
+                            [#case "usermigration"]
+                                [#assign userPoolManualTriggerConfig = userPoolManualTriggerConfig +
+                                    attributeIfContent (
+                                        "UserMigration",
+                                        linkTargetAttributes.ARN
+                                    )
+                                ]
+                                [#break]
                         [/#switch]
                     [/#if]
-                    [#break]
+                [#break]
             [/#switch]
         [/#list]
 
-        [@createUserPool 
-            mode=listMode
-            component=component
-            tier=tier
-            id=userPoolId
-            name=userPoolName
-            tags=getCfTemplateCoreTags(
-                    userPoolName,
-                    tier,
-                    component)
-            dependencies=dependencies
-            mfa=configuration.MFA
-            adminCreatesUser=configuration.AdminCreatesUser
-            unusedTimeout=configuration.UnusedAccountTimeout
-            schema=schema
-            emailVerificationMessage=emailVerificationMessage
-            emailVerificationSubject=emailVerificationSubject
-            smsVerificationMessage=smsVerificationMessage
-            emailInviteMessage=emailInviteMessage
-            emailInviteSubject=emailInviteSubject
-            smsInviteMessage=smsInviteMessage
-            lambdaTriggers=userPoolTriggerConfig
-            autoVerify=(configuration.VerifyEmail || smsVerification)?then(
-                getUserPoolAutoVerification(configuration.VerifyEmail, smsVerification),
-                []
-            )
-            loginAliases=((configuration.LoginAliases)?has_content)?then(
-                    [configuration.LoginAliases],
-                    [])
-            passwordPolicy=getUserPoolPasswordPolicy( 
-                    configuration.PasswordPolicy.MinimumLength, 
-                    configuration.PasswordPolicy.Lowercase,
-                    configuration.PasswordPolicy.Uppsercase,
-                    configuration.PasswordPolicy.Numbers,
-                    configuration.PasswordPolicy.SpecialCharacters)
-            smsConfiguration=((smsConfig)?has_content)?then(
-                smsConfig,
-                {})
-        /]
+        [#assign userPoolManualTriggerString = getJSON(userPoolManualTriggerConfig, true)]
 
-        [@createUserPoolClient 
-            mode=listMode
-            component=component
-            tier=tier
-            dependencies=dependencies
-            id=userPoolClientId
-            name=userPoolClientName
-            userPoolId=userPoolId
-            generateSecret=configuration.ClientGenerateSecret
-            tokenValidity=configuration.ClientTokenValidity
-        /]
+        [#if ((configuration.MFA) || ( configuration.VerifyPhone))]
+            [#if (deploymentSubsetRequired("iam", true) || deploymentSubsetRequired("userpool", true)) &&
+                isPartOfCurrentDeploymentUnit(userPoolId)]
 
-        [#assign cognitoIdentityPoolProvider = getIdentityPoolCognitoProvider( userPoolId, userPoolClientId )]
+                    [@createRole
+                        mode=listMode
+                        id=userPoolRoleId
+                        trustedServices=["cognito-idp.amazonaws.com"]
+                        policies=
+                            [
+                                getPolicyDocument(
+                                    snsPublishPermission(),
+                                    "smsVerification" 
+                                )
+                            ]
+                    /]
 
-        [@createIdentityPool 
-            mode=listMode
-            component=component
-            tier=tier
-            dependencies=dependencies
-            id=identityPoolId
-            name=identityPoolName
-            cognitoIdProviders=cognitoIdentityPoolProvider
-            allowUnauthenticatedIdentities=configuration.AllowUnauthenticatedIds
-        /]
 
-        [@createRole
-            mode=listMode
-            id=identityPoolUnAuthRoleId
-            policies=[
-                getPolicyDocument(
-                    getUserPoolUnAuthPolicy(),
-                    "DefaultUnAuthIdentityRole"
+                )]
+
+            [/#if]
+        [/#if]
+
+        [#if deploymentSubsetRequired("userpool", true) ]
+            [@createUserPool 
+                mode=listMode
+                component=component
+                tier=tier
+                id=userPoolId
+                name=userPoolName
+                tags=getCfTemplateCoreTags(
+                        userPoolName,
+                        tier,
+                        component)
+                dependencies=dependencies
+                mfa=configuration.MFA
+                adminCreatesUser=configuration.AdminCreatesUser
+                unusedTimeout=configuration.UnusedAccountTimeout
+                schema=schema
+                emailVerificationMessage=emailVerificationMessage
+                emailVerificationSubject=emailVerificationSubject
+                smsVerificationMessage=smsVerificationMessage
+                emailInviteMessage=emailInviteMessage
+                emailInviteSubject=emailInviteSubject
+                smsInviteMessage=smsInviteMessage
+                lambdaTriggers=userPoolTriggerConfig
+                autoVerify=(configuration.VerifyEmail || smsVerification)?then(
+                    getUserPoolAutoVerification(configuration.VerifyEmail, smsVerification),
+                    []
                 )
-            ]
-            federatedServices="cognito-identity.amazonaws.com"
-            condition={
-                "StringEquals": {
-                    "cognito-identity.amazonaws.com:aud": getReference(identityPoolId)
-                },
-                "ForAnyValue:StringLike": {
-                    "cognito-identity.amazonaws.com:amr": "unauthenticated"
-                }
-            }
-        /]
+                loginAliases=((configuration.LoginAliases)?has_content)?then(
+                        [configuration.LoginAliases],
+                        [])
+                passwordPolicy=getUserPoolPasswordPolicy( 
+                        configuration.PasswordPolicy.MinimumLength, 
+                        configuration.PasswordPolicy.Lowercase,
+                        configuration.PasswordPolicy.Uppsercase,
+                        configuration.PasswordPolicy.Numbers,
+                        configuration.PasswordPolicy.SpecialCharacters)
+                smsConfiguration=((smsConfig)?has_content)?then(
+                    smsConfig,
+                    {})
+            /]
 
-        [@createRole 
-            mode=listMode
-            id=identityPoolAuthRoleId
-            policies=[
-                getPolicyDocument(
-                    getUserPoolAuthPolicy(),
-                    "DefaultAuthIdentityRole"
+            [@createUserPoolClient 
+                mode=listMode
+                component=component
+                tier=tier
+                dependencies=dependencies
+                id=userPoolClientId
+                name=userPoolClientName
+                userPoolId=userPoolId
+                generateSecret=configuration.ClientGenerateSecret
+                tokenValidity=configuration.ClientTokenValidity
+            /]
+
+            [#assign cognitoIdentityPoolProvider = getIdentityPoolCognitoProvider( userPoolId, userPoolClientId )]
+
+            [@createIdentityPool 
+                mode=listMode
+                component=component
+                tier=tier
+                dependencies=dependencies
+                id=identityPoolId
+                name=identityPoolName
+                cognitoIdProviders=cognitoIdentityPoolProvider
+                allowUnauthenticatedIdentities=configuration.AllowUnauthenticatedIds
+            /]
+
+            [@createRole
+                mode=listMode
+                id=identityPoolUnAuthRoleId
+                policies=[
+                    getPolicyDocument(
+                        getUserPoolUnAuthPolicy(),
+                        "DefaultUnAuthIdentityRole"
+                    )
+                ]
+                federatedServices="cognito-identity.amazonaws.com"
+                condition={
+                    "StringEquals": {
+                        "cognito-identity.amazonaws.com:aud": getReference(identityPoolId)
+                    },
+                    "ForAnyValue:StringLike": {
+                        "cognito-identity.amazonaws.com:amr": "unauthenticated"
+                    }
+                }
+            /]
+
+            [@createRole 
+                mode=listMode
+                id=identityPoolAuthRoleId
+                policies=[
+                    getPolicyDocument(
+                        getUserPoolAuthPolicy(),
+                        "DefaultAuthIdentityRole"
+                    )
+                ]
+                federatedServices="cognito-identity.amazonaws.com"
+                condition={
+                    "StringEquals": {
+                        "cognito-identity.amazonaws.com:aud": getReference(identityPoolId)
+                    },
+                    "ForAnyValue:StringLike": {
+                        "cognito-identity.amazonaws.com:amr": "authenticated"
+                    }
+                }
+            /]
+
+            [@createIdentityPoolRoleMapping
+                mode=listMode
+                component=component
+                tier=tier
+                id=identityPoolRoleMappingId
+                identityPoolId=getReference(identityPoolId)
+                authenticatedRoleArn=getReference(identityPoolAuthRoleId, ARN_ATTRIBUTE_TYPE)
+                unauthenticatedRoleArn=getReference(identityPoolUnAuthRoleId, ARN_ATTRIBUTE_TYPE)
+            /]
+        [/#if]
+        
+        [#if deploymentSubsetRequired("epilogue", false)]
+            [@cfScript
+                mode=listMode
+                content=
+                [] +
+                [#-- Some Userpool Lambda triggers are not available via Cloudformation but are available via CLI --]
+                (userPoolManualTriggerConfig?has_content)?then(
+                    [
+                        "# Add Manual Cognito Triggers",
+                        "info \"Adding Cognito Triggers that are not part of cloudformation\""
+                        "add_cognito_lambda_triggers" +
+                        " \"" + region + "\" " + 
+                        " \"" + getExistingReference(userPoolId) + "\" " + 
+                        " \"" + userPoolManualTriggerString + "\" " + 
+                        " || return $?"
+                    ],
+                    []
                 )
-            ]
-            federatedServices="cognito-identity.amazonaws.com"
-            condition={
-                "StringEquals": {
-                    "cognito-identity.amazonaws.com:aud": getReference(identityPoolId)
-                },
-                "ForAnyValue:StringLike": {
-                    "cognito-identity.amazonaws.com:amr": "authenticated"
-                }
-            }
-        /]
-
-        [@createIdentityPoolRoleMapping
-            mode=listMode
-            component=component
-            tier=tier
-            id=identityPoolRoleMappingId
-            identityPoolId=getReference(identityPoolId)
-            authenticatedRoleArn=getReference(identityPoolAuthRoleId, ARN_ATTRIBUTE_TYPE)
-            unauthenticatedRoleArn=getReference(identityPoolUnAuthRoleId, ARN_ATTRIBUTE_TYPE)
-        /]
+            /]
+        [/#if]
     [/#list]
 [/#if]

--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -11,16 +11,16 @@
         [#assign configuration = occurrence.Configuration]
         [#assign resources = occurrence.State.Resources]
 
-        [#assign userPoolId = resources["userpool"].Id]
-        [#assign userPoolName = resources["userpool"].Name]
-        [#assign userPoolClientId = resources["client"].Id]
-        [#assign userPoolClientName = resources["client"].Name]
-        [#assign userPoolRoleId = resources["userpoolrole"].Id]
-        [#assign identityPoolId = resources["identitypool"].Id]
-        [#assign identityPoolName = resources["identitypool"].Name]
-        [#assign identityPoolUnAuthRoleId = resources["unauthrole"].Id]
-        [#assign identityPoolAuthRoleId = resources["authrole"].Id]
-        [#assign identityPoolRoleMappingId = resources["rolemapping"].Id]
+        [#assign userPoolId                 = resources["userpool"].Id]
+        [#assign userPoolName               = resources["userpool"].Name]
+        [#assign userPoolClientId           = resources["client"].Id]
+        [#assign userPoolClientName         = resources["client"].Name]
+        [#assign userPoolRoleId             = resources["userpoolrole"].Id]
+        [#assign identityPoolId             = resources["identitypool"].Id]
+        [#assign identityPoolName           = resources["identitypool"].Name]
+        [#assign identityPoolUnAuthRoleId   = resources["unauthrole"].Id]
+        [#assign identityPoolAuthRoleId     = resources["authrole"].Id]
+        [#assign identityPoolRoleMappingId  = resources["rolemapping"].Id]
 
         [#assign dependencies = []]
         [#assign smsVerification = false]
@@ -110,7 +110,7 @@
                         [#-- Cognito Userpool Event Triggers --]
                         [#switch link.Name?lower_case]
                             [#case "createauthchallenge"]
-                                [#assign userPoolTriggerConfig =  userPoolTriggerConfig +
+                                [#assign userPoolTriggerConfig +=
                                     attributeIfContent (
                                         "CreateAuthChallenge",
                                         linkTargetAttributes.ARN
@@ -118,7 +118,7 @@
                                 ]
                                 [#break]
                             [#case "custommessage"]
-                                [#assign userPoolTriggerConfig = userPoolTriggerConfig +
+                                [#assign userPoolTriggerConfig +=
                                     attributeIfContent (
                                         "CustomMessage",
                                         linkTargetAttributes.ARN
@@ -126,7 +126,7 @@
                                 ]
                                 [#break]
                             [#case "defineauthchallenge"]
-                                [#assign userPoolTriggerConfig = userPoolTriggerConfig +
+                                [#assign userPoolTriggerConfig +=
                                     attributeIfContent (
                                         "DefineAuthChallenge",
                                         linkTargetAttributes.ARN
@@ -134,7 +134,7 @@
                                 ]
                                 [#break]
                             [#case "postauthentication"]
-                                [#assign userPoolTriggerConfig = userPoolTriggerConfig +
+                                [#assign userPoolTriggerConfig +=
                                     attributeIfContent (
                                         "PostAuthentication",
                                         linkTargetAttributes.ARN
@@ -142,7 +142,7 @@
                                 ]
                                 [#break]
                             [#case "postconfirmation"]
-                                [#assign userPoolTriggerConfig = userPoolTriggerConfig +
+                                [#assign userPoolTriggerConfig +=
                                     attributeIfContent (
                                         "PostConfirmation",
                                         linkTargetAttributes.ARN
@@ -150,7 +150,7 @@
                                 ]
                                 [#break]
                             [#case "preauthentication"]
-                                [#assign userPoolTriggerConfig =  userPoolTriggerConfig +
+                                [#assign userPoolTriggerConfig +=
                                     attributeIfContent (
                                         "PreAuthentication",
                                         linkTargetAttributes.ARN
@@ -158,7 +158,7 @@
                                 ]
                                 [#break]
                             [#case "presignup"]
-                                [#assign userPoolTriggerConfig = userPoolTriggerConfig + 
+                                [#assign userPoolTriggerConfig += 
                                     attributeIfContent (
                                         "PreSignUp",
                                         linkTargetAttributes.ARN
@@ -166,7 +166,7 @@
                                 ]
                                 [#break]
                             [#case "verifyauthchallengeresponse"]
-                                [#assign userPoolTriggerConfig = userPoolTriggerConfig + 
+                                [#assign userPoolTriggerConfig += 
                                     attributeIfContent (
                                         "VerifyAuthChallengeResponse",
                                         linkTargetAttributes.ARN
@@ -174,7 +174,7 @@
                                 ]
                                 [#break]
                             [#case "pretokengeneration"]
-                                [#assign userPoolManualTriggerConfig = userPoolManualTriggerConfig +
+                                [#assign userPoolManualTriggerConfig +=
                                     attributeIfContent (
                                         "PreTokenGeneration",
                                         linkTargetAttributes.ARN
@@ -182,7 +182,7 @@
                                 ]
                                 [#break]
                             [#case "usermigration"]
-                                [#assign userPoolManualTriggerConfig = userPoolManualTriggerConfig +
+                                [#assign userPoolManualTriggerConfig +=
                                     attributeIfContent (
                                         "UserMigration",
                                         linkTargetAttributes.ARN

--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -1,5 +1,5 @@
 [#-- Cognito User Pool --]
-[#if (componentType == "userpool") ]
+[#if componentType == USERPOOL_COMPONENT_TYPE ]
     
     [#list requiredOccurrences(
         getOccurrences(tier, component),
@@ -341,7 +341,6 @@
             [@cfScript
                 mode=listMode
                 content=
-                [] +
                 [#-- Some Userpool Lambda triggers are not available via Cloudformation but are available via CLI --]
                 (userPoolManualTriggerConfig?has_content)?then(
                     [

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -572,6 +572,15 @@ function encrypt_kms_string() {
   aws kms encrypt --key-id "${kms_key_id}" --plaintext "${value}" --query CiphertextBlob --output text || return $?
 }
 
+# -- Cognito -- 
+
+function add_cognito_lambda_triggers() { 
+  local region="$1"; shift 
+  local userpoolid="$1"; shift
+  local lambdaconfig"$1"; shift 
+
+  aws --region ${region} cognito-idp update-user-pool --user-pool-id "${userpoolid}" --lambda-config "${lambdaconfig}" || return $? 
+}
 
 # -- S3 --
 


### PR DESCRIPTION
Cognito user pools have the ability to trigger a lambda function based on a specific event that has occurred. The majority of the events are available through cloudformation except for some that have been added recently (Jan 2018).

This adds support for the cognito events which are available via the cli instead of cloudformation. 

The lambda event mappings are added to two seperate arrays: 
- userPoolTriggerConfig - is the array for cloudformation 
- userPoolManualTriggerConfig - is the array for cli based updates 
