### PR TITLE
Delegated Container Deployments and IAM Admin Roles

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -2112,6 +2112,25 @@
         ] ]
 [/#function]
 
+[#function pseudoStackOutputScript description outputs filesuffix="pseudo" ]
+    [#local outputString = ""]
+    [#list outputs as key,value ]
+        [#local outputString += 
+          "\"" + key + "\" \"" + value + "\" " 
+        ]
+    [/#list]
+
+    [#return 
+        [
+            "create_pseudo_stack" + " " +
+            "\"" + description + "\"" + " " +
+            "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-" + filesuffix + "-stack.json\" " +
+            outputString + " || return $?"
+        ]
+    ]
+
+[/#function]
+
 [#-- WAF functions --]
 
 [#function isWAFPresent configuration={} ]

--- a/aws/templates/container/container_codeontap.ftl
+++ b/aws/templates/container/container_codeontap.ftl
@@ -1,0 +1,15 @@
+[#case "codeontap"]
+    [#assign settings = context.DefaultEnvironment]
+
+    [@Attributes image="gen3-jenkins-slave" version="latest" /]
+
+    [#-- Validate that the appropriate settings have been provided for the container to work --]
+    [#if settings["CODEONTAPVOLUME"]?has_content ]
+        [@Volume "codeontap" "/var/opt/codeontap/" settings["CODEONTAPVOLUME"] /]
+    [/#if]  
+
+    [@Policy
+        globalAdministratorAccess()
+    /]
+
+    [#break]

--- a/aws/templates/container/container_jenkins.ftl
+++ b/aws/templates/container/container_jenkins.ftl
@@ -4,9 +4,10 @@
     [#assign settings = context.DefaultEnvironment]
 
     [@Policy ecsTaskAllPermission() /]
-
+    
     [@Settings {
-            "ECS_ARN" :  getExistingReference(ecsId)
+            "ECS_ARN" :  getExistingReference(ecsId),
+            "MAXMEMORY" : container.MemoryReservation
         }
     /]
 

--- a/aws/templates/policy/policy_global.ftl
+++ b/aws/templates/policy/policy_global.ftl
@@ -1,0 +1,12 @@
+[#function globalAdministratorAccess ]
+    [#return
+        [
+            getPolicyStatement(
+                [
+                    "*"
+                ]
+            )
+        ]
+    ]
+[/#function]
+

--- a/aws/templates/policy/policy_iam.ftl
+++ b/aws/templates/policy/policy_iam.ftl
@@ -1,0 +1,14 @@
+[#function iamPassRolePermission role ]
+    [#return
+        [
+            getPolicyStatement(
+                [
+                    "iam:GetRole",
+                    "iam:PassRole"
+                ],
+                role
+            )
+        ]
+    ]
+[/#function]
+


### PR DESCRIPTION
Epic https://github.com/codeontap/codeontap/issues/14

**Delegated Container Deployment**
Jenkins has the ability to provision slave's on demand using an ECS plugin which creates ecs tasks using the native AWS API. 

To do this you need to essentially create an ECS Task Definition within the Jenkins configuration. Since the properties and configuration are pretty much the same as a cloudformation Task definition we can use our existing Task configuration to generate the configuration file required by Jenkins and then use a groovy init jenkins script to read this file and create the task in the Jenkins config. 

This PR adds a new configuration Property to ECS tasks, DelegateDeployment (defaults to false). When this is set to true, all cloudformation components except the Task Definition (IAM roles, Log Groups etc) will be added to a cloudformation template and created as per our standard process.

The task definition will be moved to a config file and uploaded to the Ops bucket as per the standard process for generated config file 

You can then link to the Delegated Deployment Task with the role of deploy and this will provide the IAM policy and Attributes required to provision the Task. 

**IAM Policies**
This PR also includes two new IAM policy functions
- globalAdministratorAccess - Full Admin Access - This is used by the codeontap container fragment for deployments 
- iamPassRolePermission - With this permission applied to a Role, services using this role can pass the specified role to other services. This is used in Delegated deployments of containers that have task roles assigned to them, the service calling ECS to create the task definition needs the permissions to pass the role to the task definition. 

**Pseduo Stack output script**
Added a Pseduo Stack script function to generate the script body needed to create Pseduo stacks. I added it during the work I was doing but found that it wasn't required yet. Can be used in furture PR's