### PR TITLE
Fix LB Healthcheck lookup

### DIFF
--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -164,11 +164,11 @@
                 
                 [#case "classic"]
                 
-                    [#if !healthCheckPort?has_content ]
-                        [@cfPreconditionFailed listMode "solution_lb" {} "No health check port provided" /]
+                    [#if healthCheckPort?has_content ]
+                        [#assign healthCheckPort = ports[solution.HealthCheckPort]]
+                    [#else]
+                        [@cfPreconditionFailed listMode "solution_lb" {} "No health check port provided" /]    
                     [/#if]
-
-                    [#assign healthCheckPort = ports[solution.HealthCheckPort]]
 
                     [#assign healthCheck = {
                         "Target" : healthCheckPort.HealthCheck.Protocol!healthCheckPort.Protocol + ":" 

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -20,6 +20,13 @@
 
             [#assign engine = solution.Engine]
 
+            [#assign healthCheckPort = "" ]
+            [#if engine == "classic" && solution.HealthCheckPort?has_content ]
+                [#assign healthCheckPort = ports[solution.HealthCheckPort]]
+            [#else]
+                [@cfPreconditionFailed listMode "solution_lb" {} "No health check port provided" /]    
+            [/#if]
+
             [#assign portProtocols = [] ]
             [#assign classicListeners = []]
 
@@ -164,11 +171,6 @@
                 
                 [#case "classic"]
                 
-                    [#if healthCheckPort?has_content ]
-                        [#assign healthCheckPort = ports[solution.HealthCheckPort]]
-                    [#else]
-                        [@cfPreconditionFailed listMode "solution_lb" {} "No health check port provided" /]    
-                    [/#if]
 
                     [#assign healthCheck = {
                         "Target" : healthCheckPort.HealthCheck.Protocol!healthCheckPort.Protocol + ":" 

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -21,10 +21,12 @@
             [#assign engine = solution.Engine]
 
             [#assign healthCheckPort = "" ]
-            [#if engine == "classic" && solution.HealthCheckPort?has_content ]
-                [#assign healthCheckPort = ports[solution.HealthCheckPort]]
-            [#else]
-                [@cfPreconditionFailed listMode "solution_lb" {} "No health check port provided" /]    
+            [#if engine == "classic" ]
+                [#if solution.HealthCheckPort?has_content ]
+                    [#assign healthCheckPort = ports[solution.HealthCheckPort]]
+                [#else]
+                    [@cfPreconditionFailed listMode "solution_lb" {} "No health check port provided" /]    
+                [/#if]
             [/#if]
 
             [#assign portProtocols = [] ]


### PR DESCRIPTION
The health check configuration is on the LB component instead of the listener subcomponent. This fix moves the health check lookup to the LB component so that its properties can be looked up properly

