### PR TITLE
Fixes for Lambda Alerts and Metric namespacing

### DIFF
--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -189,7 +189,7 @@
                                 name=metric.Name
                                 logGroup="/aws/lambda/" + fnName
                                 filter=metric.LogPattern
-                                namespace=formatSegmentRelativePath()
+                                namespace=formatProductRelativePath()
                                 value=1
                                 dependencies=fnId
                             /]
@@ -204,14 +204,14 @@
                             [@createCountAlarm
                                 mode=listMode
                                 id=formatDependentAlarmId(fnId, alert.Id)
-                                name=alert.Severity?upper_case + "-" + alert.Name
+                                name=alert.Severity?upper_case + "-" + fnName + "-" + alert.Name
                                 actions=[
                                     getReference(formatSegmentSNSTopicId())
                                 ]
                                 metric=alert.Metric
                                 namespace=alert.Namespace?has_content?then(
                                                 alert.Namespace,
-                                                formatSegmentRelativePath()
+                                                formatProductRelativePath()
                                                 )
                                 description=alert.Description?has_content?then(
                                                 alert.Description,

--- a/aws/templates/name/start.ftl
+++ b/aws/templates/name/start.ftl
@@ -111,8 +111,8 @@
 [#function formatProductPath absolute extensions... ]
     [#return formatPath(
                 absolute
-                tenantName,
-                productName,
+                tenantId,
+                productId,
                 extensions)]
 [/#function]
 

--- a/aws/templates/name/start.ftl
+++ b/aws/templates/name/start.ftl
@@ -108,6 +108,22 @@
     [#return formatSegmentPath(true, extensions)]
 [/#function]
 
+[#function formatProductPath absolute extensions... ]
+    [#return formatPath(
+                absolute
+                tenantName,
+                productName,
+                extensions)]
+[/#function]
+
+[#function formatProductRelativePath extensions...]
+    [#return formatProductPath(false, extensions)]
+[/#function]
+
+[#function formatProductAbsolutePath extensions...]
+    [#return formatProductPath(true, extensions)]
+[/#function]
+
 [#-- Format a file prefix path --]
 [#function formatSegmentPrefixPath type extensions...]
     [#return formatRelativePath(

--- a/aws/templates/name/start.ftl
+++ b/aws/templates/name/start.ftl
@@ -111,8 +111,8 @@
 [#function formatProductPath absolute extensions... ]
     [#return formatPath(
                 absolute
-                tenantId,
-                productId,
+                tenantName,
+                productName,
                 extensions)]
 [/#function]
 

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -65,7 +65,16 @@
         },
         {
             "Name" : "Metric",
-            "Mandatory" : true
+            "Children" : [
+                {
+                    "Name" : "Name",
+                    "Mandatory" : true
+                },
+                {
+                    "Name" : "Type",
+                    "Mandatory" : true
+                }
+            ]
         },
         {
             "Name" : "Threshold",


### PR DESCRIPTION
Moves namespaces up to the tenant/product, the idea being that custom metrics are specific for the product and how it behaves. 

The alert metric also now requires a type field which is used to add dimensions to the Alarm configuration to ensure that the right component is generating the alert. 

Also updates alerts to ensure they are unique 