### PR TITLE
Remove usage functionality from IP Address Groups

### DIFF
--- a/aws/templates/account/account_waf.ftl
+++ b/aws/templates/account/account_waf.ftl
@@ -1,10 +1,10 @@
 [#-- WAF IP setup --]
 [#if deploymentUnit?contains("waf") && deploymentSubsetRequired("waf", true)]
-    [#list getUsage("waf")?values as group]
+    [#list ipAddressGroups?values as group]
         [#assign ipSetId = formatWAFIPSetId(group)]
         [#assign ipSetName = formatWAFIPSetName(group)]
         [#assign ipRuleId = formatWAFIPSetRuleId(group)]
-        [#assign cidrs = getUsageCIDRs("waf", group.Id, false) ]
+        [#assign cidrs = getGroupCIDRs(group.Id, false) ]
         [#if cidrs?has_content]
             [@createWAFIPSet
                 listMode,

--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -127,7 +127,7 @@
         [#assign cfOriginId             = resources["cforigin"].Id]
         [#assign cfOriginFqdn           = resources["cforigin"].Fqdn]
 
-        [#assign wafPresent             = solution.WAF.Configured && solution.WAF.Enabled ]
+        [#assign wafPresent             = isWAFPresent(solution.WAF) ]
         [#assign wafAclId               = resources["wafacl"].Id]
         [#assign wafAclName             = resources["wafacl"].Name]
 
@@ -282,9 +282,7 @@
                         restrictions)
                     wafAclId=valueIfTrue(
                         wafAclId,
-                        (solution.WAF.Configured &&
-                            solution.WAF.Enabled &&
-                            ipAddressGroupsUsage["waf"]?has_content))
+                        wafPresent)
                 /]
                 [@cfResource
                     mode=listMode
@@ -304,77 +302,14 @@
                     dependencies=stageId
                 /]
 
-                [#if wafPresent && ipAddressGroupsUsage["waf"]?has_content ]
-                    [#assign wafGroups = [] ]
-                    [#assign wafRuleDefault =
-                                solution.WAF.RuleDefault?has_content?then(
-                                    solution.WAF.RuleDefault,
-                                    "ALLOW")]
-                    [#assign wafDefault =
-                                solution.WAF.Default?has_content?then(
-                                    solution.WAF.Default,
-                                    "BLOCK")]
-                    [#if solution.WAF.IPAddressGroups?has_content]
-                        [#list solution.WAF.IPAddressGroups as group]
-                            [#assign groupId = group?is_hash?then(
-                                            group.Id,
-                                            group)]
-                            [#if (ipAddressGroupsUsage["waf"][groupId])?has_content]
-                                [#assign usageGroup = ipAddressGroupsUsage["waf"][groupId]]
-                                [#if usageGroup.IsOpen]
-                                    [#assign wafRuleDefault =
-                                        solution.WAF.RuleDefault?has_content?then(
-                                            solution.WAF.RuleDefault,
-                                            "COUNT")]
-                                    [#assign wafDefault =
-                                            solution.WAF.Default?has_content?then(
-                                                solution.WAF.Default,
-                                                "ALLOW")]
-                                [/#if]
-                                [#if usageGroup.CIDR?has_content]
-                                    [#assign wafGroups +=
-                                                group?is_hash?then(
-                                                    [group],
-                                                    [{"Id" : groupId}]
-                                                )]
-                                [/#if]
-                            [/#if]
-                        [/#list]
-                    [#else]
-                        [#list ipAddressGroupsUsage["waf"]?values as usageGroup]
-                            [#if usageGroup.IsOpen]
-                                [#assign wafRuleDefault =
-                                    solution.WAF.RuleDefault?has_content?then(
-                                        solution.WAF.RuleDefault,
-                                        "COUNT")]
-                                [#assign wafDefault =
-                                        solution.WAF.Default?has_content?then(
-                                            solution.WAF.Default,
-                                            "ALLOW")]
-                            [/#if]
-                            [#if usageGroup.CIDR?has_content]
-                                [#assign wafGroups += [{"Id" : usageGroup.Id}]]
-                            [/#if]
-                        [/#list]
-                    [/#if]
-
-                    [#assign wafRules = []]
-                    [#list wafGroups as group]
-                        [#assign wafRules += [
-                                {
-                                    "Id" : "${formatWAFIPSetRuleId(group)}",
-                                    "Action" : "${(group.Action?upper_case)!wafRuleDefault}"
-                                }
-                            ]
-                        ]
-                    [/#list]
+                [#if wafPresent ]
                     [@createWAFAcl
                         mode=listMode
                         id=wafAclId
                         name=wafAclName
                         metric=wafAclName
-                        default=wafDefault
-                        rules=wafRules /]
+                        default=getWAFDefault(solution.WAF)
+                        rules=getWAFRules(solution.WAF) /]
                 [/#if]
             [/#if]
 
@@ -415,9 +350,7 @@
             [#if deploymentSubsetRequired("s3", true) && isPartOfCurrentDeploymentUnit(docsS3BucketId)]
                 [#assign docsS3IPWhitelist =
                     s3IPAccessCondition(
-                        getUsageCIDRs(
-                            "publish",
-                            solution.Publish.IPAddressGroups)) ]
+                        getGroupCIDRs(solution.Publish.IPAddressGroups)) ]
 
                 [@createBucketPolicy
                     mode=listMode

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -37,22 +37,7 @@
             },
             {
                 "Name" : "WAF",
-                "Children" : [
-                    {
-                        "Name" : "Enabled",
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "IPAddressGroups",
-                        "Default" : []
-                    },
-                    {
-                        "Name" : "Default"
-                    },
-                    {
-                        "Name" : "RuleDefault"
-                    }
-                ]
+                "Children" : wafChildConfiguration
             },
             {
                 "Name" : "CloudFront",

--- a/aws/templates/id/id_spa.ftl
+++ b/aws/templates/id/id_spa.ftl
@@ -1,6 +1,6 @@
 [#-- SPA --]
 
-[#-- Componets --]
+[#-- Components --]
 [#assign SPA_COMPONENT_TYPE = "spa"]
 
 [#assign componentConfiguration +=
@@ -12,22 +12,7 @@
             },
             {
                 "Name" : "WAF",
-                "Children" : [
-                    {
-                        "Name" : "Enabled",
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "IPAddressGroups",
-                        "Default" : []
-                    },
-                    {
-                        "Name" : "Default"
-                    },
-                    {
-                        "Name" : "RuleDefault"
-                    }
-                ]
+                "Children" : wafChildConfiguration
             },
             {
                 "Name" : "CloudFront",

--- a/aws/templates/segment/segment_s3.ftl
+++ b/aws/templates/segment/segment_s3.ftl
@@ -83,22 +83,8 @@
     /]
 
     [#if dataPublicEnabled ]
-
-        [#assign dataPublicCIDRList = [] ]
-
-        [#if ipAddressGroupsUsage["dataPublic"]?has_content ]
-            [#list dataPublicWhiteList as group]
-                [#assign groupId = group?is_hash?then(
-                                group.Id,
-                                group)]
-                
-                [#if (ipAddressGroupsUsage["dataPublic"][groupId])?has_content]
-                    [#assign dataPublicCIDRList +=  (ipAddressGroupsUsage["dataPublic"][groupId]).CIDR ]
-                [/#if]
-            [/#list]
-        [/#if]
     
-        [#assign dataPublicWhitelistCondition = s3IPAccessCondition(dataPublicCIDRList)]
+        [#assign dataPublicWhitelistCondition = s3IPAccessCondition(getGroupCIDRs(dataPublicIPAddressGroups)]
 
         [@createBucketPolicy
             mode=listMode

--- a/aws/templates/segment/segment_s3.ftl
+++ b/aws/templates/segment/segment_s3.ftl
@@ -84,7 +84,8 @@
 
     [#if dataPublicEnabled ]
     
-        [#assign dataPublicWhitelistCondition = s3IPAccessCondition(getGroupCIDRs(dataPublicIPAddressGroups)]
+        [#assign dataPublicWhitelistCondition =
+            s3IPAccessCondition(getGroupCIDRs(dataPublicIPAddressGroups, true)) ]
 
         [@createBucketPolicy
             mode=listMode

--- a/aws/templates/segment/segment_vpc.ftl
+++ b/aws/templates/segment/segment_vpc.ftl
@@ -300,8 +300,7 @@
                         "Port" : "ssh",
                         "CIDR" : 
                             (sshActive || sshStandalone)?then(
-                                getUsageCIDRs(
-                                    "ssh",
+                                getGroupCIDRs(
                                     (segmentObject.SSH.IPAddressGroups)!
                                         segmentObject.IPAddressGroups![]),
                                 []

--- a/aws/templates/solution/solution_ElasticSearch.ftl
+++ b/aws/templates/solution/solution_ElasticSearch.ftl
@@ -19,10 +19,7 @@
 
         [#assign storageProfile = getStorage(tier, component, "ElasticSearch")]
         [#assign volume = (storageProfile.Volumes["codeontap"])!{}]
-        [#assign esCIDRs =
-                    getUsageCIDRs(
-                        "es",
-                        solution.IPAddressGroups)]
+        [#assign esCIDRs = getGroupCIDRs(solution.IPAddressGroups) ]
         [#list zones as zone]
             [#assign zoneIP =
                 getExistingReference(

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -48,9 +48,8 @@
         [#else]
             [#list solution.Ports as port]
                 [#assign nextPort = port?is_hash?then(port.Port, port)]
-                [#assign portCIDRs = getUsageCIDRs(
-                                    nextPort,
-                                    port?is_hash?then(port.IPAddressGroups![], []))]
+                [#assign portCIDRs = getGroupCIDRs(
+                    port?is_hash?then(port.IPAddressGroups![], []))]
                 [#if portCIDRs?has_content]
                     [#assign ingressRules +=
                         [{


### PR DESCRIPTION
Experience has shown that the usage capability in IP Address Groups can
be replaced by using more granular address groups and configuring lists
in the solution. This is also more explicit as it is obvious from the
solution what is actually happening, rather than indirectly based on
usage.

As part of this change, mandatory subchildren are now supported. they
will be ignored if the parent doesn;'t exist, but checked for where
there are candidate values to consider.