### PR TITLE
Support environment and segment in names

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1284,8 +1284,8 @@
     "Wildcard": true,
     "IncludeInHost": {
       "Product": false,
-      "Environment": false,
-      "Segment": true,
+      "Environment": true,
+      "Segment": false,
       "Tier": false,
       "Component": true,
       "Instance": true,

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -156,7 +156,7 @@
                 formatOccurrenceBucketName(occurrence))]
 
     [#if certificatePresent ]
-        [#local certificateObject = getCertificateObject(solution.Certificate!"", segmentId, segmentName)]
+        [#local certificateObject = getCertificateObject(solution.Certificate!"", segmentQualifiers)]
         [#local hostName = getHostName(certificateObject, occurrence)]
         [#local certificateId = formatDomainCertificateId(certificateObject, hostName) ]
 

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -187,7 +187,7 @@
     [#local id = formatResourceId(AWS_ALB_LISTENER_RESOURCE_TYPE, core.Id) ]
 
     [#if (sourcePort.Certificate)!false ]
-        [#local certificateObject = getCertificateObject(solution.Certificate, segmentId, segmentName) ]
+        [#local certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers) ]
         [#local hostName = getHostName(certificateObject, occurrence) ]
 
         [#local fqdn = formatDomainName(hostName, certificateObject.Domain.Name)]

--- a/aws/templates/id/id_spa.ftl
+++ b/aws/templates/id/id_spa.ftl
@@ -83,7 +83,7 @@
     [#assign cfName = formatComponentCFDistributionName(core.Tier, core.Component, occurrence)]
 
     [#if solution.Certificate.Configured && solution.Certificate.Enabled ]
-            [#local certificateObject = getCertificateObject(solution.Certificate!"", segmentId, segmentName) ]
+            [#local certificateObject = getCertificateObject(solution.Certificate!"", segmentQualifiers) ]
             [#local hostName = getHostName(certificateObject, occurrence) ]
             [#local fqdn = formatDomainName(hostName, certificateObject.Domain.Name)]
     [#else]

--- a/aws/templates/name/start.ftl
+++ b/aws/templates/name/start.ftl
@@ -40,18 +40,17 @@
 
 [#-- Format segment short name --]
 [#function formatSegmentShortName extensions...]
-    [#return formatName(
-                productId,
-                segmentId,
-                extensions)]
+    [#return formatName(shortNamePrefixes, extensions) ]
 [/#function]
 
 [#-- Format segment name --]
 [#function formatSegmentFullName extensions...]
-    [#return formatName(
-                productName,
-                segmentName,
-                extensions)]
+    [#return formatName(fullNamePrefixes,  extensions) ]
+[/#function]
+
+[#-- Format environment name --]
+[#function formatEnvironmentFullName extensions...]
+    [#return formatName(fullNamePrefixes[0..1],  extensions) ]
 [/#function]
 
 [#-- Format a component short name - based on ids not names --]
@@ -97,11 +96,7 @@
 
 [#-- Format a segment path --]
 [#function formatSegmentPath absolute extensions...]
-    [#return formatPath(
-                absolute,
-                productName,
-                segmentName,
-                extensions)]
+    [#return formatPath(absolute, fullNamePrefixes, extensions)]
 [/#function]
 
 [#function formatSegmentRelativePath extensions...]

--- a/aws/templates/policy/policy_dynamodb.ftl
+++ b/aws/templates/policy/policy_dynamodb.ftl
@@ -3,7 +3,7 @@
 [#function getDynamodbStatement actions tables=[] streams=[] indexes=[] principals="" conditions=""]
     [#local result = [] ]
     [#-- TODO(mfl): for now aws doesn't support partitioning on the basis of prefix --]
-    [#-- local tablePrefix = productName + "_" + segmentName + "_" --]
+    [#-- local tablePrefix = fullNamePrefixes?join("_") + "_" --]
     [#local tablePrefix = "" ]
     [#if tables?has_content]
         [#list asArray(tables) as table]

--- a/aws/templates/resource/resource_sns.ftl
+++ b/aws/templates/resource/resource_sns.ftl
@@ -53,7 +53,7 @@
 [/#macro]
 
 [#macro createSegmentSNSTopic mode id extensions...]
-    [@createSNSTopic mode, id, formatName(productName, segmentName, extensions) /]
+    [@createSNSTopic mode, id, formatSegmentFullName(extensions) /]
 [/#macro]
 
 [#macro createProductSNSTopic mode id extensions...]

--- a/aws/templates/resource/start.ftl
+++ b/aws/templates/resource/start.ftl
@@ -230,12 +230,6 @@
             ],
             []
         ) +
-        segmentId?has_content?then(
-            [
-                { "Key" : "cot:segment", "Value" : segmentName }
-            ],
-            []
-        ) +
         environmentId?has_content?then(
             [
                 { "Key" : "cot:environment", "Value" : environmentName }
@@ -245,6 +239,12 @@
         [
             { "Key" : "cot:category", "Value" : categoryName }
         ] +
+        segmentId?has_content?then(
+            [
+                { "Key" : "cot:segment", "Value" : segmentName }
+            ],
+            []
+        ) +
         tier?has_content?then(
             [
                 { "Key" : "cot:tier", "Value" : getTierName(tier) }

--- a/aws/templates/segment/segment_cmk.ftl
+++ b/aws/templates/segment/segment_cmk.ftl
@@ -8,7 +8,7 @@
         [@createCMK
             mode=listMode
             id=cmkId
-            description=formatName(productName,segmentName)
+            description=formatSegmentFullName()
             statements=
                 [
                     getPolicyStatement(
@@ -25,12 +25,12 @@
         [@createCMKAlias
             mode=listMode
             id=cmkAliasId
-            name=formatName("alias/" + productName, segmentName)
+            name=formatName("alias/" + formatSegmentFullName())
             cmkId=cmkId
         /]
     [/#if]
     [#if deploymentSubsetRequired("epilogue", false)]
-        [#if sshPerSegment]
+        [#if sshPerEnvironment]
             [#-- Make sure SSH credentials are in place --]
             [@cfScript
                 mode=listMode
@@ -40,20 +40,20 @@
                         "  info \"Checking SSH credentials ...\"",
                         "  #",
                         "  # Create SSH credential for the segment",
-                        "  mkdir -p \"$\{SEGMENT_CREDENTIALS_DIR}\"",
-                        "  create_pki_credentials \"$\{SEGMENT_CREDENTIALS_DIR}\" || return $?",
+                        "  mkdir -p \"$\{ENVIRONMENT_CREDENTIALS_DIR}\"",
+                        "  create_pki_credentials \"$\{ENVIRONMENT_CREDENTIALS_DIR}\" || return $?",
                         "  #",
                         "  # Update the credential",
                         "  update_ssh_credentials" + " " +
                             "\"" + regionId + "\" " +
-                            "\"" + productName + "-" + segmentName + "\" " +
-                            "\"$\{SEGMENT_CREDENTIALS_DIR}/aws-ssh-crt.pem\" || return $?",
-                        "  [[ -f \"$\{SEGMENT_CREDENTIALS_DIR}/aws-ssh-prv.pem.plaintext\" ]] && ",
+                            "\"" + formatEnvironmentFullName() + "\" " +
+                            "\"$\{ENVIRONMENT_CREDENTIALS_DIR}/aws-ssh-crt.pem\" || return $?",
+                        "  [[ -f \"$\{ENVIRONMENT_CREDENTIALS_DIR}/aws-ssh-prv.pem.plaintext\" ]] && ",
                         "    { encrypt_file" + " " +
                                "\"" + regionId + "\"" + " " +
                                "segment" + " " +
-                               "\"$\{SEGMENT_CREDENTIALS_DIR}/aws-ssh-prv.pem.plaintext\"" + " " +
-                               "\"$\{SEGMENT_CREDENTIALS_DIR}/aws-ssh-prv.pem\" || return $?; }",
+                               "\"$\{ENVIRONMENT_CREDENTIALS_DIR}/aws-ssh-prv.pem.plaintext\"" + " " +
+                               "\"$\{ENVIRONMENT_CREDENTIALS_DIR}/aws-ssh-prv.pem\" || return $?; }",
                         "  return 0"
                         "}",
                         "#",
@@ -61,8 +61,8 @@
                         "  delete)",
                         "    delete_ssh_credentials " + " " +
                             "\"" + regionId + "\" " +
-                            "\"" + productName + "-" + segmentName + "\" || return $?",
-                        "    delete_pki_credentials \"$\{SEGMENT_CREDENTIALS_DIR}\" || return $?",
+                            "\"" + formatEnvironmentFullName() + "\" || return $?",
+                        "    delete_pki_credentials \"$\{ENVIRONMENT_CREDENTIALS_DIR}\" || return $?",
                         "    ;;",
                         "  create|update)",
                         "    manage_ssh_credentials || return $?",
@@ -82,7 +82,7 @@
                     "  local oai_file=\"$(getTopTempDir)/oai.json\"",
                     "  update_oai_credentials" + " " +
                         "\"" + regionId + "\" " +
-                        "\"" + productName + "-" + segmentName + "\" " +
+                        "\"" + formatSegmentFullName() + "\" " +
                         "\"$\{oai_file}\" || return $?",
                     "  #",
                     "  oai_id=$(jq -r \".Id\" < \"$\{oai_file}\") || return $?",
@@ -99,7 +99,7 @@
                     "  delete)",
                     "  delete_oai_credentials" + " " +
                         "\"" + regionId + "\" " +
-                        "\"" + productName + "-" + segmentName + "\" || return $?",
+                        "\"" + formatSegmentFullName() + "\" || return $?",
                     "  rm -f \"$\{pseudo_stack_file}\"",
                     "    ;;",
                     "  create|update)",

--- a/aws/templates/segment/segment_dns.ftl
+++ b/aws/templates/segment/segment_dns.ftl
@@ -8,10 +8,10 @@
         properties=
             {
                 "HostedZoneConfig" : {
-                    "Comment" : formatName(productName, segmentName)
+                    "Comment" : formatSegmentFullName()
                 },
                 "HostedZoneTags" : getCfTemplateCoreTags(),
-                "Name" : segmentName + "." + productName + ".internal",
+                "Name" : concatenate(fullNamePrefixes?reverse + ["internal"], "."),
                 "VPCs" : [                
                     {
                         "VPCId" : getReference(formatVPCId()),

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -394,7 +394,12 @@
                             "IamInstanceProfile" : { "Ref" : ec2InstanceProfileId },
                             "InstanceInitiatedShutdownBehavior" : "stop",
                             "InstanceType": processorProfile.Processor,
-                            "KeyName": productName + sshPerSegment?then("-" + segmentName,""),
+                            "KeyName":
+                                valueIfTrue(
+                                    formatEnvironmentFullName(),
+                                    sshPerEnvironment,
+                                    productName
+                                ),
                             "Monitoring" : false,
                             "NetworkInterfaces" : [
                                 {

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -318,7 +318,12 @@
                 properties=
                     getBlockDevices(storageProfile) +
                     {
-                        "KeyName": productName + sshPerSegment?then("-" + segmentName,""),
+                        "KeyName":
+                            valueIfTrue(
+                                formatEnvironmentFullName(),
+                                sshPerEnvironment,
+                                productName
+                            ),
                         "ImageId": regionObject.AMIs.Centos.ECS,
                         "InstanceType": processorProfile.Processor,
                         "SecurityGroups" : 

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -70,7 +70,7 @@
                             segmentObject.Network.CIDR.Address + "/" +segmentObject.Network.CIDR.Mask
                         )) ]
 
-                [#assign certificateObject = getCertificateObject(solution.Certificate, segmentId, segmentName, sourcePort.Id, sourcePort.Name) ]
+                [#assign certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers, sourcePort.Id, sourcePort.Name) ]
                 [#assign hostName = getHostName(certificateObject, subOccurrence) ]
                 [#assign certificateId = formatDomainCertificateId(certificateObject, hostName) ]
 

--- a/aws/templates/solution/solution_spa.ftl
+++ b/aws/templates/solution/solution_spa.ftl
@@ -12,7 +12,7 @@
         [#assign resources = occurrence.State.Resources]
         [#assign solution = occurrence.Configuration.Solution ]
 
-        [#assign certificateObject = getCertificateObject(solution.Certificate, segmentId, segmentName) ]
+        [#assign certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers) ]
         [#assign hostName = getHostName(certificateObject, occurrence) ]
         [#assign dns = formatDomainName(hostName, certificateObject.Domain.Name) ]
         [#assign certificateId = formatDomainCertificateId(certificateObject, hostName) ]


### PR DESCRIPTION
Move to using the environment by default the segment only if it differs
from the environment and does not have the value of "default".

The next stage will be to change the cmdb layout to explicitly include
the environment in the tree to allow for multi-segment environments.

NOTE: This change may need adjustment to segment.json files where the
environment is not the same as the segment.