### PR TITLE
Moving Jenkins config to JenkinsEnv to avoid builtin properties

### DIFF
--- a/aws/templates/container/container_jenkins.ftl
+++ b/aws/templates/container/container_jenkins.ftl
@@ -11,15 +11,15 @@
     /]
 
     [#-- Validate that the appropriate settings have been provided for the container to work --]
-    [#switch settings["JENKINS_SECURITYREALM"]!""]
+    [#switch settings["JENKINSENV_SECURITYREALM"]!""]
         [#case "local"]
-            [#if !(settings["JENKINS_USER"]?has_content && settings["JENKINS_PASS"]?has_content) ]
+            [#if !(settings["JENKINSENV_USER"]?has_content && settings["JENKINSENV_PASS"]?has_content) ]
                 [@cfException
                     mode=listMode
                     description="Login Details not provided"
                     context=component
                     detail={
-                        "Jenkins" : {
+                        "JenkinsEnv" : {
                             "User" : "",
                             "Pass" : ""
                         }
@@ -49,7 +49,7 @@
                 description="Security Realm Not Configured"
                 context=component
                 detail={ 
-                    "Jenkins" : {
+                    "JenkinsEnv" : {
                         "SecurityRealm" : "local|github"
                     }
                 }


### PR DESCRIPTION
Epic https://github.com/codeontap/codeontap/issues/14

JENKINS itself uses the JENKINS_environment variables for different purposes. We should probably move the environment specific configuration to another location to ensure they don't cause issues with Jenkins