### PR TITLE
Minor fix for RDS epilogue script

### DIFF
--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -304,7 +304,7 @@
                         "create_pseudo_stack" + " " + 
                         "\"RDS Master Password\"" + " " + 
                         "\"$\{password_pseudo_stack_file}\"" + " " + 
-                        "\"" + rdsId + "Xgeneratedpassword\" \"$\{encrypted_master_password}\" " +
+                        "\"" + rdsId + "Xgeneratedpassword\" \"$\{encrypted_master_password}\" || return $?", 
                         "info \"Generating URL... \"",
                         "rds_url=\"$(get_rds_url" + 
                         " \"" + engine + "\" " + 


### PR DESCRIPTION
Typo in RDS epilogue script meant that wrong information was being added to the psuedo stack output. This removes the info object from the output and make it an actual statement again.