### PR TITLE
Add support for Custom Metrics and Alerts for lambda functions

### DIFF
--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -47,6 +47,16 @@
                 "Children" : linkChildrenConfiguration
             },
             {
+                "Name" : "Metrics",
+                "Subobjects" : true,
+                "Children" : metricChildrenConfiguration
+            },
+            {
+                "Name" : "Alerts",
+                "Subobjects" : true,
+                "Children" : alertChildrenConfiguraiton
+            }
+            {
                 "Name" : ["Memory", "MemorySize"],
                 "Default" : 0
             },

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -40,6 +40,56 @@
         ]
 ]
 
+[#assign 
+    metricChildrenConfiguration = [
+        "Name",
+        "Type",
+        {
+            "Name" : "LogPattern",
+            "Default" : ""
+        }
+    ]
+]
+
+[#assign alertChildrenConfiguraiton = [
+        "Name",
+        "Description",
+        "Metric",
+        "Threshold",
+        {
+            "Name" : "Severity",
+            "Default" : "Info"
+        },
+        {
+            "Name" : "Namespace",
+            "Default" : ""
+        },
+        {
+            "Name" : "Comparison",
+            "Default" : "Threshold"
+        },
+        {
+            "Name" : "Operator",
+            "Default" : "GreaterThanOrEqualToThreshold"
+        },
+        {
+            "Name" : "Time",
+            "Default" : 300
+        },
+        {
+            "Name" : "Periods",
+            "Default" : 1
+        },
+        {
+            "Name" : "Statistic",
+            "Default" : "Sum"
+        },
+        {
+            "Name" : "ReportOk",
+            "Default" : false
+        }
+    ]
+]
 
 [#include idList]
 [#include nameList]


### PR DESCRIPTION
This adds support for the creation of Log based custom metrics and component level alarms based on metrics. 

The functionality is intended to extend beyond lambda but the current requirements is for it to be enabled in lambda. 

The first metric that this supports is the LogFilter based metric which can raise metrics based on the entry of a log. 
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-metricfilter.html 

The alert configuration at this stage creates an alarm and forwards it to the segment level SNS topic. 