### PR TITLE
Filter LogMetrics using Name instead of dimension

### DIFF
--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -189,7 +189,7 @@
                             [@createLogMetric
                                 mode=listMode
                                 id=formatDependentLogMetricId(fnId, metric.Id)
-                                name=metric.Name
+                                name=formatName(metric.Name, fnName) 
                                 logGroup=logGroupName
                                 filter=metric.LogPattern
                                 namespace=formatProductRelativePath()
@@ -204,19 +204,16 @@
                 [#list solution.Alerts?values as alert ]
 
                     [#assign dimensions=[] ]
+                    [#assign metricName = alert.Metric.Name ]
 
                     [#switch alert.Metric.Type]
                         [#case "LogFilter" ]
-                            [#assign dimensions +=
-                                [
-                                    {
-                                        "Name" : "LogGroupName",
-                                        "Value" : logGroupName
-                                    }
-                                ]
-                            ]
-                        [#break]
-                    [/#switch]
+                            [#-- TODO: Ideally We should use dimensions for filtering but they aren't available on Log Metrics --]
+                            [#-- feature requst has been reaised... --]
+                            [#-- Instead we name the logMetric with the function name and will use that --]
+                            [#assign metricName = formatName(alert.Metric.Name, fnName) ]
+                        [#break] 
+                    [/#switch]                  
 
                     [#switch alert.Comparison ]
                         [#case "Threshold" ]
@@ -227,7 +224,7 @@
                                 actions=[
                                     getReference(formatSegmentSNSTopicId())
                                 ]
-                                metric=alert.Metric.Name
+                                metric=metricName
                                 namespace=alert.Namespace?has_content?then(
                                                 alert.Namespace,
                                                 formatProductRelativePath()
@@ -242,6 +239,7 @@
                                 period=alert.Time
                                 operator=alert.Operator
                                 reportOK=alert.ReportOk
+                                missingData=alert.MissingData
                                 dimensions=dimensions
                                 dependencies=fnId
                             /]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -111,6 +111,10 @@
         {
             "Name" : "ReportOk",
             "Default" : false
+        },
+        {
+            "Name" : MissingData",
+            "Default : "notBreaching" 
         }
     ]
 ]


### PR DESCRIPTION
The intention of metric dimensions is to filter a metric to the source that generated it. This allows you to have the same metric but reported from different locations. 

Unfortunately dimensions are not available for LogMetrics. After raising a support case with AWS they have advised that at the moment you can not add dimensions to LogMetrics and instead to filter the metric the metric name should include a unique Id. 

This PR updates the metric name to make it unique for each function and then updates the alarm Metric to include the function name. 

The intention would be to move this back to dimensions when they are supported by AWS.