### PR TITLE
Update Cognito Epilogue to support AWS shorthand format

### DIFF
--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -195,7 +195,12 @@
             [/#switch]
         [/#list]
 
-        [#assign userPoolManualTriggerString = getJSON(userPoolManualTriggerConfig, true)]
+        [#assign userPoolManualTriggerString = [] ] 
+        [#list userPoolManualTriggerConfig as key,value ]
+            [#assign userPoolManualTriggerString += [ key + "=" + value ]]
+        [/#list]
+
+        [#assign userPoolManualTriggerString = userPoolManualTriggerString?join(",")]
 
         [#if ((configuration.MFA) || ( configuration.VerifyPhone))]
             [#if (deploymentSubsetRequired("iam", true) || deploymentSubsetRequired("userpool", true)) &&


### PR DESCRIPTION
Instead of passing the JSON values for the lambda config mapping the AWS shorthand format is an easier way to pass the configuration. 