### PR TITLE
asFile references are now relative to ROOT_DIR

### DIFF
--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -141,7 +141,7 @@ function assemble_settings() {
 
     tmp_file="$( getTempFile "account_appsettings_XXXX.json" "${tmp_dir}")"
     readarray -t setting_files < <(find . -type f -name "appsettings.json" )
-    convertFilesToJSONObject "AppSettings Accounts" "${name}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
+    convertFilesToJSONObject "AppSettings Accounts" "${name}" "" "${setting_files[@]}" > "${tmp_file}" || return 1
     tmp_file_list+=("${tmp_file}")
     popd > /dev/null
   done
@@ -160,26 +160,35 @@ function assemble_settings() {
     pushd "$(filePath "${product_file}")/appsettings" > /dev/null 2>&1 || continue
 
     # Appsettings
-    readarray -t setting_files < <(find . -type f \( -not -name "*build.json" -and -not -name "*.ref" -and -not -path "*/asFile/*" \) )
+    readarray -t setting_files < <(find . -type f \( \
+      -not -name "*build.json" \
+      -and -not -name "*.ref" \
+      -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
       tmp_file="$( getTempFile "product_appsettings_XXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "AppSettings Products" "${name}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
+      convertFilesToJSONObject "AppSettings Products" "${name}" "" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
 
     # Builds
-    readarray -t setting_files < <(find . -type f \( -name "*build.json" -and -not -path "*/asFile/*" \) )
+    readarray -t setting_files < <(find . -type f \( \
+      -name "*build.json" \
+      -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
       tmp_file="$( getTempFile "product_builds_XXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Builds Products" "${name}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
+      convertFilesToJSONObject "Builds Products" "${name}" "" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
 
     # asFiles
-    readarray -t setting_files < <(find . -type f \( -path "*/asFile/*" \) )
+    readarray -t setting_files < <(find . -type f \( \
+      \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
       tmp_file="$( getTempFile "product_appsettings_asfile_XXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "AppSettings Products" "${name}" "true" "${setting_files[@]}" > "${tmp_file}" || return 1
+      convertFilesToJSONObject "AppSettings Products" "${name}" "${ROOT_DIR}" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
 
@@ -198,18 +207,23 @@ function assemble_settings() {
     pushd "$(findGen3ProductInfrastructureDir "${root_dir}" "${name}")/credentials" > /dev/null 2>&1 || continue
 
     # Credentials
-    readarray -t setting_files < <(find . -type f \( -name "credentials.json" -and -not -path "*/asFile/*" \) )
+    readarray -t setting_files < <(find . -type f \( \
+      -name "credentials.json" \
+      -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
       tmp_file="$( getTempFile "product_credentials_XXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Credentials Products" "${name}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
+      convertFilesToJSONObject "Credentials Products" "${name}" "" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
 
     # asFiles
-    readarray -t setting_files < <(find . -type f \( -path "*/asFile/*" \) )
+    readarray -t setting_files < <(find . -type f \( \
+      \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
       tmp_file="$( getTempFile "product_credentials_asfile_XXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Credentials Products" "${name}" "true" "${setting_files[@]}" > "${tmp_file}" || return 1
+      convertFilesToJSONObject "Credentials Products" "${name}" "${ROOT_DIR}" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
 
@@ -222,15 +236,6 @@ function assemble_settings() {
 
   popTempDir
   return ${return_status}
-}
-
-function assemble_credentials() {
-  local result_file="${1:-${COMPOSITE_CREDENTIALS}}"
-
-  pushd "${PRODUCT_CREDENTIALS_DIR}" > /dev/null
-  readarray -t files < <(find -name credentials.json)
-  convertFilesToJSONObject "" "${PRODUCT}" "${files[@]}" > "${result_file}"
-  popd > /dev/null
 }
 
 function assemble_composite_stack_outputs() {

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -2046,6 +2046,9 @@
         [
             "addToArray" + " " +
                "\"" + "dirsToCheck"                 + "\"" + " " +
+               "\"" + "$\{ROOT_DIR}" + "\"",
+            "addToArray" + " " +
+               "\"" + "dirsToCheck"                 + "\"" + " " +
                "\"" + "$\{PRODUCT_APPSETTINGS_DIR}" + "\"",
             "addToArray" + " " +
                "\"" + "dirsToCheck"                 + "\"" + " " +

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -677,7 +677,7 @@ function addJSONAncestorObjects() {
 function convertFilesToJSONObject() {
   local base_ancestors=($1); shift
   local prefixes=($1); shift
-  local as_file="$1";shift
+  local as_file_root="$1";shift
   local files=("$@")
 
   pushTempDir "convertFilesToJSONObject_XXXX"
@@ -693,9 +693,13 @@ function convertFilesToJSONObject() {
     local source_file="${file}"
     local attribute="$( fileBase "${file}" | tr "-" "_" )"
 
-    if [[ "${as_file}" == "true" ]]; then
+    if [[ -n "${as_file_root}" ]]; then
+      local file_name="$(fileName "${file}")"
+      local file_path="$(filePath "${file}")"
+      local file_absolute_path="$(cd "${file_path}"; pwd)"
+      local file_root_relative_path="${file_absolute_path##${as_file_root}/}"
       source_file="$(getTempFile "asfile_${attribute,,}_XXXX.json" "${tmp_dir}")"
-      echo -n "{\"${attribute^^}\" : {\"Value\" : \"$(fileName "${file}")\", \"AsFile\" : \"${file}\" }}" > "${source_file}" || return 1
+      echo -n "{\"${attribute^^}\" : {\"Value\" : \"$(fileName "${file}")\", \"AsFile\" : \"${file_root_relative_path}/${file_name}\" }}" > "${source_file}" || return 1
     else
       case "$(fileExtension "${file}")" in
         json)


### PR DESCRIPTION
To make it easier to have files coming from various directories once we
move to shared directories, change the processing of asFiles to be
relative to the root of the cmdb.

This allows the absolute path to vary (e.g. between workspaces for
different Jenkins jobs) but a prepared template should still work.

The commit also removes an unused function to assemble credentials,
which is done as part of assembling the settings.