### PR TITLE
Cleanup temporary file management

### DIFF
--- a/aws/cleanupContext.sh
+++ b/aws/cleanupContext.sh
@@ -6,7 +6,6 @@
 [[ -z "${GENERATION_CONTEXT_DEFINED_LOCAL}" ]] && return 0
 
 if [[ -z "${GENERATION_DEBUG}" ]]; then
-  [[ -n "${GENERATION_DATA_DIR}" ]] && cleanup "${GENERATION_DATA_DIR}"
   [[ -n "${GENERATION_TMPDIR}" ]] && rm -rf "${GENERATION_TMPDIR}"
 fi
 

--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -302,7 +302,8 @@ function process_template() {
   args+=("-v" "configurationReference=${configuration_reference}")
 
   # Directory for temporary files
-  local tmpdir="$(getTempDir "create_template_XXX")"
+  pushTempDir "create_template_XXXX"
+  local tmp_dir="$(getTopTempDir)"
 
   # Perform each pass
   for pass in "${passes[@]}"; do
@@ -324,11 +325,11 @@ function process_template() {
       pass_alternative_prefix="${pass_alternative:+${pass_alternative}-}"
 
       local output_file="${cf_dir}/${output_prefix}${pass_alternative_prefix}${pass_suffix[${pass}]}"
-      local template_result_file="${tmpdir}/${output_prefix}${pass_alternative_prefix}${pass_suffix[${pass}]}"
+      local template_result_file="${tmp_dir}/${output_prefix}${pass_alternative_prefix}${pass_suffix[${pass}]}"
       if [[ ! -f "${output_file}" ]]; then
         # Include account prefix
         local output_file="${cf_dir}/${output_prefix_with_account}${pass_alternative_prefix}${pass_suffix[${pass}]}"
-        local template_result_file="${tmpdir}/${output_prefix_with_account}${pass_alternative_prefix}${pass_suffix[${pass}]}"
+        local template_result_file="${tmp_dir}/${output_prefix_with_account}${pass_alternative_prefix}${pass_suffix[${pass}]}"
       fi
 
       ${GENERATION_DIR}/freemarker.sh \

--- a/aws/rebootRDSDatabase.sh
+++ b/aws/rebootRDSDatabase.sh
@@ -77,6 +77,8 @@ done
 # Set up the context
 . "${GENERATION_DIR}/setContext.sh"
 
+status_file="$(getTopTempDir)/reboot_rds_status.txt"
+
 # Ensure we are in the right place
 checkInSegmentDirectory
 
@@ -94,12 +96,12 @@ if [ "$RESULT" -ne 0 ]; then exit; fi
 
 if [[ "${WAIT}" == "true" ]]; then
     while true; do
-        aws --region ${REGION} rds describe-db-instances --db-instance-identifier ${DB_INSTANCE_IDENTIFIER} 2>/dev/null | grep "DBInstanceStatus" > STATUS.txt
-        cat STATUS.txt
-        grep "available" STATUS.txt >/dev/null 2>&1
+        aws --region ${REGION} rds describe-db-instances --db-instance-identifier ${DB_INSTANCE_IDENTIFIER} 2>/dev/null | grep "DBInstanceStatus" > "${status_file}"
+        cat "${status_file}"
+        grep "available" "${status_file}" >/dev/null 2>&1
         RESULT=$?
         if [ "$RESULT" -eq 0 ]; then break; fi
-        grep "rebooting" STATUS.txt  >/dev/null 2>&1
+        grep "rebooting" "${status_file}"  >/dev/null 2>&1
         RESULT=$?
         if [ "$RESULT" -ne 0 ]; then break; fi
         sleep $DELAY

--- a/aws/snapshotRDSDatabase.sh
+++ b/aws/snapshotRDSDatabase.sh
@@ -92,6 +92,8 @@ done
 # Set up the context
 . "${GENERATION_DIR}/setContext.sh"
 
+status_file="$(getTopTempDir)/snapshot_rds_status.txt"
+
 # Ensure we are in the right place
 checkInSegmentDirectory
 
@@ -136,12 +138,12 @@ fi
 RESULT=1
 if [[ "${WAIT}" == "true" ]]; then
     while true; do
-        aws --region ${REGION} rds describe-db-snapshots --db-snapshot-identifier ${DB_SNAPSHOT_IDENTIFIER} 2>/dev/null | grep "Status" > STATUS.txt
-        cat STATUS.txt
-        grep "available" STATUS.txt >/dev/null 2>&1
+        aws --region ${REGION} rds describe-db-snapshots --db-snapshot-identifier ${DB_SNAPSHOT_IDENTIFIER} 2>/dev/null | grep "Status" > "${status_file}"
+        cat "${status_file}"
+        grep "available" "${status_file}" >/dev/null 2>&1
         RESULT=$?
         if [ "$RESULT" -eq 0 ]; then break; fi
-        grep "creating" STATUS.txt  >/dev/null 2>&1
+        grep "creating" "${status_file}"  >/dev/null 2>&1
         RESULT=$?
         if [ "$RESULT" -ne 0 ]; then break; fi
         sleep $DELAY

--- a/aws/syncAccountBuckets.sh
+++ b/aws/syncAccountBuckets.sh
@@ -61,6 +61,8 @@ done
 # Set up the context
 . "${GENERATION_DIR}/setContext.sh"
 
+status_file="$(getTopTempDir)/sync_account_bucket_status.txt"
+
 checkInAccountDirectory
 
 # Locate the bucket names
@@ -76,7 +78,7 @@ pushd ${ACCOUNT_DIR}  > /dev/null 2>&1
 
 # Confirm access to the code bucket
 if [[ "${CHECK}" == "true" ]]; then
-    aws --region ${ACCOUNT_REGION} s3 ls s3://${CODE_BUCKET}/ > temp_code_access.txt
+    aws --region ${ACCOUNT_REGION} s3 ls s3://${CODE_BUCKET}/ > "${status_file}"
     RESULT=$?
     [[ "$RESULT" -ne 0 ]] &&
         fatal "Can't access the code bucket. Does the service role for the server include access to the \"${ACCOUNT}\" code bucket? If windows, is a profile matching the account been set up?"
@@ -94,7 +96,7 @@ fi
 
 # Confirm access to the credentials bucket
 if [[ "${CHECK}" == "true" ]]; then
-    aws --region ${ACCOUNT_REGION} s3 ls s3://${CREDENTIALS_BUCKET}/ > temp_credential_access.txt
+    aws --region ${ACCOUNT_REGION} s3 ls s3://${CREDENTIALS_BUCKET}/ > "${status_file}"
     RESULT=$?
     [[ "$RESULT" -ne 0 ]] &&
         fatal "Can't access the credentials bucket. Does the service role for the server include access to the \"${ACCOUNT}\" credentials bucket? If windows, is a profile matching the account been set up?"

--- a/aws/templates/account/account_s3.ftl
+++ b/aws/templates/account/account_s3.ftl
@@ -54,7 +54,7 @@
                         "#",
                         "function initialise_registries() {",
                         "  info \"Initialising the registry bucket ...\"",
-                        "  local registry_marker=\"$\{ACCOUNT_DIR}/temp_registry\"",
+                        "  local registry_marker=\"$(getTopTempDir)/registry\"",
                         "  touch \"$\{registry_marker}\"",
                         "  for registry in \"$@\"; do",
                         "    aws --region \"$\{ACCOUNT_REGION}\" s3 cp \"$\{registry_marker}\" \"s3://" +

--- a/aws/templates/segment/segment_cmk.ftl
+++ b/aws/templates/segment/segment_cmk.ftl
@@ -79,7 +79,7 @@
                     "function manage_oai_credentials() {"
                     "  info \"Checking OAI credentials ...\"",
                     "  #",
-                    "  local oai_file=\"./temp_oai.json\"",
+                    "  local oai_file=\"$(getTopTempDir)/oai.json\"",
                     "  update_oai_credentials" + " " +
                         "\"" + regionId + "\" " +
                         "\"" + productName + "-" + segmentName + "\" " +


### PR DESCRIPTION
All temporary files are now created in a temporary directory, and more
use is made of nested temporary directories to assist in debugging the
flow of function calls.

The composite_* files have been moved into a "cache" directory at the
root of the tree in preparation for improvements in the use of cached
information.

The templates for temporary files now used four X's. With only three,
there was occassionally a temporary file called "aux" created which is
not a valid file/directory name on windows.