### PR TITLE
Show error handling for status updates

### DIFF
--- a/aws/manageStack.sh
+++ b/aws/manageStack.sh
@@ -246,14 +246,14 @@ function wait_for_stack_execution() {
       update)
         status_attribute="StackStatus"
         operation_to_check="UPDATE"
-        aws --region ${REGION} cloudformation describe-stacks --stack-name "${STACK_NAME}" > "${STACK}" 2>/dev/null
+        aws --region ${REGION} cloudformation describe-stacks --stack-name "${STACK_NAME}" > "${STACK}"
         exit_status=$?
       ;;
 
       create)
         status_attribute="StackStatus"
         operation_to_check="CREATE"
-        aws --region ${REGION} cloudformation describe-stacks --stack-name "${STACK_NAME}" > "${STACK}" 2>/dev/null
+        aws --region ${REGION} cloudformation describe-stacks --stack-name "${STACK_NAME}" > "${STACK}"
         exit_status=$?
       ;;
 


### PR DESCRIPTION
At the moment if a stack update fails mid way through we don't see the error that caused it. 

This just displays the error if a describe stack action fails for create or update tasks