### PR TITLE
EC2 Occurrence Conversion, ALB Load Balancing Refactor, Deploy Script

### DIFF
--- a/aws/templates/account/account_s3.ftl
+++ b/aws/templates/account/account_s3.ftl
@@ -67,7 +67,7 @@
                         "case $\{STACK_OPERATION} in",
                         "  create|update)",
                         "    sync_code_bucket || return $?",
-                        "    initialise_registries \"lambda\" \"swagger\" \"spa\" \"contentnode\" || return $?",
+                        "    initialise_registries \"lambda\" \"scripts\" \"swagger\" \"spa\" \"contentnode\" \"scripts\" || return $?",
                         "    ;;",
                         " esac"
                     ]

--- a/aws/templates/account/account_s3.ftl
+++ b/aws/templates/account/account_s3.ftl
@@ -67,7 +67,7 @@
                         "case $\{STACK_OPERATION} in",
                         "  create|update)",
                         "    sync_code_bucket || return $?",
-                        "    initialise_registries \"lambda\" \"scripts\" \"swagger\" \"spa\" \"contentnode\" \"scripts\" || return $?",
+                        "    initialise_registries \"contentnode\" \"lambda\" \"scripts\" \"spa\" \"swagger\" || return $?",
                         "    ;;",
                         " esac"
                     ]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1774,14 +1774,14 @@
     [#assign targetComponentId = (port.LB.Component) ]
     [#assign targetLinkName = port.LB.LinkName ] 
     [#assign targetSource = 
-    contentIfContent(
-        port.LB.Port,
-        valueIfContent(
-            (portMappings[port.LB.PortMapping].Source)!"",
-            port.LB.PortMapping,
-            port.Id
-        )
-    )]
+                contentIfContent(
+                    port.LB.Port,
+                    valueIfContent(
+                        (portMappings[port.LB.PortMapping].Source)!"",
+                        port.LB.PortMapping,
+                        port.Id
+                    )
+            )]
 
     [#local targetLink =
         {

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -336,15 +336,17 @@
                     "HostPort" : port.Id,
                     "DynamicHostPort" : port.DynamicHostPort
                 } ]
-            [#if targetLoadBalancer?has_content]
+
+            [#if lbLink[port.LB.LinkName]?has_content ]
+                [#local loadBalancer = lbLink[port.LB.LinkName]]
                 [#local containerPortMapping +=
                     {
                         "LoadBalancer" :
                             {
-                                "Link" : lbLink.Name,
-                                "TargetGroup" : lbLink.targetGroup,
+                                "Link" : loadBalancer.Name,
+                                "TargetGroup" : loadBalancer.TargetGroup,
                                 "Priority" : port.LB.Priority,
-                                "Path" : lbLink.targetPath
+                                "Path" : loadBalancer.TargetPath
                             }
                     }
                 ]

--- a/aws/templates/id/id_ec2.ftl
+++ b/aws/templates/id/id_ec2.ftl
@@ -121,7 +121,7 @@
                 },
                 "ec2ENI" : {
                     "Id" : formatResourceId(AWS_EC2_NETWORK_INTERFACE_RESOURCE_TYPE, core.Id, zone.Id, "eth0"),
-                    "Type" : "AWS_EC2_NETWORK_INTERFACE_RESOURCE_TYPE"
+                    "Type" : AWS_EC2_NETWORK_INTERFACE_RESOURCE_TYPE
                 },
                 "ec2EIP" : {
                     "Id" : getExistingReference(formatEIPId( core.Id, zone.Id))?has_content?then(

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -55,42 +55,7 @@
                 },
                 {
                     "Name" : "LB",
-                    "Children" : [
-                        {
-                            "Name" : "Component",
-                            "Mandatory" : true
-                        },
-                        "Instance",
-                        {
-                            "Name" : "LinkName",
-                            "Default" : "lb"
-                        },
-                        {
-                            "Name" : "Path",
-                            "Default" : ""
-                        },
-                        {
-                            "Name" : "Port",
-                            "Default" : ""
-                        },
-                        {
-                            "Name" : "PortMapping",
-                            "Default" : ""
-                        },
-                        {
-                            "Name" : "Priority",
-                            "Default" : 100
-                        },
-                        {
-                            "Name" : "TargetGroup",
-                            "Default" : ""
-                        },
-                        {
-                            "Name" : "Tier",
-                            "Mandatory" : true
-                        },
-                        "Version"
-                    ]
+                    "Children" : lbChildConfiguration
                 }
             ]
         },

--- a/aws/templates/id/id_eip.ftl
+++ b/aws/templates/id/id_eip.ftl
@@ -10,24 +10,27 @@
                 ids)]
 [/#function]
 
+[#function formatEIPAssociationId ids...]
+    [#return formatResourceId(
+        AWS_EIP_ASSOCIATION_RESOURCE_TYPE,
+        ids)]
+[/#function]
+
 [#function formatDependentEIPId resourceId extensions...]
-    [#return formatDependentResourceId(
-                AWS_EIP_RESOURCE_TYPE,
+    [#return formatEIPId(
                 resourceId,
                 extensions)]
 [/#function]
 
 [#function formatComponentEIPId tier component extensions...]
-    [#return formatComponentResourceId(
-                AWS_EIP_RESOURCE_TYPE,
+    [#return formatEIPId(
                 tier,
                 component,
                 extensions)]
 [/#function]
 
 [#function formatComponentEIPAssociationId tier component extensions...]
-    [#return formatComponentResourceId(
-                AWS_EIP_ASSOCIATION_RESOURCE_TYPE,
+    [#return formatEIPAssociationId(
                 tier,
                 component,
                 extensions)]

--- a/aws/templates/policy/policy_alb.ftl
+++ b/aws/templates/policy/policy_alb.ftl
@@ -1,0 +1,12 @@
+[#function albRegisterTargetPermission ]
+    [#return
+        [
+            getPolicyStatement(
+                [
+                    "elasticloadbalancing:RegisterTargets",
+                    "elasticloadbalancing:DeregisterTargets"
+                ]
+            )
+        ]
+    ]
+[/#function]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -119,6 +119,44 @@
     ]
 ]
 
+[#assign lbChildConfiguration = [
+        {
+            "Name" : "Tier",
+            "Mandatory" : true
+        },
+        {
+            "Name" : "Component",
+            "Mandatory" : true
+        },
+        {
+            "Name" : "LinkName",
+            "Default" : "lb"
+        },
+        "Instance",
+        "Version",
+        {
+            "Name" : "Path",
+            "Default" : ""
+        },
+        {
+            "Name" : "Port",
+            "Default" : ""
+        },
+        {
+            "Name" : "PortMapping",
+            "Default" : ""
+        },
+        {
+            "Name" : "Priority",
+            "Default" : 100
+        },
+        {
+            "Name" : "TargetGroup",
+            "Default" : ""
+        }
+    ]
+]
+
 [#include idList]
 [#include nameList]
 [#include policyList]

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -10,6 +10,8 @@
         [#assign core = occurrence.Core]
         [#assign solution = occurrence.Configuration.Solution]
         [#assign resources = occurrence.State.Resources]
+        [#assign zoneResources = occurrence.State.Resources.Zones]
+        [#assign links = solution.Links ]
 
         [#assign fixedIP = solution.FixedIP]
         [#assign loadBalanced = solution.LoadBalanced]
@@ -17,54 +19,126 @@
 
         [#assign ec2FullName            = resources["ec2Instance"].Name ]
         [#assign ec2SecurityGroupId     = resources["sg"].Id]
+        [#assign ec2SecurityGroupName   = resources["sg"].Name]
         [#assign ec2RoleId              = resources["ec2Role"].Id]
         [#assign ec2InstanceProfileId   = resources["instanceProfile"].Id]
         [#assign ec2ELBId               = resources["ec2ELB"].Id]
 
+        [#assign targetGroupRegistrations = {}]
+        [#assign componentDependencies = []]
         [#assign ingressRules = []]
 
-        [#list solution.Ports as port]
-            [#assign nextPort = port?is_hash?then(port.Port, port)]
-            [#assign portCIDRs = getUsageCIDRs(
-                                nextPort,
-                                port?is_hash?then(port.IPAddressGroups![], []))]
-            [#if portCIDRs?has_content]
-                [#assign ingressRules +=
-                    [{
-                        "Port" : nextPort,
-                        "CIDR" : portCIDRs
-                    }]]
-            [/#if]
-        [/#list]
-
-        [#if deploymentSubsetRequired("iam", true) &&
-                isPartOfCurrentDeploymentUnit(ec2RoleId)]
-            [@createRole
-                mode=listMode
-                id=ec2RoleId
-                trustedServices=["ec2.amazonaws.com" ]
-                policies=
-                    [
-                        getPolicyDocument(
-                            s3ListPermission(codeBucket) +
-                                s3ReadPermission(codeBucket) +
-                                s3ListPermission(operationsBucket) +
-                                s3WritePermission(operationsBucket, "DOCKERLogs") +
-                                s3WritePermission(operationsBucket, "Backups"),
-                            "basic")
-                    ]
-            /]
+        [#if solution.Ports?is_hash?has_content ]
+            [#list solution.Ports as id,port ]
+                [#assign links += getLBLink(occurrence port)] 
+            [/#list]
+        [#else]
+            [#list solution.Ports as port]
+                [#assign nextPort = port?is_hash?then(port.Port, port)]
+                [#assign portCIDRs = getUsageCIDRs(
+                                    nextPort,
+                                    port?is_hash?then(port.IPAddressGroups![], []))]
+                [#if portCIDRs?has_content]
+                    [#assign ingressRules +=
+                        [{
+                            "Port" : nextPort,
+                            "CIDR" : portCIDRs
+                        }]]
+                [/#if]
+            [/#list]
         [/#if]
+        
+    [#if deploymentSubsetRequired("iam", true) &&
+            isPartOfCurrentDeploymentUnit(ec2RoleId)]
+        [@createRole
+            mode=listMode
+            id=ec2RoleId
+            trustedServices=["ec2.amazonaws.com" ]
+            policies=
+                [
+                    getPolicyDocument(
+                        s3ListPermission(codeBucket) +
+                            s3ReadPermission(codeBucket) +
+                            s3ListPermission(operationsBucket) +
+                            s3WritePermission(operationsBucket, "DOCKERLogs") +
+                            s3WritePermission(operationsBucket, "Backups"),
+                        "basic")
+                ]
+        /]
+    [/#if]
 
     [#if deploymentSubsetRequired("ec2", true)]
 
-        [@createComponentSecurityGroup
+        [#list links?values as link]
+            [#if link?is_hash]
+                [#assign linkTarget = getLinkTarget(occurrence, link) ]
+
+                [@cfDebug listMode linkTarget false /]
+
+                [#if !linkTarget?has_content]
+                    [#continue]
+                [/#if]
+
+                [#assign linkTargetCore = linkTarget.Core ]
+                [#assign linkTargetConfiguration = linkTarget.Configuration ]
+                [#assign linkTargetResources = linkTarget.State.Resources ]
+                [#assign linkTargetAttributes = linkTarget.State.Attributes ]
+
+                [#switch linkTargetCore.Type]
+                    [#case ALB_PORT_COMPONENT_TYPE]
+                        [#if link.TargetGroup?has_content ]
+                            [#assign targetId = (linkTargetResources["targetgroups"][link.TargetGroup].Id) ]
+                            [#if targetId?has_content]
+
+                                [#if isPartOfCurrentDeploymentUnit(targetId)]
+
+                                    [@createTargetGroup
+                                        mode=listMode
+                                        id=targetId
+                                        name=formatName(linkTargetCore.FullName,link.TargetGroup)
+                                        tier=link.Tier
+                                        component=link.Component
+                                        destination=ports[link.Port]
+                                    /]
+                                    [#assign listenerRuleId = formatALBListenerRuleId(occurrence, link.TargetGroup) ]
+                                    [@createListenerRule
+                                        mode=listMode
+                                        id=listenerRuleId
+                                        listenerId=linkTargetResources["listener"].Id
+                                        actions=getListenerRuleForwardAction(targetId)
+                                        conditions=getListenerRulePathCondition(link.TargetPath)
+                                        priority=link.Priority!100
+                                        dependencies=targetId
+                                    /]
+                                    
+                                    [#assign componentDependencies += [targetId]]
+                                    
+                                [/#if]
+                                [#assign targetGroupRegistrations += 
+                                        {
+                                            "03RegisterWithTG" + targetId  : {
+                                                "command" : "/opt/codeontap/bootstrap/register_targetgroup.sh",
+                                                "env" : {
+                                                    "TARGET_GROUP_ARN" : getReference(targetId)
+                                                },
+                                                "ignoreErrors" : "false"
+                                            }
+                                        }
+                                    ]
+                            [/#if]
+                        [/#if]
+                        [#break]
+                [/#switch]
+            [/#if]
+        [/#list]
+
+        [@createSecurityGroup
             mode=listMode
+            id=ec2SecurityGroupId
+            name=ec2SecurityGroupName
             tier=tier
             component=component
-            ingressRules=ingressRules
-         /]
-
+            ingressRules=ingressRules /]
 
         [@cfResource
             mode=listMode
@@ -77,39 +151,14 @@
                 }
             outputs={}
         /]
-
+        
         [#list zones as zone]
             [#if multiAZ || (zones[0].Id = zone.Id)]
-                [#assign ec2InstanceId =
-                            formatEC2InstanceId(
-                                tier,
-                                component,
-                                zone)]
-                [#assign ec2ENIId =
-                            formatEC2ENIId(
-                                tier,
-                                component,
-                                zone,
-                                "eth0")]
-                [#assign ec2EIPId = formatComponentEIPId(
-                                        tier,
-                                        component,
-                                        zone)]
-              [#-- Support backwards compatability with existing installs --]
-                [#if !(getExistingReference(ec2EIPId)?has_content)]
-                    [#assign ec2EIPId = formatComponentEIPId(
-                                            tier,
-                                            component,
-                                            zone
-                                            "eth0")]
-                [/#if]
-
-                [#assign ec2EIPAssociationId =
-                            formatComponentEIPAssociationId(
-                                tier,
-                                component,
-                                zone,
-                                "eth0")]
+                [#assign zoneEc2InstanceId          = zoneResources[zone.Id]["ec2Instance"].Id ]
+                [#assign zoneEc2InstanceName        = zoneResources[zone.Id]["ec2Instance"].Name ]
+                [#assign zoneEc2ENIId               = zoneResources[zone.Id]["ec2ENI"].Id ]
+                [#assign zoneEc2EIPId               = zoneResources[zone.Id]["ec2EIP"].Id]
+                [#assign zoneEc2EIPAssociationId    = zoneResources[zone.Id]["ec2EIPAssociation"].Id]
 
                 [#assign processorProfile = getProcessor(tier, component, "EC2")]
                 [#assign storageProfile = getStorage(tier, component, "EC2")]
@@ -123,7 +172,7 @@
 
                 [@cfResource
                     mode=listMode
-                    id=ec2InstanceId
+                    id=zoneEc2InstanceId
                     type="AWS::EC2::Instance"
                     metadata=
                         {
@@ -151,25 +200,25 @@
                                                 "Fn::Join" : [
                                                     "",
                                                     [
-                                                        "#!/bin/bash\n",
-                                                        "echo \"cot:request="       + requestReference       + "\"\n",
-                                                        "echo \"cot:configuration=" + configurationReference + "\"\n",
-                                                        "echo \"cot:accountRegion=" + accountRegionId        + "\"\n",
-                                                        "echo \"cot:tenant="        + tenantId               + "\"\n",
-                                                        "echo \"cot:account="       + accountId              + "\"\n",
-                                                        "echo \"cot:product="       + productId              + "\"\n",
-                                                        "echo \"cot:region="        + regionId               + "\"\n",
-                                                        "echo \"cot:segment="       + segmentId              + "\"\n",
-                                                        "echo \"cot:environment="   + environmentId          + "\"\n",
-                                                        "echo \"cot:tier="          + tierId                 + "\"\n",
-                                                        "echo \"cot:component="     + componentId            + "\"\n",
-                                                        "echo \"cot:zone="          + zone.Id                + "\"\n",
-                                                        "echo \"cot:name="          + formatName(ec2FullName, zone) + "\"\n",
-                                                        "echo \"cot:role="          + component.Role         + "\"\n",
-                                                        "echo \"cot:credentials="   + credentialsBucket      + "\"\n",
-                                                        "echo \"cot:code="          + codeBucket             + "\"\n",
-                                                        "echo \"cot:logs="          + operationsBucket       + "\"\n",
-                                                        "echo \"cot:backups="       + dataBucket             + "\"\n"
+                                                        "#!/bin/bash\\n",
+                                                        "echo \\\"cot:request="       + requestReference       + "\\\"\\n",
+                                                        "echo \\\"cot:configuration=" + configurationReference + "\\\"\\n",
+                                                        "echo \\\"cot:accountRegion=" + accountRegionId        + "\\\"\\n",
+                                                        "echo \\\"cot:tenant="        + tenantId               + "\\\"\\n",
+                                                        "echo \\\"cot:account="       + accountId              + "\\\"\\n",
+                                                        "echo \\\"cot:product="       + productId              + "\\\"\\n",
+                                                        "echo \\\"cot:region="        + regionId               + "\\\"\\n",
+                                                        "echo \\\"cot:segment="       + segmentId              + "\\\"\\n",
+                                                        "echo \\\"cot:environment="   + environmentId          + "\\\"\\n",
+                                                        "echo \\\"cot:tier="          + tierId                 + "\\\"\\n",
+                                                        "echo \\\"cot:component="     + componentId            + "\\\"\\n",
+                                                        "echo \\\"cot:zone="          + zone.Id                + "\\\"\\n",
+                                                        "echo \\\"cot:name="          + zoneEc2InstanceName    + "\\\"\\n",
+                                                        "echo \\\"cot:role="          + component.Role!""      + "\\\"\\n",
+                                                        "echo \\\"cot:credentials="   + credentialsBucket      + "\\\"\\n",
+                                                        "echo \\\"cot:code="          + codeBucket             + "\\\"\\n",
+                                                        "echo \\\"cot:logs="          + operationsBucket       + "\\\"\\n",
+                                                        "echo \\\"cot:backups="       + dataBucket             + "\\\"\\n"
                                                     ]
                                                 ]
                                             },
@@ -211,13 +260,7 @@
                                             },
                                             "ignoreErrors" : "false"
                                         }) +
-                                    attributeIfTrue(
-                                        "04DockerHostSetup",
-                                        dockerHost,
-                                        {
-                                            "command" : "/opt/codeontap/bootstrap/docker.sh",
-                                            "ignoreErrors" : "false"
-                                        })
+                                    targetGroupRegistrations
                                 },
                                 "puppet": {
                                     "commands": {
@@ -235,7 +278,6 @@
                             "DisableApiTermination" : false,
                             "EbsOptimized" : false,
                             "IamInstanceProfile" : { "Ref" : ec2InstanceProfileId },
-                            "ImageId": regionObject.AMIs.Centos.EC2,
                             "InstanceInitiatedShutdownBehavior" : "stop",
                             "InstanceType": processorProfile.Processor,
                             "KeyName": productName + sshPerSegment?then("-" + segmentName,""),
@@ -243,7 +285,7 @@
                             "NetworkInterfaces" : [
                                 {
                                     "DeviceIndex" : "0",
-                                    "NetworkInterfaceId" : getReference(ec2ENIId)
+                                    "NetworkInterfaceId" : getReference(zoneEc2ENIId)
                                 }
                             ],
                             "UserData" : {
@@ -259,13 +301,17 @@
                                             "# Remainder of configuration via metadata\n",
                                             "/opt/aws/bin/cfn-init -v",
                                             "         --stack ", { "Ref" : "AWS::StackName" },
-                                            "         --resource ", ec2InstanceId,
-                                            "         --region ", regionId, " --configsets ec2\n"
+                                            "         --resource ", zoneEc2InstanceId,
+                                            "         --region ", regionId, " --configsets ec2\\n"
                                         ]
                                     ]
                                 }
                             }
-                        }
+                        } +
+                        dockerHost?then(
+                            { "ImageId" : regionObject.AMIs.Centos.ECS },
+                            { "ImageId" : regionObject.AMIs.Centos.EC2} 
+                        )
                     tags=
                         getCfTemplateCoreTags(
                             formatComponentFullName(tier, component, zone),
@@ -273,21 +319,20 @@
                             component,
                             zone)
                     outputs={}
-                    dependencies=
-                        [ec2ENIId] +
+                    dependencies=[zoneEc2ENIId] +
+                        componentDependencies + 
                         loadBalanced?then(
                             [ec2ELBId],
                             []
                         ) +
                         fixedIP?then(
-                            [ec2EIPAssociationId],
-                            []
-                        )
+                            [zoneEc2EIPAssociationId],
+                            [])
                 /]
 
                 [@cfResource
                     mode=listMode
-                    id=ec2ENIId
+                    id=zoneEc2ENIId
                     type="AWS::EC2::NetworkInterface"
                     properties=
                         {
@@ -313,20 +358,20 @@
                 [#if fixedIP]
                     [@createEIP
                         mode=listMode
-                        id=ec2EIPId
-                        dependencies=[ec2ENIId]
+                        id=zoneEc2EIPId
+                        dependencies=[zoneEc2ENIId]
                     /]
 
                     [@cfResource
                         mode=listMode
-                        id=ec2EIPAssociationId
+                        id=zoneEc2EIPAssociationId
                         type="AWS::EC2::EIPAssociation"
                         properties=
                             {
-                                "AllocationId" : getReference(ec2EIPId, ALLOCATION_ATTRIBUTE_TYPE),
-                                "NetworkInterfaceId" : getReference(ec2ENIId)
+                                "AllocationId" : getReference(zoneEc2EIPId, ALLOCATION_ATTRIBUTE_TYPE),
+                                "NetworkInterfaceId" : getReference(zoneEc2ENIId)
                             }
-                        dependencies=[ec2EIPId]
+                        dependencies=[zoneEc2EIPId]
                         outputs={}
                     /]
                 [/#if]
@@ -334,5 +379,4 @@
         [/#list]
         [/#if]
     [/#list]
-
 [/#if]

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -231,29 +231,29 @@
                                                 "Fn::Join" : [
                                                     "",
                                                     [
-                                                        "#!/bin/bash\\n",
-                                                        "echo \"cot:request="       + requestReference       + "\"\\n",
-                                                        "echo \"cot:configuration=" + configurationReference + "\"\\n",
-                                                        "echo \"cot:accountRegion=" + accountRegionId        + "\"\\n",
-                                                        "echo \"cot:tenant="        + tenantId               + "\"\\n",
-                                                        "echo \"cot:account="       + accountId              + "\"\\n",
-                                                        "echo \"cot:product="       + productId              + "\"\\n",
-                                                        "echo \"cot:region="        + regionId               + "\"\\n",
-                                                        "echo \"cot:segment="       + segmentId              + "\"\\n",
-                                                        "echo \"cot:environment="   + environmentId          + "\"\\n",
-                                                        "echo \"cot:tier="          + tierId                 + "\"\\n",
-                                                        "echo \"cot:component="     + componentId            + "\"\\n",
-                                                        "echo \"cot:zone="          + zone.Id                + "\"\\n",
-                                                        "echo \"cot:name="          + zoneEc2InstanceName    + "\"\\n",
-                                                        "echo \"cot:role="          + component.Role!""      + "\"\\n",
-                                                        "echo \"cot:credentials="   + credentialsBucket      + "\"\\n",
-                                                        "echo \"cot:code="          + codeBucket             + "\"\\n",
-                                                        "echo \"cot:logs="          + operationsBucket       + "\"\\n",
-                                                        "echo \"cot:backups="       + dataBucket             + "\"\\n"
+                                                        "#!/bin/bash\n",
+                                                        "echo \"cot:request="       + requestReference       + "\"\n",
+                                                        "echo \"cot:configuration=" + configurationReference + "\"\n",
+                                                        "echo \"cot:accountRegion=" + accountRegionId        + "\"\n",
+                                                        "echo \"cot:tenant="        + tenantId               + "\"\n",
+                                                        "echo \"cot:account="       + accountId              + "\"\n",
+                                                        "echo \"cot:product="       + productId              + "\"\n",
+                                                        "echo \"cot:region="        + regionId               + "\"\n",
+                                                        "echo \"cot:segment="       + segmentId              + "\"\n",
+                                                        "echo \"cot:environment="   + environmentId          + "\"\n",
+                                                        "echo \"cot:tier="          + tierId                 + "\"\n",
+                                                        "echo \"cot:component="     + componentId            + "\"\n",
+                                                        "echo \"cot:zone="          + zone.Id                + "\"\n",
+                                                        "echo \"cot:name="          + zoneEc2InstanceName    + "\"\n",
+                                                        "echo \"cot:role="          + component.Role!""      + "\"\n",
+                                                        "echo \"cot:credentials="   + credentialsBucket      + "\"\n",
+                                                        "echo \"cot:code="          + codeBucket             + "\"\n",
+                                                        "echo \"cot:logs="          + operationsBucket       + "\"\n",
+                                                        "echo \"cot:backups="       + dataBucket             + "\"\n"
                                                     ] + 
                                                     scriptsFile?has_content?then(
                                                         [
-                                                            "echo \"cot:scripts="       + scriptsFile             + "\"\\n"
+                                                            "echo \"cot:scripts="       + scriptsFile             + "\"\n"
                                                         ],
                                                         []
                                                     )
@@ -316,15 +316,15 @@
                                                 "Fn::Join" : [
                                                     "",
                                                     [
-                                                        "#!/bin/bash -ex\\n",
-                                                        "exec > >(tee /var/log/codeontap/fetch.log|logger -t codeontap-scripts-fetch -s 2>/dev/console) 2>&1\\n",
-                                                        "REGION=$(/etc/codeontap/facts.sh | grep cot:accountRegion | cut -d '=' -f 2)\\n",
-                                                        "SCRIPTS=$(/etc/codeontap/facts.sh | grep cot:scripts | cut -d '=' -f 2)\\n",
-                                                        "if [ -z " + r"${SCRIPTS}" +" ]; then\\n",
-                                                        "aws --region " + r"${REGION}" + " s3 cp --quiet s3://" + r"${SCRIPTS}" + " /opt/codeontap/scripts\\n", 
-                                                        "[ -f /opt/codeontap/scripts/scripts.zip ] && unzip /opt/codeontap/scripts/scripts.zip\\n",
-                                                        "chmod -R 0500 /opt/codeontap/scripts/\\n"
-                                                        "fi\\n"
+                                                        "#!/bin/bash -ex\n",
+                                                        "exec > >(tee /var/log/codeontap/fetch.log|logger -t codeontap-scripts-fetch -s 2>/dev/console) 2>&1\n",
+                                                        "REGION=$(/etc/codeontap/facts.sh | grep cot:accountRegion | cut -d '=' -f 2)\n",
+                                                        "SCRIPTS=$(/etc/codeontap/facts.sh | grep cot:scripts | cut -d '=' -f 2)\n",
+                                                        "if [ -z " + r"${SCRIPTS}" +" ]; then\n",
+                                                        "aws --region " + r"${REGION}" + " s3 cp --quiet s3://" + r"${SCRIPTS}" + " /opt/codeontap/scripts\n", 
+                                                        "[ -f /opt/codeontap/scripts/scripts.zip ] && unzip /opt/codeontap/scripts/scripts.zip\n",
+                                                        "chmod -R 0500 /opt/codeontap/scripts/\n"
+                                                        "fi\n"
                                                     ]
                                                 ]
                                             },
@@ -335,9 +335,9 @@
                                                 "Fn::Join" : [
                                                     "",
                                                     [
-                                                        "#!/bin/bash -ex\\n",
-                                                        "exec > >(tee /var/log/codeontap/fetch.log|logger -t codeontap-scripts-init -s 2>/dev/console) 2>&1\\n",
-                                                        "[ -f /opt/codeontap/scripts/init.sh ] &&  /opt/codeontap/scripts/init.sh\\n" 
+                                                        "#!/bin/bash -ex\n",
+                                                        "exec > >(tee /var/log/codeontap/fetch.log|logger -t codeontap-scripts-init -s 2>/dev/console) 2>&1\n",
+                                                        "[ -f /opt/codeontap/scripts/init.sh ] &&  /opt/codeontap/scripts/init.sh\n" 
                                                     ]
                                                 ]
                                             },
@@ -390,7 +390,7 @@
                                             "/opt/aws/bin/cfn-init -v",
                                             "         --stack ", { "Ref" : "AWS::StackName" },
                                             "         --resource ", zoneEc2InstanceId,
-                                            "         --region ", regionId, " --configsets ec2\\n"
+                                            "         --region ", regionId, " --configsets ec2\n"
                                         ]
                                     ]
                                 }

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -17,7 +17,6 @@
         [#assign loadBalanced = solution.LoadBalanced]
         [#assign dockerHost = solution.DockerHost]
 
-        [#assign ec2FullName            = resources["ec2Instance"].Name ]
         [#assign ec2SecurityGroupId     = resources["sg"].Id]
         [#assign ec2SecurityGroupName   = resources["sg"].Name]
         [#assign ec2RoleId              = resources["ec2Role"].Id]
@@ -233,28 +232,28 @@
                                                     "",
                                                     [
                                                         "#!/bin/bash\\n",
-                                                        "echo \\\"cot:request="       + requestReference       + "\\\"\\n",
-                                                        "echo \\\"cot:configuration=" + configurationReference + "\\\"\\n",
-                                                        "echo \\\"cot:accountRegion=" + accountRegionId        + "\\\"\\n",
-                                                        "echo \\\"cot:tenant="        + tenantId               + "\\\"\\n",
-                                                        "echo \\\"cot:account="       + accountId              + "\\\"\\n",
-                                                        "echo \\\"cot:product="       + productId              + "\\\"\\n",
-                                                        "echo \\\"cot:region="        + regionId               + "\\\"\\n",
-                                                        "echo \\\"cot:segment="       + segmentId              + "\\\"\\n",
-                                                        "echo \\\"cot:environment="   + environmentId          + "\\\"\\n",
-                                                        "echo \\\"cot:tier="          + tierId                 + "\\\"\\n",
-                                                        "echo \\\"cot:component="     + componentId            + "\\\"\\n",
-                                                        "echo \\\"cot:zone="          + zone.Id                + "\\\"\\n",
-                                                        "echo \\\"cot:name="          + zoneEc2InstanceName    + "\\\"\\n",
-                                                        "echo \\\"cot:role="          + component.Role!""      + "\\\"\\n",
-                                                        "echo \\\"cot:credentials="   + credentialsBucket      + "\\\"\\n",
-                                                        "echo \\\"cot:code="          + codeBucket             + "\\\"\\n",
-                                                        "echo \\\"cot:logs="          + operationsBucket       + "\\\"\\n",
-                                                        "echo \\\"cot:backups="       + dataBucket             + "\\\"\\n"
+                                                        "echo \"cot:request="       + requestReference       + "\"\\n",
+                                                        "echo \"cot:configuration=" + configurationReference + "\"\\n",
+                                                        "echo \"cot:accountRegion=" + accountRegionId        + "\"\\n",
+                                                        "echo \"cot:tenant="        + tenantId               + "\"\\n",
+                                                        "echo \"cot:account="       + accountId              + "\"\\n",
+                                                        "echo \"cot:product="       + productId              + "\"\\n",
+                                                        "echo \"cot:region="        + regionId               + "\"\\n",
+                                                        "echo \"cot:segment="       + segmentId              + "\"\\n",
+                                                        "echo \"cot:environment="   + environmentId          + "\"\\n",
+                                                        "echo \"cot:tier="          + tierId                 + "\"\\n",
+                                                        "echo \"cot:component="     + componentId            + "\"\\n",
+                                                        "echo \"cot:zone="          + zone.Id                + "\"\\n",
+                                                        "echo \"cot:name="          + zoneEc2InstanceName    + "\"\\n",
+                                                        "echo \"cot:role="          + component.Role!""      + "\"\\n",
+                                                        "echo \"cot:credentials="   + credentialsBucket      + "\"\\n",
+                                                        "echo \"cot:code="          + codeBucket             + "\"\\n",
+                                                        "echo \"cot:logs="          + operationsBucket       + "\"\\n",
+                                                        "echo \"cot:backups="       + dataBucket             + "\"\\n"
                                                     ] + 
                                                     scriptsFile?has_content?then(
                                                         [
-                                                            "echo \\\"cot:scripts="       + scriptsFile             + "\\\"\\n"
+                                                            "echo \"cot:scripts="       + scriptsFile             + "\"\\n"
                                                         ],
                                                         []
                                                     )


### PR DESCRIPTION
Updates the S3 Solution component to align with use some of our new features 

- Registration with ALB based load balancers using linking/port definitions
- Converting ID/naming generation to support occurrence structure adds the idea of Zone level resources which individual resources for each zone that could potentially be deployed to 
- Adds the ability to deploy scripts to an Ec2 Instance
  
**To Deploy a script** 

1. create a code repo with an init.sh script as an entry point with other scripts or content. 
2. The script repo content will be copied to the ec2 instances under /opt/codeontap/scripts 
3. The /opt/codeontap/scripts/init.sh script will then be run on the inital setup of the instance as part of the cfn-init process 
4. The instance will be recreated each time the code is updated. Make sure that the data does not require persistence. 