### PR TITLE
Add custom domain for api gateway signing

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1277,8 +1277,9 @@
     ]
 [/#function]
 
-[#function getHostName certificateObject tier="" component="" occurrence={}]
+[#function getHostName certificateObject occurrence]
 
+    [#local core = occurrence.Core ]
     [#local includes = certificateObject.IncludeInHost ]
 
     [#return
@@ -1287,10 +1288,10 @@
             certificateObject.Host?has_content && (!(includes.Host)),
             formatName(
                 valueIfTrue(certificateObject.Host, includes.Host),
-                valueIfTrue(getTierName(tier), includes.Tier),
-                valueIfTrue(getComponentName(component), includes.Component),
-                valueIfTrue(occurrence.Core.Instance.Name!"", includes.Instance),
-                valueIfTrue(occurrence.Core.Version.Name!"", includes.Version),
+                valueIfTrue(getTierName(core.Tier), includes.Tier),
+                valueIfTrue(getComponentName(core.Component), includes.Component),
+                valueIfTrue(core.Instance.Name!"", includes.Instance),
+                valueIfTrue(core.Version.Name!"", includes.Version),
                 valueIfTrue(segmentName!"", includes.Segment),
                 valueIfTrue(environmentName!"", includes.Environment),
                 valueIfTrue(productName!"", includes.Product)

--- a/aws/templates/id/id_alb.ftl
+++ b/aws/templates/id/id_alb.ftl
@@ -90,7 +90,7 @@
             )]
         [#if (ports[portMappings[mappingObject.Mapping].Source].Certificate)!false ]
             [#local certificateObject = getCertificateObject(configuration.Certificate!"", segmentId, segmentName) ]
-            [#local hostName = getHostName(certificateObject, core.Tier, core.Component, occurrence) ]
+            [#local hostName = getHostName(certificateObject, occurrence) ]
             
             [#local fqdn = formatDomainName(hostName, certificateObject.Domain.Name)]
             [#local scheme = "https" ]

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -105,8 +105,26 @@
                 ]
             },
             {
-                "Name" : "IncludePathInUrls",
-                "Default" : true
+                "Name" : "Mapping",
+                "Children" : [
+                    {
+                        "Name"  : "Enabled",
+                        "Default" : true
+                    },
+                    {
+                        "Name" : "IncludeStage",
+                        "Default" : true
+                    }
+                ]
+            },
+            {
+                "Name" : "Service",
+                "Children" : [
+                    {
+                        "Name" : "Name",
+                        "Default" : "execute-api"
+                    }
+                ]
             }
         ]
     }]
@@ -116,50 +134,64 @@
     [#local configuration = occurrence.Configuration]
 
     [#local apiId = formatResourceId("api", core.Id)]
-    
+
     [#-- Resource Id doesn't follow the resource type for backwards compatability --]
     [#if getExistingReference(formatResourceId("api", core.Id))?has_content ]
         [#local apiId = formatResourceId("api", core.Id)]
     [#else ]
         [#local apiId = formatResourceId(AWS_APIGATEWAY_RESOURCE_TYPE, core.Id)]
     [/#if]
-    
     [#local apiName = formatComponentFullName(core.Tier, core.Component, occurrence)]
-    [#local stageId = formatResourceId(AWS_APIGATEWAY_STAGE_RESOURCE_TYPE, core.Id)]
 
-    [#local docsId = formatS3Id(core.Id, APIGATEWAY_COMPONENT_DOCS_EXTENSION)]
+    [#local stageId = formatResourceId(APIGATEWAY_STAGE_RESOURCE_TYPE, core.Id)]
+    [#local stageName = core.Version.Name]
+
+    [#local docsId = formatS3Id(core.Id, APIGATEWAY_DOCS_EXTENSION)]
+
     [#local cfId = formatDependentCFDistributionId(apiId)]
 
     [#local internalFqdn =
         formatDomainName(
             getExistingReference(apiId),
-            "execute-api",
+            configuration.Service.Name,
             regionId,
             "amazonaws.com") ]
 
+    [#local fqdn = internalFqdn]
+    [#local signingFqdn = internalFqdn]
+    [#local mappingStage = ""]
+    [#local versionPath = "/" + stageName]
+    [#local certificateId = "" ]
+    [#local docsName =
+            formatName(
+                configuration.Publish.DnsNamePrefix,
+                formatOccurrenceBucketName(occurrence))]
+
     [#if configuration.Certificate.Configured && configuration.Certificate.Enabled ]
-            [#local certificateObject = getCertificateObject(configuration.Certificate!"", segmentId, segmentName)]
-            [#local hostName = getHostName(certificateObject, core.Tier, core.Component, occurrence)]
+        [#local certificateObject = getCertificateObject(configuration.Certificate!"", segmentId, segmentName)]
+        [#local hostName = getHostName(certificateObject, occurrence)]
+        [#local certificateId = formatDomainCertificateId(certificateObject, hostName) ]
+
+        [#if configuration.Mapping.Configured && configuration.Mapping.Enabled ]
             [#local fqdn = formatDomainName(hostName, certificateObject.Domain.Name)]
-            [#local signingFqdn = formatDomainName(formatName("sig4", hostName), certificateObject.Domain.Name)] 
-    [#else]
-            [#local fqdn = internalFqdn]
-            [#local signingFqdn = internalFqdn]
+            [#local docsName = formatDomainName(configuration.Publish.DnsNamePrefix, fqdn) ]
+            [#local signingFqdn = fqdn]
+            [#if configuration.Mapping.IncludeStage]
+                [#local mappingStage = stageName ]
+                [#local versionPath = "" ]
+            [/#if]
+
+            [#if configuration.CloudFront.Configured && configuration.CloudFront.Enabled]
+                [#local signingFqdn = formatDomainName(formatName("sig4", hostName), certificateObject.Domain.Name)]
+            [/#if]
+        [#else]
+            [#if configuration.CloudFront.Configured && configuration.CloudFront.Enabled]
+                [#local fqdn = formatDomainName(hostName, certificateObject.Domain.Name)]
+                [#local docsName = formatDomainName(configuration.Publish.DnsNamePrefix, fqdn) ]
+            [/#if]
+        [/#if]
     [/#if]
 
-    [#-- Paths are tricky as sometimes the API gateway "consumes" version path. --]
-    [#-- So the caller needs to provide it but the implementer doesn't see it.  --]
-    [#local versionPath =
-        valueIfTrue(
-            "/" + core.Version.Id,
-            configuration.IncludePathInUrls,
-            ""
-        ) ]
-
-    [#-- For now assume the path is seen by the implementation --]
-    [#-- A later change will refine this once behaviour of the --]
-    [#-- API Gateway is confirmed                              --]
-    [#local internalPath = core.Version.Id ]
     [#return
         {
             "Resources" : {
@@ -174,15 +206,18 @@
                 },
                 "apistage" : {
                     "Id" : stageId,
-                    "Name" : core.Version.Name,
+                    "Name" : stageName,
                     "Type" : AWS_APIGATEWAY_STAGE_RESOURCE_TYPE
                 },
                 "apidomain" : {
-                    "Id" : formatDependentResourceId(AWS_APIGATEWAY_DOMAIN_RESOURCE_TYPE, apiId),
+                    "Id" : formatDependentResourceId(APIGATEWAY_DOMAIN_RESOURCE_TYPE, apiId),
+                    "Fqdn" : signingFqdn,
+                    "CertificateId" : certificateId,
                     "Type" : AWS_APIGATEWAY_DOMAIN_RESOURCE_TYPE
                 },
-                "apibasepathmapping" : { 
-                    "Id" : formatDependentResourceId(AWS_APIGATEWAY_BASEPATHMAPPING_RESOURCE_TYPE, stageId),
+                "apibasepathmapping" : {
+                    "Id" : formatDependentResourceId(APIGATEWAY_BASEPATHMAPPING_RESOURCE_TYPE, stageId),
+                    "Stage" : mappingStage,
                     "Type" : AWS_APIGATEWAY_BASEPATHMAPPING_RESOURCE_TYPE
                 },
                 "apiusageplan" : {
@@ -203,19 +238,23 @@
                 "cf" : {
                     "Id" : cfId,
                     "Name" : formatComponentCFDistributionName(core.Tier, core.Component, occurrence),
+                    "CertificateId" : certificateId,
+                    "Fqdn" : fqdn,
                     "Type" : AWS_CLOUDFRONT_DISTRIBUTION_RESOURCE_TYPE
                 },
                 "cforigin" : {
                     "Id" : "apigateway",
+                    "Fqdn" : signingFqdn,
                     "Type" : AWS_CLOUDFRONT_ORIGIN_RESOURCE_TYPE
                 },
-                "wafacl" : { 
+                "wafacl" : {
                     "Id" : formatDependentWAFAclId(apiId),
                     "Name" : formatComponentWAFAclName(core.Tier, core.Component, occurrence),
                     "Type" : AWS_WAF_ACL_RESOURCE_TYPE
                 },
                 "docs" : {
                     "Id" : docsId,
+                    "Name" : docsName,
                     "Type" : AWS_S3_RESOURCE_TYPE
                 },
                 "docspolicy" : {
@@ -226,22 +265,22 @@
             "Attributes" : {
                 "FQDN" : fqdn,
                 "URL" : "https://" + fqdn + versionPath,
+                "SIGNING_SERVICE_NAME" : configuration.Service.Name,
                 "SIGNING_FQDN" : signingFqdn,
-                "SIGNING_URL" : "https://" + signingFqdn + versionPath,
                 "INTERNAL_FQDN" : internalFqdn,
                 "INTERNAL_URL" : "https://" + internalFqdn + versionPath,
-                "INTERNAL_PATH" : internalPath,
+                "INTERNAL_PATH" : versionPath,
                 "DOCS_URL" : "http://" + getExistingReference(docsId, NAME_ATTRIBUTE_TYPE)
             },
             "Roles" : {
                 "Outbound" : {
                     "default" : "invoke",
-                    "invoke" : apigatewayInvokePermission(apiId, core.Version.Name)
+                    "invoke" : apigatewayInvokePermission(apiId, stageName)
                 },
                 "Inbound" : {
                     "invoke" : {
                         "Principal" : "apigateway.amazonaws.com",
-                        "SourceArn" : formatInvokeApiGatewayArn(apiId, core.Version.Name)
+                        "SourceArn" : formatInvokeApiGatewayArn(apiId, stageName)
                     }
                 }
             }

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -116,15 +116,6 @@
                         "Default" : true
                     }
                 ]
-            },
-            {
-                "Name" : "Service",
-                "Children" : [
-                    {
-                        "Name" : "Name",
-                        "Default" : "execute-api"
-                    }
-                ]
             }
         ]
     }]
@@ -150,10 +141,12 @@
 
     [#local cfId = formatDependentCFDistributionId(apiId)]
 
+    [#local serviceName = "execute-api" ]
+
     [#local internalFqdn =
         formatDomainName(
             getExistingReference(apiId),
-            configuration.Service.Name,
+            serviceName,
             regionId,
             "amazonaws.com") ]
 
@@ -265,7 +258,7 @@
             "Attributes" : {
                 "FQDN" : fqdn,
                 "URL" : "https://" + fqdn + versionPath,
-                "SIGNING_SERVICE_NAME" : configuration.Service.Name,
+                "SIGNING_SERVICE_NAME" : serviceName,
                 "SIGNING_FQDN" : signingFqdn,
                 "INTERNAL_FQDN" : internalFqdn,
                 "INTERNAL_URL" : "https://" + internalFqdn + versionPath,

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -143,10 +143,10 @@
     [/#if]
     [#local apiName = formatComponentFullName(core.Tier, core.Component, occurrence)]
 
-    [#local stageId = formatResourceId(APIGATEWAY_STAGE_RESOURCE_TYPE, core.Id)]
+    [#local stageId = formatResourceId(AWS_APIGATEWAY_STAGE_RESOURCE_TYPE, core.Id)]
     [#local stageName = core.Version.Name]
 
-    [#local docsId = formatS3Id(core.Id, APIGATEWAY_DOCS_EXTENSION)]
+    [#local docsId = formatS3Id(core.Id, APIGATEWAY_COMPONENT_DOCS_EXTENSION)]
 
     [#local cfId = formatDependentCFDistributionId(apiId)]
 
@@ -210,13 +210,13 @@
                     "Type" : AWS_APIGATEWAY_STAGE_RESOURCE_TYPE
                 },
                 "apidomain" : {
-                    "Id" : formatDependentResourceId(APIGATEWAY_DOMAIN_RESOURCE_TYPE, apiId),
+                    "Id" : formatDependentResourceId(AWS_APIGATEWAY_DOMAIN_RESOURCE_TYPE, apiId),
                     "Fqdn" : signingFqdn,
                     "CertificateId" : certificateId,
                     "Type" : AWS_APIGATEWAY_DOMAIN_RESOURCE_TYPE
                 },
                 "apibasepathmapping" : {
-                    "Id" : formatDependentResourceId(APIGATEWAY_BASEPATHMAPPING_RESOURCE_TYPE, stageId),
+                    "Id" : formatDependentResourceId(AWS_APIGATEWAY_BASEPATHMAPPING_RESOURCE_TYPE, stageId),
                     "Stage" : mappingStage,
                     "Type" : AWS_APIGATEWAY_BASEPATHMAPPING_RESOURCE_TYPE
                 },

--- a/aws/templates/id/id_spa.ftl
+++ b/aws/templates/id/id_spa.ftl
@@ -99,7 +99,7 @@
 
     [#if configuration.Certificate.Configured && configuration.Certificate.Enabled ]
             [#local certificateObject = getCertificateObject(configuration.Certificate!"", segmentId, segmentName) ]
-            [#local hostName = getHostName(certificateObject, core.Tier, core.Component, occurrence) ]
+            [#local hostName = getHostName(certificateObject, occurrence) ]
             [#local fqdn = formatDomainName(hostName, certificateObject.Domain.Name)]
     [#else]
             [#local fqdn = getExistingReference(cfId,DNS_ATTRIBUTE_TYPE)]

--- a/aws/templates/resource/resource_cf.ftl
+++ b/aws/templates/resource/resource_cf.ftl
@@ -5,7 +5,7 @@
         REFERENCE_ATTRIBUTE_TYPE : {
             "UseRef" : true
         },
-        DNS_ATTRIBUTE_TYPE : { 
+        DNS_ATTRIBUTE_TYPE : {
             "Attribute" : "DomainName"
         }
     }
@@ -17,7 +17,7 @@
         REFERENCE_ATTRIBUTE_TYPE : {
             "UseRef" : true
         },
-        CANONICAL_ID_ATTRIBUTE_TYPE : { 
+        CANONICAL_ID_ATTRIBUTE_TYPE : {
             "Attribute" : "S3CanonicalUserId"
         }
     }
@@ -39,7 +39,7 @@
                 "S3OriginConfig" : {
                     "OriginAccessIdentity" : "origin-access-identity/cloudfront/" + accessId
                 }
-            } + 
+            } +
             attributeIfContent("OriginPath", path)
         ]
     ]
@@ -68,29 +68,10 @@
                 "DomainName" : domain,
                 "Id" : id,
                 "CustomOriginConfig" : httpConfig
-            } + 
+            } +
             attributeIfContent("OriginCustomHeaders", asArray(headers)) +
             attributeIfContent("OriginPath", path)
         ]
-    ]
-[/#function]
-
-[#function getCFAPIGatewayOrigin id apiId headers=[] path=""]
-    [#return
-        getCFHTTPOrigin(
-            id,
-            {
-                "Fn::Join" : [
-                    ".",
-                    [
-                        getReference(apiId),
-                        "execute-api." + regionId + ".amazonaws.com"
-                    ]
-                ]
-            },
-            headers,
-            path
-        )
     ]
 [/#function]
 
@@ -114,14 +95,14 @@
                 "ForwardedValues" :
                     {
                         "QueryString" : forwarded.QueryString
-                    } + 
+                    } +
                     attributeIfContent("Cookies", forwarded.Cookies!"") +
                     attributeIfContent("Headers", forwarded.Headers!"") +
                     attributeIfContent("QueryStringCacheKeys", forwarded.QueryStringCacheKeys!""),
                 "SmoothStreaming" : smoothStreaming,
                 "TargetOriginId" : asString(origin, "Id"),
                 "ViewerProtocolPolicy" : viewerProtocolPolicy
-            } + 
+            } +
             attributeIfContent("PathPattern", path) +
             attributeIfContent("AllowedMethods", methods.Allowed![], asArray(methods.Allowed![])) +
             attributeIfContent("CachedMethods", methods.Cached![], asArray(methods.Cached![])) +
@@ -220,7 +201,7 @@
     [#return
         {
             "AcmCertificateArn" :
-                acmCertificateArn?has_content?then( 
+                acmCertificateArn?has_content?then(
                     acmCertificateArn,
                     formatRegionalArn(
                         "acm",
@@ -286,7 +267,7 @@
     restrictions={}
     wafAclId=""
 ]
-    [@cfResource 
+    [@cfResource
         mode=mode
         id=id
         type="AWS::CloudFront::Distribution"

--- a/aws/templates/solution/solution_alb.ftl
+++ b/aws/templates/solution/solution_alb.ftl
@@ -92,7 +92,7 @@
                                 occurrence)]
                                 
                 [#assign certificateObject = getCertificateObject(mappingObject.Certificate, segmentId, segmentName, sourcePort.Id, sourcePort.Name) ]
-                [#assign hostName = getHostName(certificateObject, tier, component, occurrence) ]
+                [#assign hostName = getHostName(certificateObject, occurrence) ]
                 [#assign certificateId = formatDomainCertificateId(certificateObject, hostName) ]
 
                 [@createALBListener

--- a/aws/templates/solution/solution_spa.ftl
+++ b/aws/templates/solution/solution_spa.ftl
@@ -13,7 +13,7 @@
         [#assign resources = occurrence.State.Resources]
 
         [#assign certificateObject = getCertificateObject(configuration.Certificate, segmentId, segmentName) ]
-        [#assign hostName = getHostName(certificateObject, tier, component, occurrence) ]
+        [#assign hostName = getHostName(certificateObject, occurrence) ]
         [#assign dns = formatDomainName(hostName, certificateObject.Domain.Name) ]
         [#assign certificateId = formatDomainCertificateId(certificateObject, hostName) ]
   


### PR DESCRIPTION
Support addition of a base path mapping when using cloudfront in front
of the api gateway so the fqdn used in the signature doesn't vary when
the api gateway is recreated.

Also remove the need for tier/component when generating a host name, as
these are already present in the occurrence structure.