### PR TITLE
ALB listeners are now subcomponents of the ALB

### DIFF
--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -172,11 +172,11 @@
             {
                 "Name" : "UseTaskRole",
                 "Default" : true
-            } 
+            }
         ]
     }
 ]
-    
+
 [#function getECSState occurrence]
     [#local core = occurrence.Core ]
     [#return

--- a/aws/templates/id/id_elb.ftl
+++ b/aws/templates/id/id_elb.ftl
@@ -3,15 +3,6 @@
 [#-- Resources --]
 [#assign AWS_ELB_RESOURCE_TYPE = "elb" ]
 
-[#function formatELBId tier component extensions...]
-    [#return formatComponentResourceId(
-                AWS_ELB_RESOURCE_TYPE,
-                tier,
-                component,
-                extensions)]
-[/#function]
-
-
 [#-- Components --]
 [#assign ELB_COMPONENT_TYPE = "elb"]
 
@@ -61,18 +52,18 @@
 [#function getELBState occurrence]
     [#local core = occurrence.Core]
 
-    [#local id = formatELBId(core.Tier, core.Component)]
+    [#local id = formatResourceId(AWS_ELB_RESOURCE_TYPE, core.Id)]
 
     [#return
         {
             "Resources" : {
-                "elb" : { 
+                "lb" : {
                     "Id" : id,
-                    "Name" : formatComponentFullName(core.Tier, core.Component),
-                    "ShortName" : formatComponentShortFullName(core.Tier, core.Component),
+                    "Name" : core.FullName,
+                    "ShortName" : core.ShortFullName,
                     "Type" : AWS_ELB_RESOURCE_TYPE
                 },
-                "secGroup" : { 
+                "sg" : {
                     "Id" : formatSecurityGroupId(core.Id),
                     "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
                 }

--- a/aws/templates/resource/resource_alb.ftl
+++ b/aws/templates/resource/resource_alb.ftl
@@ -5,10 +5,10 @@
         REFERENCE_ATTRIBUTE_TYPE : {
             "UseRef" : true
         },
-        ARN_ATTRIBUTE_TYPE : { 
+        ARN_ATTRIBUTE_TYPE : {
             "UseRef" : true
         },
-        DNS_ATTRIBUTE_TYPE : { 
+        DNS_ATTRIBUTE_TYPE : {
             "Attribute" : "DNSName"
         }
     }
@@ -19,7 +19,7 @@
         REFERENCE_ATTRIBUTE_TYPE : {
             "UseRef" : true
         },
-        ARN_ATTRIBUTE_TYPE : { 
+        ARN_ATTRIBUTE_TYPE : {
             "UseRef" : true
         }
     }
@@ -30,7 +30,7 @@
         REFERENCE_ATTRIBUTE_TYPE : {
             "UseRef" : true
         },
-        ARN_ATTRIBUTE_TYPE : { 
+        ARN_ATTRIBUTE_TYPE : {
             "UseRef" : true
         }
     }
@@ -41,10 +41,10 @@
         REFERENCE_ATTRIBUTE_TYPE : {
             "UseRef" : true
         },
-        ARN_ATTRIBUTE_TYPE : { 
+        ARN_ATTRIBUTE_TYPE : {
             "UseRef" : true
         },
-        NAME_ATTRIBUTE_TYPE : { 
+        NAME_ATTRIBUTE_TYPE : {
             "Attribute" : "TargetGroupFullName"
         }
     }
@@ -87,7 +87,7 @@
                         "Key" : "access_logs.s3.prefix",
                         "Value" : ""
                     }
-                ]) 
+                ])
         tags=getCfTemplateCoreTags(name, tier, component)
         outputs=ALB_OUTPUT_MAPPINGS
     /]
@@ -103,7 +103,7 @@
             {
                 "DefaultActions" : [
                     {
-                      "TargetGroupArn" : getReference(albTargetGroupId),
+                      "TargetGroupArn" : getReference(defaultTargetGroupId),
                       "Type" : "forward"
                     }
                 ],
@@ -125,7 +125,7 @@
     /]
 [/#macro]
 
-[#macro createTargetGroup mode id name tier component source destination extensions=""]
+[#macro createTargetGroup mode id name tier component destination]
     [@cfResource
         mode=mode
         id=id
@@ -154,16 +154,7 @@
                     "Matcher" : { "HttpCode" : (destination.HealthCheck.SuccessCodes)!"" }
                 },
                 (destination.HealthCheck.SuccessCodes)!"")
-        tags=
-            getCfTemplateCoreTags(
-                formatComponentFullName(
-                    tier, 
-                    component,
-                    extensions,
-                    source.Port, 
-                    name),
-                tier,
-                component)
+        tags= getCfTemplateCoreTags(name, tier, component)
         outputs=ALB_TARGET_GROUP_OUTPUT_MAPPINGS
     /]
 [/#macro]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -23,6 +23,9 @@
         {
             "Name" : ["Task", "Subcomponent"]
         },
+        {
+            "Name" : ["Port", "Subcomponent"]
+        },
         "Instance",
         "Version"
     ]

--- a/aws/templates/solution/solution_elb.ftl
+++ b/aws/templates/solution/solution_elb.ftl
@@ -12,10 +12,10 @@
         [#assign configuration = occurrence.Configuration]
         [#assign resources = occurrence.State.Resources]
 
-        [#assign elbId              = resources["elb"].Id]
-        [#assign elbFullName        = resources["elb"].Name]
-        [#assign elbShortFullName   = resources["elb"].ShortName]
-        [#assign securityGroupId    = resources["secGroup"].Id]
+        [#assign elbId              = resources["lb"].Id]
+        [#assign elbFullName        = resources["lb"].Name]
+        [#assign elbShortFullName   = resources["lb"].ShortName]
+        [#assign securityGroupId    = resources["sg"].Id]
         
         [#assign healthCheckDestination = ports[portMappings[configuration.PortMappings[0]].Destination] ]
         


### PR DESCRIPTION
This allows each listener to carry its own certificate info and be
linked to via ECS containers.

It required the migration of the solution structure representing the
ports so a per-occurrence generation migration step has been added for
cases where older format solutions need to be migrated to support
backwards compatability. This only changes the internal structure used -
the assumption is the actual solution file can be edited separately to
align with the current spec.