### PR TITLE
Bug Fix - Composite Stack output file not found

### DIFF
--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -239,7 +239,6 @@ function assemble_settings() {
 }
 
 function assemble_composite_stack_outputs() {
-  local result_file="${1:-${COMPOSITE_STACK_OUTPUTS}}"
 
   # Create the composite stack outputs
   local restore_nullglob=$(shopt -p nullglob)
@@ -285,7 +284,7 @@ function assemble_composite_stack_outputs() {
     debug "MODIFIED_STACK_OUTPUTS=${modified_stack_array[*]}"
     ${GENERATION_DIR}/manageJSON.sh -f "[.[].Stacks | select(.!=null) | .[].Outputs | select(.!=null) ]" -o ${COMPOSITE_STACK_OUTPUTS} "${modified_stack_array[@]}"
   else
-    echo "[]" > ${result_file}
+    echo "[]" > ${COMPOSITE_STACK_OUTPUTS}
   fi
 
   popTempDir


### PR DESCRIPTION
When provisioning a new account the stack outputs file is empty. currently this is failing because the COMPOSITE_STACK_OUTPUTS variable has not been defined at the start of the function. 
