### PR TITLE
Use dependent ids for sg

### DIFF
--- a/aws/templates/id/id_alb.ftl
+++ b/aws/templates/id/id_alb.ftl
@@ -160,6 +160,9 @@
 
     [#local sourcePort = (ports[portMappings[configuration.Mapping].Source])!{} ]
 
+    [#local id = formatResourceId(AWS_ALB_LISTENER_RESOURCE_TYPE, core.Id) ]
+
+
     [#if (sourcePort.Certificate)!false ]
         [#local certificateObject = getCertificateObject(configuration.Certificate, segmentId, segmentName) ]
         [#local hostName = getHostName(certificateObject, occurrence) ]
@@ -174,11 +177,11 @@
         {
             "Resources" : {
                 "listener" : {
-                    "Id" : formatResourceId(AWS_ALB_LISTENER_RESOURCE_TYPE, core.Id),
+                    "Id" : id,
                     "Type" : AWS_ALB_LISTENER_RESOURCE_TYPE
                 },
                 "sg" : {
-                    "Id" : formatSecurityGroupId(core.Id),
+                    "Id" : formatDependentSecurityGroupId(id),
                     "Name" : core.FullName,
                     "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
                 },

--- a/aws/templates/id/id_cache.ftl
+++ b/aws/templates/id/id_cache.ftl
@@ -50,8 +50,8 @@
                     "Id" : formatResourceId(AWS_CACHE_PARAMETER_GROUP_RESOURCE_TYPE, core.Id),
                     "Type" : AWS_CACHE_PARAMETER_GROUP_RESOURCE_TYPE
                 },
-                "secGroup" : {
-                    "Id" : formatSecurityGroupId(core.Id),
+                "sg" : {
+                    "Id" : formatDependentSecurityGroupId(id),
                     "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
                 }
             },

--- a/aws/templates/id/id_ec2.ftl
+++ b/aws/templates/id/id_ec2.ftl
@@ -95,13 +95,14 @@
 [#function getEC2State occurrence]
     [#local core = occurrence.Core]
 
+    [#local id = formatEC2InstanceId(core.Tier, core.Component) ]
     [#local ec2ELBId = formatELBId("elb", core.Id) ]
 
     [#return
         {
             "Resources" : {
-                "ec2Instance" : { 
-                    "Id" : formatEC2InstanceId(core.Tier, core.Component),
+                "ec2Instance" : {
+                    "Id" : id,
                     "Name" : formatName(tenantId, formatComponentFullName(core.Tier, core.Component)),
                     "Type" : AWS_EC2_INSTANCE_RESOURCE_TYPE
                 },
@@ -109,11 +110,11 @@
                     "Id" : formatEC2InstanceProfileId(core.Tier, core.Component),
                     "Type" : AWS_EC2_INSTANCE_PROFILE_RESOURCE_TYPE
                 },
-                "secGroup" : { 
-                    "Id" : formatSecurityGroupId(core.Id),
+                "sg" : {
+                    "Id" : formatDependentSecurityGroupId(id),
                     "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
                 },
-                "ec2Role" : { 
+                "ec2Role" : {
                     "Id" : formatComponentRoleId(core.Tier, core.Component),
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
                 },

--- a/aws/templates/id/id_efs.ftl
+++ b/aws/templates/id/id_efs.ftl
@@ -28,29 +28,29 @@
         EFS_COMPONENT_TYPE  : {
 
         }
-        
+
     }]
-    
+
 [#function getEFSState occurrence]
 
     [#local core = occurrence.Core]
 
-    [#local efsId = formatEFSId( core.Tier, core.Component, occurrence) ]
+    [#local id = formatEFSId( core.Tier, core.Component, occurrence) ]
 
     [#return
         {
             "Resources" : {
                 "efs" : {
-                    "Id" : efsId,
+                    "Id" : id,
                     "Name" : formatComponentFullName(core.Tier, core.Component, occurrence),
                     "Type" : AWS_EFS_RESOURCE_TYPE
                 },
-                "efsMountTarget" : { 
+                "efsMountTarget" : {
                     "Id" : formatDependentResourceId(AWS_EFS_MOUNTTARGET_RESOURCE_TYPE, efsId),
                     "Type" : AWS_EFS_MOUNTTARGET_RESOURCE_TYPE
                 },
-                "secGroup" : { 
-                    "Id" : formatSecurityGroupId(core.Id),
+                "sg" : {
+                    "Id" : formatDependentSecurityGroupId(id),
                     "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
                 }
             },

--- a/aws/templates/id/id_elb.ftl
+++ b/aws/templates/id/id_elb.ftl
@@ -64,7 +64,7 @@
                     "Type" : AWS_ELB_RESOURCE_TYPE
                 },
                 "sg" : {
-                    "Id" : formatSecurityGroupId(core.Id),
+                    "Id" : formatDependentSecurityGroupId(id),
                     "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
                 }
             },

--- a/aws/templates/solution/solution_cache.ftl
+++ b/aws/templates/solution/solution_cache.ftl
@@ -61,7 +61,7 @@
         [#assign cacheFullName = resources["cache"].Name ]
         [#assign cacheSubnetGroupId = resources["subnetGroup"].Id ]
         [#assign cacheParameterGroupId = resources["parameterGroup"].Id ]
-        [#assign cacheSecurityGroupId = resources["secGroup"].Id ]
+        [#assign cacheSecurityGroupId = resources["sg"].Id ]
 
         [#assign cacheSecurityGroupIngressId = formatDependentSecurityGroupIngressId(
                                                 cacheSecurityGroupId, 

--- a/aws/templates/solution/solution_efs.ftl
+++ b/aws/templates/solution/solution_efs.ftl
@@ -15,7 +15,7 @@
         [#assign efsId              = resources["efs"].Id]
         [#assign efsFullName        = resources["efs"].Name]
         [#assign efsMountTargetId   = resources["efsMountTarget"].Id]
-        [#assign efsSecurityGroupId = resources["secGroup"].Id]
+        [#assign efsSecurityGroupId = resources["sg"].Id]
         
         [#if deploymentSubsetRequired("efs", true) ]
             [@createComponentSecurityGroup


### PR DESCRIPTION
Ensure ids are unique by using primary component ids (which have the primary resource type in them) when generating sg ids.

Ideally we should switch to including component types in occurrence ids so two components with the same tier/component info but different types have different ids. At present its largely not an issue as the resulting resources tend to be quite different - but sgs are the exception. 