### PR TITLE
Adds Glacier Transition rules and versioning to s3 resources

### DIFF
--- a/aws/templates/account/account_audit.ftl
+++ b/aws/templates/account/account_audit.ftl
@@ -5,8 +5,17 @@
 
         [#if deploymentSubsetRequired("audit", true)]
             [#assign lifecycleRules = []]
+
+            [#if accountObject.Audit.Expiration?has_content ]
+                [#assign lifecycleRules += 
+                    getS3LifecycleRule(
+                        accountObject.Audit.Expiration, 
+                        accountObject.Audit.Backup)
+                ]
+            [/#if]
+        
             [#assign sqsNotifications = []]
-                
+            
             [@cfResource 
                 mode=listMode
                 id=formatAccountS3Id("audit")
@@ -14,7 +23,10 @@
                 properties=
                     {
                         "BucketName" : formatName("account", "audit", accountObject.Seed),
-                        "AccessControl" : "LogDeliveryWrite"
+                        "AccessControl" : "LogDeliveryWrite",
+                        "VersioningConfiguration" : {
+                            "Status" : "Enabled"
+                        }
                     } +
                     attributeIfContent(
                         "LifecycleConfiguration",

--- a/aws/templates/account/account_audit.ftl
+++ b/aws/templates/account/account_audit.ftl
@@ -10,7 +10,7 @@
                 [#assign lifecycleRules += 
                     getS3LifecycleRule(
                         accountObject.Audit.Expiration, 
-                        accountObject.Audit.Backup)
+                        accountObject.Audit.Offline)
                 ]
             [/#if]
         

--- a/aws/templates/id/id_s3.ftl
+++ b/aws/templates/id/id_s3.ftl
@@ -79,6 +79,13 @@
                 "Children" : [
                     {
                         "Name" : "Expiration"
+                    },
+                    {
+                        "Name" : "Backup"
+                    },
+                    {
+                        "Name" : "Versioning",
+                        "Default" : false
                     }
                 ]
             },

--- a/aws/templates/id/id_s3.ftl
+++ b/aws/templates/id/id_s3.ftl
@@ -81,7 +81,7 @@
                         "Name" : "Expiration"
                     },
                     {
-                        "Name" : "Backup"
+                        "Name" : "Offline"
                     },
                     {
                         "Name" : "Versioning",

--- a/aws/templates/segment/segment_s3.ftl
+++ b/aws/templates/segment/segment_s3.ftl
@@ -17,10 +17,10 @@
         id=s3OperationsTemplateId
         name=operationsBucket
         lifecycleRules=
-            operationsExpiration?is_number?then(
-                getS3LifecycleExpirationRule(operationsExpiration, "AWSLogs") +
-                    getS3LifecycleExpirationRule(operationsExpiration, "CLOUDFRONTLogs") +
-                    getS3LifecycleExpirationRule(operationsExpiration, "DOCKERLogs"),
+            (operationsExpiration?is_number || operationsBackup?is_number)?then(
+                    getS3LifecycleRule(operationsExpiration, operationsBackup, "AWSLogs") +
+                    getS3LifecycleRule(operationsExpiration, operationsBackup, "CLOUDFRONTLogs") +
+                    getS3LifecycleRule(operationsExpiration, operationsBackup, "DOCKERLogs"),
                 []
             )
         outputId=s3OperationsId
@@ -75,8 +75,8 @@
         id=s3DataTemplateId
         name=dataBucket
         lifecycleRules=
-            dataExpiration?is_number?then(
-                getS3LifecycleExpirationRule(dataExpiration),
+            (dataExpiration?is_number || dataBackup?is_number)?then(
+                getS3LifecycleRule(dataExpiration, databBackup),
                 []
             )
         outputId=s3DataId

--- a/aws/templates/segment/segment_s3.ftl
+++ b/aws/templates/segment/segment_s3.ftl
@@ -17,10 +17,10 @@
         id=s3OperationsTemplateId
         name=operationsBucket
         lifecycleRules=
-            (operationsExpiration?is_number || operationsBackup?is_number)?then(
-                    getS3LifecycleRule(operationsExpiration, operationsBackup, "AWSLogs") +
-                    getS3LifecycleRule(operationsExpiration, operationsBackup, "CLOUDFRONTLogs") +
-                    getS3LifecycleRule(operationsExpiration, operationsBackup, "DOCKERLogs"),
+            (operationsExpiration?is_number || operationsOffline?is_number)?then(
+                    getS3LifecycleRule(operationsExpiration, operationsOffline, "AWSLogs") +
+                    getS3LifecycleRule(operationsExpiration, operationsOffline, "CLOUDFRONTLogs") +
+                    getS3LifecycleRule(operationsExpiration, operationsOffline, "DOCKERLogs"),
                 []
             )
         outputId=s3OperationsId
@@ -75,8 +75,8 @@
         id=s3DataTemplateId
         name=dataBucket
         lifecycleRules=
-            (dataExpiration?is_number || dataBackup?is_number)?then(
-                getS3LifecycleRule(dataExpiration, databBackup),
+            (dataExpiration?is_number || dataOffline?is_number)?then(
+                getS3LifecycleRule(dataExpiration, databOffline),
                 []
             )
         outputId=s3DataId

--- a/aws/templates/segment/segment_s3.ftl
+++ b/aws/templates/segment/segment_s3.ftl
@@ -76,7 +76,7 @@
         name=dataBucket
         lifecycleRules=
             (dataExpiration?is_number || dataOffline?is_number)?then(
-                getS3LifecycleRule(dataExpiration, databOffline),
+                getS3LifecycleRule(dataExpiration, dataOffline),
                 []
             )
         outputId=s3DataId

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -264,15 +264,15 @@
     [#assign operationsExpiration =
         (segmentObject.Operations.Expiration)!
         (environmentObject.Operations.Expiration)!""]
-    [#assign operationsBackup = 
-        (segmentObject.Operations.Backup)!
-        (environmentObject.Operations.Backup)!""]
+    [#assign operationsOffline = 
+        (segmentObject.Operations.Offline)!
+        (environmentObject.Operations.Offline)!""]
     [#assign dataExpiration =
         (segmentObject.Data.Expiration)!
         (environmentObject.Data.Expiration)!""]
-    [#assign dataBackup = 
-        (segmentObject.Data.Backup)!
-        (environmentObject.Data.Backup)!""]
+    [#assign dataOffline = 
+        (segmentObject.Data.Offline)!
+        (environmentObject.Data.Offline)!""]
     [#assign dataPublicEnabled =
         (segmentObject.Data.Public.Enabled)!
         (environmentObject.Data.Public.Enabled)!false]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -264,9 +264,15 @@
     [#assign operationsExpiration =
         (segmentObject.Operations.Expiration)!
         (environmentObject.Operations.Expiration)!""]
+    [#assign operationsBackup = 
+        (segmentObject.Operations.Backup)!
+        (environmentObject.Operations.Backup)!""]
     [#assign dataExpiration =
         (segmentObject.Data.Expiration)!
         (environmentObject.Data.Expiration)!""]
+    [#assign dataBackup = 
+        (segmentObject.Data.Backup)!
+        (environmentObject.Data.Backup)!""]
     [#assign dataPublicEnabled =
         (segmentObject.Data.Public.Enabled)!
         (environmentObject.Data.Public.Enabled)!false]

--- a/aws/templates/solution/solution_s3.ftl
+++ b/aws/templates/solution/solution_s3.ftl
@@ -52,7 +52,7 @@
                 [/#if]
             [/#if]
         [/#list]
-                            
+
         [@createS3Bucket
             mode=listMode
             id=s3Id
@@ -60,14 +60,16 @@
             tier=tier
             component=component
             lifecycleRules=
-                (configuration.Lifecycle.Configured && (configuration.Lifecycle.Expiration!operationsExpiration)?has_content)?then(
-                    getS3LifecycleExpirationRule(configuration.Lifecycle.Expiration!operationsExpiration),
-                    [])
+                (configuration.Lifecycle.Configured && ((configuration.Lifecycle.Expiration!operationsExpiration)?has_content || (configuration.Lifecycle.Backup!operationsBackup)?has_content))?then(
+                        getS3LifecycleRule(configuration.Lifecycle.Expiration!operationsExpiration,configuration.Lifecycle.Backup!operationsBackup),
+                        []
+                )
             sqsNotifications=sqsNotifications
             websiteConfiguration=
                 (configuration.Website.Configured && configuration.Website.Enabled)?then(
                     getS3WebsiteConfiguration(configuration.Website.Index, configuration.Website.Error),
                     {})
+            versioning=configuration.Lifecycle.Versioning
             dependencies=dependencies
         /]
 

--- a/aws/templates/solution/solution_s3.ftl
+++ b/aws/templates/solution/solution_s3.ftl
@@ -60,8 +60,8 @@
             tier=tier
             component=component
             lifecycleRules=
-                (configuration.Lifecycle.Configured && ((configuration.Lifecycle.Expiration!operationsExpiration)?has_content || (configuration.Lifecycle.Backup!operationsBackup)?has_content))?then(
-                        getS3LifecycleRule(configuration.Lifecycle.Expiration!operationsExpiration,configuration.Lifecycle.Backup!operationsBackup),
+                (configuration.Lifecycle.Configured && ((configuration.Lifecycle.Expiration!operationsExpiration)?has_content || (configuration.Lifecycle.Offline!operationsOffline)?has_content))?then(
+                        getS3LifecycleRule(configuration.Lifecycle.Expiration!operationsExpiration,configuration.Lifecycle.Offline!operationsOffline),
                         []
                 )
             sqsNotifications=sqsNotifications


### PR DESCRIPTION
Fixes #273 and #272 

Adds support for S3 Bucket Versioning and updates lifecycle rules with the following
- Transitioning to glacier storage
- Expiration of non current versions of objects - By default follows the normal expiration config
- Transition of non current versions of objects - By default follows the normal transition config

Usage 
- Account level Audit Bucket 
   - Versioning always enabled 
   - Configuration - account.json 
  ```Json 
   {
     "Account" : {
        "Audit" : {
            "Backup" : "<Days before Glacier transition>",
            "Expiration" : "<Days before deletion>"
        }
    }
   ```
- Segment 
  - Versioning not available 
  - Configuration - Segment and Environment Lifecycle.Backup property, transition not enabled by default 
- Solution 
  - Versioning - defaults to disabled
  ```Json 
   {
      "Lifecycle" : { 
          "Versioning" : "true|false" 
   }
   ```
   - Glacier 
    ```json 
    { 
       "Lifecycle" : {
             "Backup" : "<Days before glacier transition>"
       }
    }