### PR TITLE
Remove occurrence deployment check

### DIFF
--- a/aws/templates/createBlueprint.ftl
+++ b/aws/templates/createBlueprint.ftl
@@ -103,27 +103,17 @@
 
       [#-- Only include deployed Occurrences --]
       [#local occurrences = getOccurrences(tier, component) ]
-      [#local deployedOccurrences = [] ]
+      [#local cleanedOccurrences = [] ]
 
-      [#list getOccurrences(tier, component) as occurrence ]
-        [#local deployed = false]
-        [#list occurrence.State.Resources?values as resource ]
-          [#if resource.Deployed ]
-              [#local deployed = true]
-              [#continue]
-          [/#if]
-        [/#list]
-        
-        [#if deployed ]
-          [#local deployedOccurrences += [ getCleanedOccurrence(occurrence) ] ]
-        [/#if]
+      [#list getOccurrences(tier, component) as occurrence ]        
+          [#local cleanedOccurrences += [ getCleanedOccurrence(occurrence) ] ]
       [/#list]
 
       [#local result += [
         {
           "Id" : id,
           "Type" : componentType,
-          "Occurrences" : deployedOccurrences
+          "Occurrences" : cleanedOccurrences
         } ] ]
 
     [/#if]


### PR DESCRIPTION
Using the resource deployment state to remove occurrrences proved to removed too much. 

This removes this check and instead we will use more fine grained control in documentation generation 

Fixes #284 