### PR TITLE
fix for IP Address Group action lookup

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -2136,7 +2136,7 @@
     [#list configuration.IPAddressGroups as group]
         [#local addressGroup = getIPAddressGroup(group) ]
         [#if ! addressGroup.IsOpen]
-            [#local action = (group.Action?upper_case)!wafRuleDefault ]
+            [#local action = (addressGroup.Action?upper_case)!wafRuleDefault ]
             [#if (wafDefault == "ALLOW") && (action == "ALLOW") ]
                 [#-- more useful to count if default is allow --]
                 [#local action = "COUNT" ]


### PR DESCRIPTION
Minor fix for IPAddress Group action lookup. 

The lookup at the moment is currently using the raw group array instead of the IP Address Group that has been looked up