### PR TITLE
Introduce separate environment directories

### DIFF
--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -44,7 +44,7 @@ function add_standard_pairs_to_stack() {
   local input_file="$1"; shift
   local output_file="$1"; shift
 
-  pushTempDir "add_standard_pairs_to_stack_XXXX"
+  pushTempDir "${FUNCNAME[0]}_XXXX"
   local result_file="$(getTopTempDir)/add_standard_pairs_to_stack.json"
   local return_status
 
@@ -71,7 +71,7 @@ function create_pseudo_stack() {
   local file="$1"; shift
   local pairs=("$@")
 
-  pushTempDir "create_pseudo_stack_XXXX"
+  pushTempDir "${FUNCNAME[0]}_XXXX"
   local tmp_file="$(getTopTempDir)/create_pseudo_stack.json"
   local return_status
 
@@ -113,11 +113,74 @@ EOF
   return ${return_status}
 }
 
-function assemble_settings() {
-  local result_file="${1:-${COMPOSITE_SETTINGS}}";shift
-  local root_dir="${1:-${ROOT_DIR}}"
+function convertFilesToJSONObject() {
+  local base_ancestors=($1); shift
+  local prefixes=($1); shift
+  local root_dir="$1";shift
+  local as_file="$1";shift
+  local files=("$@")
 
-  pushTempDir "assemble_settings_XXXX"
+  pushTempDir "${FUNCNAME[0]}_XXXX"
+  local tmp_dir="$(getTopTempDir)"
+  local base_file="${tmp_dir}/base.json"
+  local processed_files=("${base_file}")
+  local return_status
+
+  echo -n "{}" > "${base_file}"
+
+  for file in "${files[@]}"; do
+
+    local file_name="$(fileName "${file}")"
+    local file_path="$(filePath "${file}")"
+    local file_absolute_path="$(cd "${file_path}"; pwd)"
+    local file_root_relative_path="${file_absolute_path##${root_dir}/}"
+    local relative_file="${file_root_relative_path}/${file_name}"
+
+    local source_file="${file}"
+    local attribute="$( fileBase "${file}" | tr "-" "_" )"
+
+    if [[ "${as_file}" == "true" ]]; then
+      source_file="$(getTempFile "asfile_${attribute,,}_XXXX.json" "${tmp_dir}")"
+      echo -n "{\"${attribute^^}\" : {\"Value\" : \"$(fileName "${file}")\", \"AsFile\" : \"${relative_file}\" }}" > "${source_file}" || return 1
+    else
+      case "$(fileExtension "${file}")" in
+        json)
+          ;;
+
+        escjson)
+          source_file="$(getTempFile "escjson_${attribute,,}_XXXX.json" "${tmp_dir}")"
+          runJQ \
+            "{\"${attribute^^}\" : {\"Value\" : tojson, \"FromFile\" : \"${relative_file}\" }}" \
+            "${file}" > "${source_file}" || return 1
+          ;;
+
+        *)
+          # Assume raw input
+          source_file="$(getTempFile "raw_${attribute,,}_XXXX.json" "${tmp_dir}")"
+          runJQ -sR \
+            "{\"${attribute^^}\" : {\"Value\" : ., \"FromFile\" : \"${relative_file}\" }}" \
+            "${file}" > "${source_file}" || return 1
+          ;;
+
+      esac
+    fi
+
+    local file_ancestors=("${prefixes[@]}" $(filePath "${file}" | tr "./" " ") )
+    local processed_file="$(getTempFile "processed_XXXX.json" "${tmp_dir}")"
+    addJSONAncestorObjects "${source_file}" "${base_ancestors[@]}" $(join "-" "${file_ancestors[@]}" | tr "[:upper:]" "[:lower:]") > "${processed_file}" || return 1
+    processed_files+=("${processed_file}")
+  done
+
+  jqMerge "${processed_files[@]}"; return_status=$?
+  popTempDir
+  return ${return_status}
+}
+
+function assemble_settings() {
+  local root_dir="${1:-${ROOT_DIR}}"; shift
+  local result_file="${1:-${COMPOSITE_SETTINGS}}"; shift
+
+  pushTempDir "${FUNCNAME[0]}_XXXX"
   local tmp_dir="$(getTopTempDir)"
   local tmp_file_list=()
 
@@ -127,7 +190,11 @@ function assemble_settings() {
   local return_status
 
   # Process accounts
-  readarray -t account_files < <(find "${root_dir}" -name account.json)
+  readarray -t account_files < <(find "${root_dir}" \( \
+    -name account.json \
+    -and -not -path "*/.*/*" \) | sort)
+
+#  debug "Account=${account_files[@]}"
 
   # Settings
   for account_file in "${account_files[@]}"; do
@@ -137,17 +204,23 @@ function assemble_settings() {
     [[ -z "${name}" ]] && name="${id}"
     [[ (-n "${ACCOUNT}") && ("${ACCOUNT,,}" != "${name,,}") ]] && continue
 
-    pushd "$(filePath "${account_file}")/appsettings" > /dev/null 2>&1 || continue
+    local account_dir="$(filePath "${account_file}")/settings"
+    debug "Processing ${account_dir} ..."
+    pushd "${account_dir}" > /dev/null 2>&1 || continue
 
-    tmp_file="$( getTempFile "account_appsettings_XXXX.json" "${tmp_dir}")"
-    readarray -t setting_files < <(find . -type f -name "appsettings.json" )
-    convertFilesToJSONObject "AppSettings Accounts" "${name}" "" "${setting_files[@]}" > "${tmp_file}" || return 1
+    tmp_file="$( getTempFile "account_settings_XXXX.json" "${tmp_dir}")"
+    readarray -t setting_files < <(find . -type f -name "*.json" )
+    convertFilesToJSONObject "Settings Accounts" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
     tmp_file_list+=("${tmp_file}")
     popd > /dev/null
   done
 
   # Process products
-  readarray -t product_files < <(find "${root_dir}" -name product.json)
+  readarray -t product_files < <(find "${root_dir}" \( \
+    -name product.json \
+    -and -not -path "*/.*/*" \) | sort)
+
+#  debug "Products=${product_files[@]}"
 
   # Settings
   for product_file in "${product_files[@]}"; do
@@ -157,17 +230,29 @@ function assemble_settings() {
     [[ -z "${name}" ]] && name="${id}"
     [[ (-n "${PRODUCT}") && ("${PRODUCT,,}" != "${name,,}") ]] && continue
 
-    pushd "$(filePath "${product_file}")/appsettings" > /dev/null 2>&1 || continue
+    local product_dir="$(filePath "${product_file}")/settings"
+    debug "Processing ${product_dir} ..."
+    pushd "${product_dir}" > /dev/null 2>&1 || continue
 
-    # Appsettings
+    # Settings
     readarray -t setting_files < <(find . -type f \( \
-      -not -name "*build.json" \
-      -and -not -name "*.ref" \
+      -not \( -name "*build.json" -or -name "*credentials.json" -or -name "*sensitive.json" \) \
       -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
       -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "product_appsettings_XXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "AppSettings Products" "${name}" "" "${setting_files[@]}" > "${tmp_file}" || return 1
+      tmp_file="$( getTempFile "product_settings_XXXX.json" "${tmp_dir}")"
+      convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
+      tmp_file_list+=("${tmp_file}")
+    fi
+
+    # Sensitive
+    readarray -t setting_files < <(find . -type f \( \
+      -name "*credentials.json" -or -name "*sensitive.json" \
+      -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
+    if ! arrayIsEmpty "setting_files" ; then
+      tmp_file="$( getTempFile "product_sensitive_XXXX.json" "${tmp_dir}")"
+      convertFilesToJSONObject "Sensitive Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
 
@@ -178,7 +263,7 @@ function assemble_settings() {
       -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
       tmp_file="$( getTempFile "product_builds_XXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Builds Products" "${name}" "" "${setting_files[@]}" > "${tmp_file}" || return 1
+      convertFilesToJSONObject "Builds Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
 
@@ -187,8 +272,8 @@ function assemble_settings() {
       \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
       -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "product_appsettings_asfile_XXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "AppSettings Products" "${name}" "${ROOT_DIR}" "${setting_files[@]}" > "${tmp_file}" || return 1
+      tmp_file="$( getTempFile "product_settings_asfile_XXXX.json" "${tmp_dir}")"
+      convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "true" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
 
@@ -196,7 +281,7 @@ function assemble_settings() {
 
   done
 
-  # App credentials
+  # Operations
   for product_file in "${product_files[@]}"; do
 
     id="$(getJSONValue "${product_file}" ".Product.Id")"
@@ -204,16 +289,29 @@ function assemble_settings() {
     [[ -z "${name}" ]] && name="${id}"
     [[ (-n "${PRODUCT}") && ("${PRODUCT,,}" != "${name,,}") ]] && continue
 
-    pushd "$(findGen3ProductInfrastructureDir "${root_dir}" "${name}")/credentials" > /dev/null 2>&1 || continue
+    local operations_dir="$(findGen3ProductInfrastructureDir "${root_dir}" "${name}")/operations"
+    debug "Processing ${operations_dir} ..."
+    pushd "${operations_dir}" > /dev/null 2>&1 || continue
 
-    # Credentials
+    # Settings
     readarray -t setting_files < <(find . -type f \( \
-      -name "credentials.json" \
+      -not \( -name "*build.json" -or -name "*credentials.json" -or -name "*sensitive.json" \) \
       -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
       -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "product_credentials_XXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Credentials Products" "${name}" "" "${setting_files[@]}" > "${tmp_file}" || return 1
+      tmp_file="$( getTempFile "operations_settings_XXXX.json" "${tmp_dir}")"
+      convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
+      tmp_file_list+=("${tmp_file}")
+    fi
+
+    # Sensitive
+    readarray -t setting_files < <(find . -type f \( \
+      -name "*credentials.json" -or -name "*sensitive.json" \
+      -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
+    if ! arrayIsEmpty "setting_files" ; then
+      tmp_file="$( getTempFile "operations_sensitive_XXXX.json" "${tmp_dir}")"
+      convertFilesToJSONObject "Sensitive Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
 
@@ -222,8 +320,8 @@ function assemble_settings() {
       \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
       -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "product_credentials_asfile_XXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Credentials Products" "${name}" "${ROOT_DIR}" "${setting_files[@]}" > "${tmp_file}" || return 1
+      tmp_file="$( getTempFile "operations_settings_asfile_XXXX.json" "${tmp_dir}")"
+      convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "true" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
 
@@ -232,6 +330,7 @@ function assemble_settings() {
   done
 
   # Generate the merged output
+  debug "Generating ${result_file} ..."
   jqMerge "${tmp_file_list[@]}" > "${result_file}"; return_status=$?
 
   popTempDir
@@ -244,16 +343,16 @@ function assemble_composite_stack_outputs() {
   local restore_nullglob=$(shopt -p nullglob)
   shopt -s nullglob
 
-  pushTempDir "assemble_composite_stack_outputs_XXXX"
+  pushTempDir "${FUNCNAME[0]}_XXXX"
   local tmp_dir="$(getTopTempDir)"
 
   local stack_array=()
   [[ (-n "${ACCOUNT}") ]] &&
-      addToArray "stack_array" "${ACCOUNT_INFRASTRUCTURE_DIR}"/aws/cf/acc*-stack.json
+      addToArray "stack_array" "${ACCOUNT_INFRASTRUCTURE_DIR}"/cf/shared/acc*-stack.json
   [[ (-n "${PRODUCT}") && (-n "${REGION}") ]] &&
-      addToArray "stack_array" "${PRODUCT_INFRASTRUCTURE_DIR}"/aws/cf/product*-"${REGION}"*-stack.json
-  [[ (-n "${SEGMENT}") && (-n "${REGION}") ]] &&
-      addToArray "stack_array" "${PRODUCT_INFRASTRUCTURE_DIR}/aws/${SEGMENT}"/cf/*-stack.json
+      addToArray "stack_array" "${PRODUCT_INFRASTRUCTURE_DIR}"/cf/shared/product*-"${REGION}"*-stack.json
+  [[ (-n "${ENVIRONMENT}") && (-n "${SEGMENT}") && (-n "${REGION}") ]] &&
+      addToArray "stack_array" "${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"/*-stack.json
 
   ${restore_nullglob}
 
@@ -263,9 +362,6 @@ function assemble_composite_stack_outputs() {
     # Add default account, region, stack level and deployment unit
     local modified_stack_array=()
     for stack in "${stack_array[@]}"; do
-      # Ignore any existing temp files
-      [[ "${stack}" =~ temp_ ]] && continue
-
       # Annotate as necessary
       if parse_stack_filename "${stack}"; then
         modified_stack_filename="${tmp_dir}/$(fileName "${stack}")"
@@ -282,9 +378,9 @@ function assemble_composite_stack_outputs() {
       fi
     done
     debug "MODIFIED_STACK_OUTPUTS=${modified_stack_array[*]}"
-    ${GENERATION_DIR}/manageJSON.sh -f "[.[].Stacks | select(.!=null) | .[].Outputs | select(.!=null) ]" -o ${COMPOSITE_STACK_OUTPUTS} "${modified_stack_array[@]}"
+    ${GENERATION_DIR}/manageJSON.sh -f "[.[].Stacks | select(.!=null) | .[].Outputs | select(.!=null) ]" -o "${COMPOSITE_STACK_OUTPUTS}" "${modified_stack_array[@]}"
   else
-    echo "[]" > ${COMPOSITE_STACK_OUTPUTS}
+    echo "[]" > "${COMPOSITE_STACK_OUTPUTS}"
   fi
 
   popTempDir
@@ -314,7 +410,7 @@ function encrypt_file() {
   local input_file="$1"; shift
   local output_file="$1"; shift
 
-  pushTempDir "encrypt_file_XXXX"
+  pushTempDir "${FUNCNAME[0]}_XXXX"
   local tmp_dir="$(getTopTempDir)"
   local cmk=$(getCmk "${level}")
   local return_status
@@ -349,38 +445,6 @@ function getOperationsBucket() {
 
 function getCodeBucket() {
   getBucketName "s3XaccountXcode"
-}
-
-function syncCMDBFilesToOperationsBucket() {
-  local base_dir="$1"; shift
-  local prefix="$1"; shift
-  local optional_arguments=("$@")
-
-  local restore_nullglob=$(shopt -p nullglob)
-  shopt -s nullglob
-
-  local files=()
-  files+=(${base_dir}/asFile/*)
-  files+=(${base_dir}/${DEPLOYMENT_UNIT}/asFile/*)
-  files+=(${base_dir}/${BUILD_DEPLOYMENT_UNIT}/asFile/*)
-
-  ${restore_nullglob}
-
-  ! arrayIsEmpty "files" && \
-    { syncFilesToBucket "${REGION}" "$(getOperationsBucket)" \
-        "${prefix}/${PRODUCT}/${SEGMENT}/${DEPLOYMENT_UNIT}" \
-        "files" "${optional_arguments[@]}" --delete ||
-      return $?; }
-  return 0
-}
-
-function deleteCMDBFilesFromOperationsBucket() {
-  local prefix="$1"; shift
-  local optional_arguments=("$@")
-
-  deleteTreeFromBucket ${REGION} "$(getOperationsBucket)" \
-    "${prefix}/${PRODUCT}/${SEGMENT}${DEPLOYMENT_UNIT}" \
-    "${optional_arguments[@]}"
 }
 
 # -- GEN3 directory structure --
@@ -456,17 +520,15 @@ function findGen3ProductInfrastructureDir() {
     "${product}/infrastructure"
 }
 
-function findGen3SegmentDir() {
+function findGen3EnvironmentDir() {
   local root_dir="$1"; shift
   local product="${1:-${PRODUCT}}"; shift
-  local segment="${1:-${SEGMENT}}"; shift
+  local environment="${1:-${ENVIRONMENT}}"; shift
 
   local product_dir="$(findGen3ProductDir "${root_dir}" "${product}")"
   [[ -z "${product_dir}" ]] && return 1
 
-  findDir "${product_dir}" \
-    "solutions/${segment}/segment.json" \
-    "solutions/${segment}/container.json"
+  findDir "${product_dir}" "solutionsv2/${environment}/environment.json"
 }
 
 function getGen3Env() {
@@ -500,41 +562,64 @@ function findGen3Dirs() {
   local tenant="${1:-${TENANT}}"; shift
   local account="${1:-${ACCOUNT}}"; shift
   local product="${1:-${PRODUCT}}"; shift
+  local environment="${1:-${ENVIRONMENT}}"; shift
   local segment="${1:-${SEGMENT}}"; shift
   local prefix="$1"; shift
 
   setGen3DirEnv "ROOT_DIR" "${prefix}" "${root_dir}"
+  debug "ROOT_DIR=${ROOT_DIR}"
 
   setGen3DirEnv "TENANT_DIR" "${prefix}" \
     "$(findGen3TenantDir "${root_dir}" "${tenant}" )" || return 1
+  debug "TENANT_DIR=${TENANT_DIR}"
 
   setGen3DirEnv "ACCOUNT_DIR" "${prefix}" \
     "$(findGen3AccountDir "${root_dir}" "${account}" )" || return 1
+  debug "ACCOUNT_DIR=${ACCOUNT_DIR}"
 
   setGen3DirEnv "ACCOUNT_INFRASTRUCTURE_DIR" "${prefix}" \
     "$(findGen3AccountInfrastructureDir "${root_dir}" "${account}" )" || return 1
+  debug "ACCOUNT_INFRASTRUCTURE_DIR=${ACCOUNT_INFRASTRUCTURE_DIR}"
 
-  declare -gx ${prefix}ACCOUNT_APPSETTINGS_DIR=$(getGen3Env "ACCOUNT_DIR" "${prefix}")/appsettings
-  declare -gx ${prefix}ACCOUNT_CREDENTIALS_DIR=$(getGen3Env "ACCOUNT_INFRASTRUCTURE_DIR" "${prefix}")/credentials
+  declare -gx ${prefix}ACCOUNT_SETTINGS_DIR=$(getGen3Env "ACCOUNT_DIR" "${prefix}")/settings
+  declare -gx ${prefix}ACCOUNT_OPERATIONS_DIR=$(getGen3Env "ACCOUNT_INFRASTRUCTURE_DIR" "${prefix}")/operations
 
   if [[ -n "${product}" ]]; then
     setGen3DirEnv "PRODUCT_DIR" "${prefix}" \
       "$(findGen3ProductDir "${root_dir}" "${product}")" || return 1
+    debug "PRODUCT_DIR=${PRODUCT_DIR}"
 
     setGen3DirEnv "PRODUCT_INFRASTRUCTURE_DIR" "${prefix}" \
       "$(findGen3ProductInfrastructureDir "${root_dir}" "${product}")" || return 1
+    debug "PRODUCT_INFRASTRUCTURE_DIR=${PRODUCT_INFRASTRUCTURE_DIR}"
 
-    declare -gx ${prefix}PRODUCT_APPSETTINGS_DIR=$(getGen3Env "PRODUCT_DIR" "${prefix}")/appsettings
-    declare -gx ${prefix}PRODUCT_SOLUTIONS_DIR=$(getGen3Env "PRODUCT_DIR" "${prefix}")/solutions
-    declare -gx ${prefix}PRODUCT_CREDENTIALS_DIR=$(getGen3Env "PRODUCT_INFRASTRUCTURE_DIR" "${prefix}")/credentials
+    declare -gx ${prefix}PRODUCT_SETTINGS_DIR=$(getGen3Env   "PRODUCT_DIR"                "${prefix}")/settings
+    declare -gx ${prefix}PRODUCT_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_DIR"                "${prefix}")/solutionsv2
+    declare -gx ${prefix}PRODUCT_OPERATIONS_DIR=$(getGen3Env "PRODUCT_INFRASTRUCTURE_DIR" "${prefix}")/operations
 
-    if [[ -n "${segment}" ]]; then
-      setGen3DirEnv "SEGMENT_DIR"  "${prefix}" \
-        "$(findGen3SegmentDir "${root_dir}" "${product}" "${segment}")" || return 1
+    declare -gx ${prefix}PRODUCT_SHARED_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/shared
+    declare -gx ${prefix}PRODUCT_SHARED_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/shared
+    declare -gx ${prefix}PRODUCT_SHARED_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/shared
 
-      declare -gx ${prefix}SEGMENT_APPSETTINGS_DIR=$(getGen3Env "PRODUCT_APPSETTINGS_DIR" "${prefix}")/${segment}
-      declare -gx ${prefix}SEGMENT_CREDENTIALS_DIR=$(getGen3Env "PRODUCT_CREDENTIALS_DIR" "${prefix}")/${segment}
-      declare -gx ${prefix}ENVIRONMENT_CREDENTIALS_DIR=$(getGen3Env "PRODUCT_CREDENTIALS_DIR" "${prefix}")/${segment}
+    if [[ -n "${environment}" ]]; then
+
+      declare -gx ${prefix}ENVIRONMENT_SHARED_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/${environment}
+      declare -gx ${prefix}ENVIRONMENT_SHARED_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/${environment}
+      declare -gx ${prefix}ENVIRONMENT_SHARED_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}
+      debug "ENVIRONMENT_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}"
+
+      if [[ -n "${segment}" ]]; then
+
+        declare -gx ${prefix}SEGMENT_SHARED_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/shared/${segment}
+        declare -gx ${prefix}SEGMENT_SHARED_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/shared/${segment}
+        declare -gx ${prefix}SEGMENT_SHARED_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/shared/${segment}
+
+        declare -gx ${prefix}SEGMENT_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/${environment}/${segment}
+        declare -gx ${prefix}SEGMENT_BUILDS_DIR=$(getGen3Env     "PRODUCT_SETTINGS_DIR"   "${prefix}")/${environment}/${segment}
+        declare -gx ${prefix}SEGMENT_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/${environment}/${segment}
+        declare -gx ${prefix}SEGMENT_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}/${segment}
+        debug "SEGMENT_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}/${segment}"
+      fi
     fi
   fi
 
@@ -557,6 +642,12 @@ function checkInProductDirectory() {
   local location="${1:-${LOCATION}}"
 
   [[ ! ("product" =~ ${location}) ]] && fatalDirectory "product"
+}
+
+function checkInEnvironmentDirectory() {
+  local location="${1:-${LOCATION}}"
+
+  [[ ! ("environment" =~ ${location}) ]] && fatalDirectory "environment"
 }
 
 function checkInSegmentDirectory() {
@@ -657,190 +748,434 @@ function upgrade_credentials() {
     fi
 }
 
-function upgrade_cmdb_repo() {
-  local root_dir="$1";shift
-  local cleanup="$1";shift
-  local dry_run="$1";shift
-
-  local cmdb_version_file="${root_dir}/.cmdb"
-  local versions=("v1.0.0")
-  local current_version="v0.0.0"
-
-  debug "Checking repo ${root_dir} ..."
-
-  [[ ! -d "${root_dir}/.git" ]] &&
-    error "We don't appear to be in the root directory of a repo" && return 1
-
-  if [[ -f "${cmdb_version_file}" ]]; then
-    current_version="$(jq -r ".Version" < "${cmdb_version_file}")"
-    debug "Repo is at version ${current_version}"
-  fi
-
-  for version in "${versions[@]}"; do
-    # Nothing to do if not less than version being checked
-    local semver_check="$(semver_compare "${current_version}" "${version}")"
-
-    if [[ "${semver_check}" == "-1" ]]; then
-      info "Upgrading repo to ${version} ..."
-    else
-      if [[ "${cleanup}" == "true" ]]; then
-        info "Cleaning up after ${version} ..."
-      else
-        debug "Ignoring upgrade to ${version} ..."
-        continue
-      fi
-    fi
-
-    local return_status
-    upgrade_cmdb_repo_to_${version//./_} "${root_dir}" "${cleanup}" "${dry_run}"; return_status=$?
-
-    if [[ "${dry_run}" == "true" ]]; then
-      if [[ "${return_status}" -eq 0 ]]; then
-        debug "No upgrade needed"
-      else
-        debug "Upgrade needed"
-      fi
-      # Only process one level of upgrade for a dryrun
-      break
-    else
-      if [[ "${return_status}" -eq 0 ]]; then
-        if [[ "${semver_check}" == "-1" ]]; then
-          # record upgraded version
-          info "Upgrade of repo ${root_dir} to ${version} successful"
-          echo -n "{\"Version\" : \"${version}\"}" > "${cmdb_version_file}"
-          current_version="${version}"
-        else
-          info "Clean up after ${version} successful"
-        fi
-      else
-        return ${return_status}
-      fi
-    fi
-  done
-  return 0
-}
-
+# Remove .ref files, simplify credentials files
 function upgrade_cmdb_repo_to_v1_0_0() {
   local root_dir="$1";shift
-  local cleanup="$1";shift
   local dry_run="$1";shift
 
-  pushd "${root_dir}" > /dev/null
   pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXX"
   local tmp_dir="$(getTopTempDir)"
   local tmp_file
 
-  local upgrade_needed="false"
-  local upgrade_succeeded="true"
+  local return_status=0
 
   # All build references now in json format
-  readarray -t legacy_files < <(find "${root_dir}" -type f -name "build.ref" )
+  readarray -t legacy_files < <(find "${root_dir}" -type f \
+    -name "build.ref" )
   for legacy_file in "${legacy_files[@]}"; do
     debug "Checking ${legacy_file}..."
     replacement_file="$(filePath "${legacy_file}")/build.json"
     [[ -f "${replacement_file}" ]] && continue
-    upgrade_needed="true"
     info "Upgrading ${legacy_file} ..."
     tmp_file="$(getTempFile "build_XXXX.json" "${tmp_dir}")"
-    upgrade_build_ref "${legacy_file}" "${tmp_file}" || { upgrade_succeeded="false"; continue; }
+    upgrade_build_ref "${legacy_file}" "${tmp_file}" || { return_status=1; break; }
 
-    if [[ "${dry_run}" == "true" ]]; then
+    if [[ -n "${dry_run}" ]]; then
       willLog "trace" && { echo; cat "${tmp_file}"; echo; }
       continue
     fi
-    cp "${tmp_file}" "${replacement_file}" || { upgrade_succeeded="false"; continue; }
-    if [[ "${cleanup}" == "true" ]]; then
-      git_rm -f "${legacy_file}" || { upgrade_succeeded="false"; continue; }
-    fi
+    cp "${tmp_file}" "${replacement_file}" || { return_status=1; break; }
   done
 
   # All shared build references now in json format
-  readarray -t legacy_files < <(find "${root_dir}" -type f \( -name "*.ref" -and -not -name "build.ref" \) )
-  for legacy_file in "${legacy_files[@]}"; do
-    debug "Checking ${legacy_file}..."
-    replacement_file="$(filePath "${legacy_file}")/shared_build.json"
-    [[ -f "${replacement_file}" ]] && continue
-    upgrade_needed="true"
-    info "Upgrading ${legacy_file} ..."
-    tmp_file="$(getTempFile "shared_XXXX.json" "${tmp_dir}")"
-    upgrade_shared_build_ref "${legacy_file}" "${tmp_file}" || { upgrade_succeeded="false"; continue; }
-
-    if [[ "${dry_run}" == "true" ]]; then
-      willLog "trace" && { echo; cat "${tmp_file}"; echo; }
-      continue
-    fi
-    cp "${tmp_file}" "${replacement_file}" || { upgrade_succeeded="false"; continue; }
-    if [[ "${cleanup}" == "true" ]]; then
-      git_rm -f "${legacy_file}" || { upgrade_succeeded="false"; continue; }
-    fi
-  done
-
-  # Strip top level "Credentials" attribute from credentials
-  readarray -t legacy_files < <(find "${root_dir}" -type f -name "credentials.json" )
-  for legacy_file in "${legacy_files[@]}"; do
-    debug "Checking ${legacy_file}..."
-    if [[ "$(jq ".Credentials | if .==null then [] else [1] end | length" < "${legacy_file}" )" -gt 0 ]]; then
-      upgrade_needed="true"
+  if [[ ${return_status} -eq 0 ]]; then
+    readarray -t legacy_files < <(find "${root_dir}" -type f \
+      \( -name "*.ref" -and -not -name "build.ref" \) )
+    for legacy_file in "${legacy_files[@]}"; do
+      debug "Checking ${legacy_file}..."
+      replacement_file="$(filePath "${legacy_file}")/shared_build.json"
+      [[ -f "${replacement_file}" ]] && continue
       info "Upgrading ${legacy_file} ..."
-      tmp_file="$(getTempFile "credentials_XXXX.json" "${tmp_dir}")"
-      upgrade_credentials "${legacy_file}" "${tmp_file}" || { upgrade_succeeded="false"; continue; }
+      tmp_file="$(getTempFile "shared_XXXX.json" "${tmp_dir}")"
+      upgrade_shared_build_ref "${legacy_file}" "${tmp_file}" || { return_status=1; break; }
 
-      if [[ "${dry_run}" == "true" ]]; then
+      if [[ -n "${dry_run}" ]]; then
         willLog "trace" && { echo; cat "${tmp_file}"; echo; }
         continue
       fi
-      cp "${tmp_file}" "${legacy_file}" || { upgrade_succeeded="false"; continue; }
-    fi
+      cp "${tmp_file}" "${replacement_file}" || { return_status=1; break; }
+    done
+  fi
+
+  # Strip top level "Credentials" attribute from credentials
+  if [[ ${return_status} -eq 0 ]]; then
+    readarray -t legacy_files < <(find "${root_dir}" -type f \
+      -name "credentials.json" )
+    for legacy_file in "${legacy_files[@]}"; do
+      debug "Checking ${legacy_file}..."
+      if [[ "$(jq ".Credentials | if .==null then [] else [1] end | length" < "${legacy_file}" )" -gt 0 ]]; then
+        upgrade_needed="true"
+        info "Upgrading ${legacy_file} ..."
+        tmp_file="$(getTempFile "credentials_XXXX.json" "${tmp_dir}")"
+        upgrade_credentials "${legacy_file}" "${tmp_file}" || { return_status=1; break; }
+
+      if [[ -n "${dry_run}" ]]; then
+          willLog "trace" && { echo; cat "${tmp_file}"; echo; }
+          continue
+        fi
+        cp "${tmp_file}" "${legacy_file}" || { return_status=1; break; }
+      fi
+    done
+  fi
+
+  # Change of naming from "container" to "segment"
+  if [[ ${return_status} -eq 0 ]]; then
+    readarray -t legacy_files < <(find "${root_dir}" -type f \
+      -name "container.json" )
+    for legacy_file in "${legacy_files[@]}"; do
+      debug "Checking ${legacy_file}..."
+      replacement_file="$(filePath "${legacy_file}")/segment.json"
+      [[ -f "${replacement_file}" ]] && continue
+      upgrade_needed="true"
+      info "Upgrading ${legacy_file} ..."
+      tmp_file="$(getTempFile "container_XXXX.json" "${tmp_dir}")"
+      cp "${legacy_file}" "${tmp_file}" || { return_status=1; break; }
+
+      if [[ -n "${dry_run}" ]]; then
+        willLog "trace" && { echo; cat "${tmp_file}"; echo; }
+        continue
+      fi
+      cp "${legacy_file}" "${replacement_file}" || { return_status=1; break; }
+    done
+  fi
+
+  popTempDir
+
+  return ${return_status}
+}
+
+function cleanup_cmdb_repo_to_v1_0_0() {
+  local root_dir="$1";shift
+  local dry_run="$1";shift
+
+  # All build references now in json format
+  readarray -t legacy_files < <(find "${root_dir}" -type f \
+    -name "build.ref" )
+  for legacy_file in "${legacy_files[@]}"; do
+    info "${dry_run}Deleting ${legacy_file} ..."
+    [[ -n "${dry_run}" ]] && continue
+    git_rm -f "${legacy_file}" || return 1
+  done
+
+  # All shared build references now in json format
+  readarray -t legacy_files < <(find "${root_dir}" -type f \
+    \( -name "*.ref" -and -not -name "build.ref" \) )
+  for legacy_file in "${legacy_files[@]}"; do
+    info "${dry_run}Deleting ${legacy_file} ..."
+    [[ -n "${dry_run}" ]] && continue
+    git_rm -f "${legacy_file}" || return 1
   done
 
   # Change of naming from "container" to "segment"
-  readarray -t legacy_files < <(find "${root_dir}" -type f -name "container.json" )
+  readarray -t legacy_files < <(find "${root_dir}" -type f \
+    -name "container.json" )
   for legacy_file in "${legacy_files[@]}"; do
-    debug "Checking ${legacy_file}..."
-    replacement_file="$(filePath "${legacy_file}")/segment.json"
-    [[ -f "${replacement_file}" ]] && continue
-    upgrade_needed="true"
-    info "Upgrading ${legacy_file} ..."
-    tmp_file="$(getTempFile "container_XXXX.json" "${tmp_dir}")"
-    cp "${legacy_file}" "${tmp_file}" || { upgrade_succeeded="false"; continue; }
+    info "${dry_run}Deleting ${legacy_file} ..."
+    [[ -n "${dry_run}" ]] && continue
+    git_rm -f "${legacy_file}" || return 1
+  done
 
-    if [[ "${dry_run}" == "true" ]]; then
-      willLog "trace" && { echo; cat "${tmp_file}"; echo; }
-      continue
-    fi
-    cp "${legacy_file}" "${replacement_file}" || { upgrade_succeeded="false"; continue; }
-    if [[ "${cleanup}" == "true" ]]; then
-      git_rm -f "${legacy_file}"  || { upgrade_succeeded="false"; continue; }
-    fi
+  return 0
+}
+
+# Introduce separate environment and segment dirs
+function upgrade_cmdb_repo_to_v1_1_0_settings() {
+  local root_dir="$1";shift
+  local dry_run="$1";shift
+  local target_dir="$1";shift
+
+  # Create the shared file location for default segment
+  local shared_dir="${target_dir}/shared"
+  mkdir -p "${shared_dir}" || return 1
+
+  # Copy across the shared files
+  readarray -t sub_files < <(find "${root_dir}" -mindepth 1 -maxdepth 1 -type f )
+  for sub_file in "${sub_files[@]}"; do
+    debug "Copying ${sub_file} to ${shared_dir} ..."
+    [[ -n "${dry_run}" ]] && continue
+    cp "${sub_file}" "${shared_dir}" || return 1
+  done
+
+  # Process each sub dir
+  readarray -t sub_dirs < <(find "${root_dir}" -mindepth 1 -maxdepth 1 -type d )
+  for sub_dir in "${sub_dirs[@]}"; do
+    local environment="$(fileName "${sub_dir}")"
+    local segment_dir="${target_dir}/${environment}/default"
+    mkdir -p "${segment_dir}" || return 1
+
+    debug "Copying ${sub_dir} to ${segment_dir} ..."
+    [[ -n "${dry_run}" ]] && continue
+    cp -rp "${sub_dir}"/* "${segment_dir}" || return 1
+
+    # Remove anything unwanted
+    readarray -t segment_files < <(find "${segment_dir}" -type f \
+      -name "*.ref" \
+      -or -name "container.json" )
+    for segment_file in "${segment_files[@]}"; do
+      debug "Deleting ${segment_file} ..."
+      rm "${segment_file}" || return 1
+    done
+  done
+  return 0
+}
+
+function upgrade_cmdb_repo_to_v1_1_0_state() {
+  local root_dir="$1";shift
+  local dry_run="$1";shift
+  local target_dir="$1";shift
+
+  # Create the shared file location
+  local shared_dir="${target_dir}/shared"
+  mkdir -p "${shared_dir}" || return 1
+
+  # Copy across the shared files
+  if [[ -d "${root_dir}/cf" ]]; then
+    readarray -t sub_files < <(find "${root_dir}/cf" -mindepth 1 -maxdepth 1 -type f )
+    for sub_file in "${sub_files[@]}"; do
+      debug "Copying ${sub_file} to ${shared_dir} ..."
+      [[ -n "${dry_run}" ]] && continue
+      cp "${sub_file}" "${shared_dir}" || return 1
+    done
+  fi
+
+  # Process each sub dir
+  readarray -t sub_dirs < <(find "${root_dir}" -mindepth 1 -maxdepth 1 -type d \( \
+    -not -name "cf" \) )
+  for sub_dir in "${sub_dirs[@]}"; do
+    local environment="$(fileName "${sub_dir}")"
+    local segment_dir="${target_dir}/${environment}/default"
+    mkdir -p "${segment_dir}" || return 1
+
+    [[ ! -d "${sub_dir}/cf" ]] && continue
+    debug "Copying ${sub_dir}/cf to ${segment_dir} ..."
+    [[ -n "${dry_run}" ]] && continue
+    cp -rp "${sub_dir}"/cf/* "${segment_dir}" || return 1
+  done
+  return 0
+}
+
+declare -A upgrade_v1_1_0_sources
+upgrade_v1_1_0_sources=( \
+  ["appsettings"]="settings" \
+  ["solutions"]="solutionsv2" \
+  ["credentials"]="operations" \
+  ["aws"]="cf")
+
+# config segment folders now under an environment folder
+function upgrade_cmdb_repo_to_v1_1_0() {
+  local root_dir="$1";shift
+  local dry_run="$1";shift
+
+  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXX"
+  local tmp_dir="$(getTopTempDir)"
+  local return_status=0
+
+  for source in "${!upgrade_v1_1_0_sources[@]}"; do
+    readarray -t source_dirs < <(find "${root_dir}" -type d -name "${source}" )
+    for source_dir in "${source_dirs[@]}"; do
+      local target_dir="$(filePath "${source_dir}")/${upgrade_v1_1_0_sources[${source}]}"
+      debug "Checking ${source_dir} ..."
+      [[ -d "${target_dir}" ]] && continue
+      info "Converting ${source_dir} into ${target_dir} ..."
+      if [[ "${source}" == "aws" ]]; then
+        upgrade_cmdb_repo_to_v1_1_0_state "${source_dir}" "${dryrun}" "${target_dir}" ||
+        { return_status=$?; break; }
+      else
+        upgrade_cmdb_repo_to_v1_1_0_settings "${source_dir}" "${dryrun}" "${target_dir}" ||
+        { return_status=$?; break; }
+      fi
+
+      [[ -n "${dry_run}" ]] && continue
+
+      # Special processing
+      case "${source}" in
+        solutions)
+          # Shared solution files are specific to the default segment
+          local shared_default_dir="${target_dir}/shared/default"
+          mkdir -p "${shared_default_dir}" || { return_status=$?; break; }
+
+          readarray -t solution_files < <(find "${target_dir}/shared" -mindepth 1 -maxdepth 1 -type f)
+          for solution_file in "${solution_files[@]}"; do
+            debug "Moving ${solution_file} to ${shared_default_dir} ..."
+            mv "${solution_file}" "${shared_default_dir}"
+          done
+
+          # Process environments
+          readarray -t segment_files < <(find "${target_dir}" -type f -name "segment.json")
+          for segment_file in "${segment_files[@]}"; do
+            local segment_dir="$(filePath "${segment_file}")"
+            local environment_dir="$(filePath "${segment_dir}")"
+
+            # Add environment.json file
+            local environment_id="$(jq -r ".Segment.Environment | select(.!=null)" < "${segment_file}")"
+            local environment_file="${environment_dir}/environment.json"
+            debug "Creating ${environment_file} ..."
+            cat << EOF > "${environment_file}"
+{
+  "Environment" : {
+    "Id" : "${environment_id}"
+  }
+}
+EOF
+            # Remove segment attributes that are now elsewhere
+            debug "Cleaning ${segment_file} ..."
+            local tmp_file="${tmp_dir}/segment.json"
+            jq "del(.Segment.Id) | del(.Segment.Name) | del(.Segment.Title) | del(.Segment.Environment)" \
+              < "${segment_file}" \
+              > "${tmp_file}"  ||
+            { return_status=$?; break; }
+            cp "${tmp_file}" "${segment_file}"
+          done
+
+          local shared_segment_file="${shared_default_dir}/segment.json"
+          debug "Creating ${shared_segment_file} ..."
+          cat << EOF > "${shared_segment_file}"
+{
+  "Segment" : {
+    "Id" : "default"
+  }
+}
+EOF
+          ;;
+
+        credentials)
+          readarray -t pem_files < <(find "${target_dir}" -type f -name "aws-ssh*.pem")
+          for pem_file in "${pem_files[@]}"; do
+            local file_name="$(fileName "${pem_file}")"
+            local segment_dir="$(filePath "${pem_file}")"
+            local environment_dir="$(filePath "${segment_dir}")"
+
+            # Move the file so it can be shared by all segments in the environment
+            # Also make it invisible to the generation process
+            debug "Moving ${pem_file} to ${environment_dir}/.${file_name} ..."
+            mv "${pem_file}" "${environment_dir}/.${file_name}"
+
+            local environment_ignore_file="${environment_dir}/.gitignore"
+            if [[ ! -f "${environment_ignore_file}" ]]; then
+              debug "Creating ${environment_ignore_file} ..."
+              cat << EOF > "${environment_ignore_file}"
+*.plaintext
+*.decrypted
+*.ppk
+EOF
+            fi
+          done
+          ;;
+      esac
+      done
   done
 
   popTempDir
-  popd > /dev/null
 
-  # Is an upgrade needed?
-  if [[ "${dry_run}" == "true" ]]; then
-    [[ "${upgrade_needed}" == "false" ]]
-  else
-    [[ "${upgrade_succeeded}" == "true" ]]
-  fi
-  return $?
+  return ${return_status}
+}
+
+function cleanup_cmdb_repo_to_v1_1_0() {
+  local root_dir="$1";shift
+  local dry_run="$1";shift
+
+  for source in "${!upgrade_v1_1_0_sources[@]}"; do
+    readarray -t source_dirs < <(find "${root_dir}" -mindepth 1 -maxdepth 1 -type d \
+      -name "${source}" )
+    for source_dir in "${source_dirs[@]}"; do
+      info "Deleting ${source_dir} ..."
+      [[ -n "${dry_run}" ]] && continue
+      git_rm -rf "${source_dir}" || return 1
+    done
+  done
+
+  return 0
+}
+
+function process_cmdb() {
+  local root_dir="$1";shift
+  local action="$1";shift
+  local version_list="$1";shift
+  local dry_run="${1:+(Dryrun) }";shift
+
+  declare -a versions
+  arrayFromList versions "${version_list}"
+  local return_status=0
+
+  # Find all the repos
+  readarray -t cmdb_git_repos < <(find "${root_dir}" -type d -name ".git" | sort )
+
+  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXX"
+  local tmp_version_file="$(getTopTempDir)/new_version.json"
+  local tmp_result_file="$(getTopTempDir)/new_cmdb.json"
+
+  # Process each one
+  for cmdb_git_repo in "${cmdb_git_repos[@]}"; do
+
+    local cmdb_repo="$(filePath "${cmdb_git_repo}")"
+    debug "Checking repo ${cmdb_repo} ..."
+
+    local cmdb_version_file="${cmdb_repo}/.cmdb"
+    local current_version=""
+
+    if [[ -f "${cmdb_version_file}" ]]; then
+      current_version="$(jq -r ".Version.${action^} | select(.!=null)" < "${cmdb_version_file}")"
+      debug "Repo is at ${action,,} version ${current_version:-<not initialised>}"
+    else
+      echo -n "{}" > "${cmdb_version_file}"
+    fi
+
+    [[ -z "${current_version}" ]] && current_version="v0.0.0"
+
+    for version in "${versions[@]}"; do
+      # Nothing to do if not less than version being checked
+      local semver_check="$(semver_compare "${current_version}" "${version}")"
+
+      if [[ "${semver_check}" == "-1" ]]; then
+        info "${dry_run}${action^} of repo "${cmdb_repo}" to ${version} required ..."
+      else
+        debug "${action^} of repo "${cmdb_repo}" to ${version} is not required"
+        continue
+      fi
+
+      ${action,,}_cmdb_repo_to_${version//./_} "${cmdb_repo}" "${dry_run}"; return_status=$?
+
+      if [[ "${return_status}" -eq 0 ]]; then
+        # Only check the first version to be applied for a dryrun
+        if [[ -n "${dry_run}" ]]; then
+          debug "${dry_run}Skipping later versions"
+          break
+        fi
+
+        # Record the action
+        info "${action^} of repo "${cmdb_repo}" to ${version} successful"
+        echo -n "{\"Version\" : {\"${action^}\" : \"${version}\"}}" > "${tmp_version_file}"
+        jqMerge "${cmdb_version_file}" "${tmp_version_file}" > "${tmp_result_file}" &&
+          { cp "${tmp_result_file}" "${cmdb_version_file}"; current_version="${version}"; } ||
+          return_status=$?
+      fi
+      [[ "${return_status}" -ne 0 ]] && break
+    done
+
+    [[ "${return_status}" -ne 0 ]] && break
+  done
+
+  popTempDir
+  return ${return_status}
 }
 
 function upgrade_cmdb() {
   local root_dir="$1";shift
-  local cleanup="${1:-false}";shift
-  local dry_run="${1:-false}";shift
+  local dry_run="$1";shift
+  local versions="$1";shift
 
-  # Find all the repos
-  readarray -t cmdb_repos < <(find "${root_dir}" -type d -name ".git" | sort )
+  local required_versions=(${versions})
+  [[ -z "${versions}" ]] && required_versions=("v1.0.0" "v1.1.0")
 
-  pushTempDir "upgrade_cmdb_$(fileName "${root_dir}")_XXXX"
+  process_cmdb "${root_dir}" "upgrade" "${required_versions[*]}" ${dry_run}
+}
 
-  # Process each one
-  for cmdb_repo in "${cmdb_repos[@]}"; do
-    local cmdb_repo_dir=
-    upgrade_cmdb_repo "$(filePath "${cmdb_repo}")" "${cleanup}" "${dry_run}" || return $?
-  done
+function cleanup_cmdb() {
+  local root_dir="$1";shift
+  local dry_run="$1";shift
 
-  popTempDir
+  local required_versions=(${versions})
+  [[ -z "${versions}" ]] && required_versions=("v1.0.0")
+
+  process_cmdb "${root_dir}" "cleanup" "${required_versions[*]}" ${dry_run}
 }

--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -166,11 +166,11 @@ function process_template() {
   # Default passes
   local passes=("prologue" "template" "epilogue")
 
-  local cf_dir="${PRODUCT_INFRASTRUCTURE_DIR}/aws/${SEGMENT}/cf"
+  local cf_dir="${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
 
   case "${level}" in
     blueprint)
-      cf_dir="${PRODUCT_INFRASTRUCTURE_DIR}/cot/${SEGMENT}/bp"
+      cf_dir="${PRODUCT_INFRASTRUCTURE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
       pass_list=("template")
       passes=("template")
       template_composites+=("SEGMENT" "SOLUTION" "APPLICATION" "CONTAINER" )
@@ -187,7 +187,7 @@ function process_template() {
       ;;
 
     account)
-      cf_dir="${ACCOUNT_INFRASTRUCTURE_DIR}/aws/cf"
+      cf_dir="${ACCOUNT_INFRASTRUCTURE_DIR}/cf/shared"
       for pass in "${pass_list[@]}"; do pass_region_prefix["${pass}"]="${account_region}-"; done
       template_composites+=("ACCOUNT")
 
@@ -198,7 +198,7 @@ function process_template() {
       ;;
 
     product)
-      cf_dir="${PRODUCT_INFRASTRUCTURE_DIR}/aws/cf"
+      cf_dir="${PRODUCT_INFRASTRUCTURE_DIR}/cf/shared"
       template_composites+=("PRODUCT")
 
       # LEGACY: Support stacks created before deployment units added to product
@@ -294,8 +294,6 @@ function process_template() {
   args+=("-v" "productRegion=${product_region}")
   args+=("-v" "accountRegion=${account_region}")
   args+=("-v" "blueprint=${COMPOSITE_BLUEPRINT}")
-  args+=("-v" "credentials=${COMPOSITE_CREDENTIALS}")
-  args+=("-v" "appsettings=${COMPOSITE_APPSETTINGS}")
   args+=("-v" "settings=${COMPOSITE_SETTINGS}")
   args+=("-v" "stackOutputs=${COMPOSITE_STACK_OUTPUTS}")
   args+=("-v" "requestReference=${request_reference}")

--- a/aws/setStackContext.sh
+++ b/aws/setStackContext.sh
@@ -31,7 +31,12 @@ LEVEL_PREFIX="${LEVEL}-"
 DEPLOYMENT_UNIT_PREFIX="${DEPLOYMENT_UNIT}-"
 ACCOUNT_PREFIX="${ACCOUNT}-"
 REGION_PREFIX="${REGION}-"
+ENVIRONMENT_SUFFIX="-${ENVIRONMENT}"
 SEGMENT_SUFFIX="-${SEGMENT}"
+if [[ ("${SEGMENT_SUFFIX}" == "${ENVIRONMENT_SUFFIX}") ||
+        ("${SEGMENT_SUFFIX}" == "default") ]]; then
+    SEGMENT_SUFFIX=""
+fi
 LEVEL_SUFFIX="-${LEVEL}"
 DEPLOYMENT_UNIT_SUFFIX="-${DEPLOYMENT_UNIT}"
 if [[ -n "${DEPLOYMENT_UNIT_SUBSET}" ]]; then
@@ -40,10 +45,11 @@ if [[ -n "${DEPLOYMENT_UNIT_SUBSET}" ]]; then
 fi
 case $LEVEL in
     account)
-        CF_DIR="${ACCOUNT_INFRASTRUCTURE_DIR}/aws/cf"
+        CF_DIR="${ACCOUNT_INFRASTRUCTURE_DIR}/cf/shared"
         PRODUCT_PREFIX="${ACCOUNT}"
         REGION="${ACCOUNT_REGION}"
         REGION_PREFIX="${ACCOUNT_REGION}-"
+        ENVIRONMENT_SUFFIX=""
         SEGMENT_SUFFIX=""
 
         # LEGACY: Support stacks created before deployment units added to account
@@ -64,7 +70,8 @@ case $LEVEL in
         ;;
 
     product)
-        CF_DIR="${PRODUCT_INFRASTRUCTURE_DIR}/aws/cf"
+        CF_DIR="${PRODUCT_INFRASTRUCTURE_DIR}/cf/shared"
+        ENVIRONMENT_SUFFIX=""
         SEGMENT_SUFFIX=""
 
         # LEGACY: Support stacks created before deployment units added to product
@@ -77,7 +84,7 @@ case $LEVEL in
         ;;
 
     solution)
-        CF_DIR="${PRODUCT_INFRASTRUCTURE_DIR}/aws/${SEGMENT}/cf"
+        CF_DIR="${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
         LEVEL_PREFIX="soln-"
         LEVEL_SUFFIX="-soln"
         if [[ -f "${CF_DIR}/solution-${REGION}-template.json" ]]; then
@@ -89,7 +96,7 @@ case $LEVEL in
         ;;
 
     segment)
-        CF_DIR="${PRODUCT_INFRASTRUCTURE_DIR}/aws/${SEGMENT}/cf"
+        CF_DIR="${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
         LEVEL_PREFIX="seg-"
         LEVEL_SUFFIX="-seg"
 
@@ -123,13 +130,13 @@ case $LEVEL in
         ;;
 
     application)
-        CF_DIR="${PRODUCT_INFRASTRUCTURE_DIR}/aws/${SEGMENT}/cf"
+        CF_DIR="${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
         LEVEL_PREFIX="app-"
         LEVEL_SUFFIX="-app"
         ;;
 
     multiple)
-        CF_DIR="${PRODUCT_INFRASTRUCTURE_DIR}/aws/${SEGMENT}/cf"
+        CF_DIR="${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
         LEVEL_PREFIX="multi-"
         LEVEL_SUFFIX="-multi"
         ;;
@@ -139,7 +146,7 @@ case $LEVEL in
         ;;
 esac
 
-STACK_NAME="${STACK_NAME:-${PRODUCT_PREFIX}${SEGMENT_SUFFIX}${LEVEL_SUFFIX}${DEPLOYMENT_UNIT_SUFFIX}${DEPLOYMENT_UNIT_SUBSET_SUFFIX}}"
+STACK_NAME="${STACK_NAME:-${PRODUCT_PREFIX}${ENVIRONMENT_SUFFIX}${SEGMENT_SUFFIX}${LEVEL_SUFFIX}${DEPLOYMENT_UNIT_SUFFIX}${DEPLOYMENT_UNIT_SUBSET_SUFFIX}}"
 TEMPLATE="${LEVEL_PREFIX}${DEPLOYMENT_UNIT_PREFIX}${DEPLOYMENT_UNIT_SUBSET_PREFIX}${REGION_PREFIX}template.json"
 STACK="${LEVEL_PREFIX}${DEPLOYMENT_UNIT_PREFIX}${DEPLOYMENT_UNIT_SUBSET_PREFIX}${REGION_PREFIX}stack.json"
 CHANGE="${LEVEL_PREFIX}${DEPLOYMENT_UNIT_PREFIX}${DEPLOYMENT_UNIT_SUBSET_PREFIX}${REGION_PREFIX}lastchange.json"

--- a/aws/templates/container/container_couchdb.ftl
+++ b/aws/templates/container/container_couchdb.ftl
@@ -1,31 +1,9 @@
 [#case "couchdb"]
+    [#-- COUCHDB credentials (USER, PASSWORD) expected in env --]
 
     [@Attributes image="couchdb" /]
 
-    [#assign adminCredentials = 
-                (credentialsObject[formatComponentShortName(
-                                    tier,
-                                    component,
-                                    containerId)])!""]
-    [#if adminCredentials?has_content]
-        [@Variables
-            {
-                "COUCHDB_USER" : adminCredentials.Login.Username,
-                "COUCHDB_PASSWORD" : adminCredentials.Login.Password
-            }
-        /]
-    [#else]
-        [@Variables
-            {
-                "COUCHDB_USER" : "admin",
-                "COUCHDB_PASSWORD" : "changeme"
-            }
-        /]
-    [/#if]
-
     [@Volume "couchdb" "/usr/local/var/lib/couchdb" "/codeontap/couchdb" /]
     
-    [@Policy credentialsDecryptPermission() /]
-
     [#break]
 

--- a/aws/templates/container/container_filter.ftl
+++ b/aws/templates/container/container_filter.ftl
@@ -1,6 +1,7 @@
 [#case "filter"]
+    [#-- DATA and QUERY credentials (USERNAME, PASSWORD) expected in env --]
+    [#-- TODO(mfl): change container to use standard ES atributes --]
     [#assign es = component.Links["es"]]
-    [#assign sharedCredential = credentialsObject["shared"]]
     
     [@Attributes image="esfilter" /]
     
@@ -12,15 +13,8 @@
                     formatElasticSearchId(
                         es.Tier,
                         es.Component),
-                    DNS_ATTRIBUTE_TYPE) + ":443",
-            "DATA_USERNAME" : sharedCredential.Data.Username,
-            "DATA_PASSWORD" : sharedCredential.Data.Password,
-            "QUERY_USERNAME" : sharedCredential.Query.Username,
-            "QUERY_PASSWORD" : sharedCredential.Query.Password
-        }
+                    DNS_ATTRIBUTE_TYPE) + ":443"        }
     /]
             
-    [@Policy credentialsDecryptPermission() /]
-
     [#break]
 

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -113,8 +113,6 @@
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
-    [#local apiId = formatResourceId("api", core.Id)]
-
     [#-- Resource Id doesn't follow the resource type for backwards compatability --]
     [#if getExistingReference(formatResourceId("api", core.Id))?has_content ]
         [#local apiId = formatResourceId("api", core.Id)]

--- a/aws/templates/id/id_ec2.ftl
+++ b/aws/templates/id/id_ec2.ftl
@@ -91,11 +91,14 @@
                 "Subobjects" : true,
                 "Children" : [
                     {
+                        "Name" : "IPAddressGroups",
+                        "Default" : []
+                    },
+                    {
                         "Name" : "LB",
                         "Children" : lbChildConfiguration
                     }
                 ]
-                
             }
         ]
     }]
@@ -106,7 +109,7 @@
     [#local zoneResources = {}]
 
     [#list zones as zone ]
-        [#local zoneResources += 
+        [#local zoneResources +=
             { zone.Id : {
                 "ec2Instance" : {
                     "Id"   : formatResourceId(AWS_EC2_INSTANCE_RESOURCE_TYPE, core.Id, zone.Id),
@@ -148,7 +151,7 @@
                     "Id" : formatComponentRoleId(core.Tier, core.Component),
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
                 },
-                "Zones" : zoneResources 
+                "Zones" : zoneResources
             },
             "Attributes" : {
             },

--- a/aws/templates/id/id_eip.ftl
+++ b/aws/templates/id/id_eip.ftl
@@ -23,14 +23,16 @@
 [/#function]
 
 [#function formatComponentEIPId tier component extensions...]
-    [#return formatEIPId(
+    [#return formatComponentResourceId(
+                AWS_EIP_RESOURCE_TYPE,
                 tier,
                 component,
                 extensions)]
 [/#function]
 
 [#function formatComponentEIPAssociationId tier component extensions...]
-    [#return formatEIPAssociationId(
+    [#return formatComponentResourceId(
+                AWS_EIP_ASSOCIATION_RESOURCE_TYPE,
                 tier,
                 component,
                 extensions)]

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -58,88 +58,10 @@
                 "Default" : {}
             },
             {
-                "Name" : "Mapping",
-                "Mandatory" : true
+                "Name" : "Mapping"
             }
         ]
     }]
-
-[#function addPortMappingIdAndName mapping component]
-    [#local portMapping = mapping.Mapping!""]
-
-    [#if !portMapping?has_content ]
-        [@cfException
-            mode=listMode
-            description="Port mapping missing"
-            context=component
-            detail=mapping /]
-
-        [#local portMapping = "?"]
-    [/#if]
-
-    [#local source = (portMappings[portMapping].Source)!""]
-    [#local destination = (portMappings[portMapping].Destination)!""]
-
-    [#if !source?has_content ]
-        [@cfException
-            mode=listMode
-            description="Unknown source port"
-            context=component
-            detail=mapping /]
-    [/#if]
-    [#if !destination?has_content ]
-        [@cfException
-            mode=listMode
-            description="Unknown destination port"
-            context=component
-            detail=mapping /]
-    [/#if]
-
-    [#return
-        mapping +
-        {
-            "Id" : (ports[source].Port)!portMapping,
-            "Name" : contentIfContent(source, portMapping),
-            "Mapping" : portMapping
-        } ]
-[/#function]
-
-[#function migrateLBComponent component ]
-    [#local newPortMappings = {} ]
-    [#if component.PortMappings?is_sequence ]
-        [#list component.PortMappings as portMapping]
-            [#if portMapping?is_string]
-                [#local newPortMappings +=
-                    {
-                        portMapping :
-                            addPortMappingIdAndName(
-                                {"Mapping" : portMapping},
-                                component)
-                    } ]
-            [/#if]
-            [#if portMapping?is_hash]
-                [#local newPortMappings +=
-                {
-                    portMapping :
-                        addPortMappingIdAndName(
-                            portMapping,
-                            component)
-                } ]
-            [/#if]
-        [/#list]
-    [#else]
-        [#list component.PortMappings as key,portMapping]
-            [#local newPortMappings +=
-            {
-                portMapping :
-                    addPortMappingIdAndName(
-                        portMapping,
-                        component)
-            } ]
-        [/#list]
-    [/#if]
-    [#return component + { "PortMappings" : newPortMappings } ]
-[/#function]
 
 [#function getLBState occurrence]
     [#local core = occurrence.Core]
@@ -182,7 +104,7 @@
     [#local internalFqdn = parentState.Attributes["INTERNAL_FQDN"] ]
     [#local lbId = parentState.Resources["lb"].Id]
 
-    [#local sourcePort = (ports[portMappings[solution.Mapping].Source])!{} ]
+    [#local sourcePort = (ports[portMappings[solution.Mapping!core.SubComponent.Name].Source])!{} ]
 
     [#local id = formatResourceId(AWS_ALB_LISTENER_RESOURCE_TYPE, core.Id) ]
 

--- a/aws/templates/segment/segment_cmk.ftl
+++ b/aws/templates/segment/segment_cmk.ftl
@@ -40,20 +40,23 @@
                         "  info \"Checking SSH credentials ...\"",
                         "  #",
                         "  # Create SSH credential for the segment",
-                        "  mkdir -p \"$\{ENVIRONMENT_CREDENTIALS_DIR}\"",
-                        "  create_pki_credentials \"$\{ENVIRONMENT_CREDENTIALS_DIR}\" || return $?",
+                        "  mkdir -p \"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}\"",
+                        "  create_pki_credentials \"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}\" || return $?",
                         "  #",
                         "  # Update the credential",
+                        "  pem_file=\"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}/aws-ssh-crt.pem\"",
+                        "  [[ -f \"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}/.aws-ssh-crt.pem\" ]] &&",
+                        "    pem_file=\"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}/.aws-ssh-crt.pem\"",
                         "  update_ssh_credentials" + " " +
                             "\"" + regionId + "\" " +
                             "\"" + formatEnvironmentFullName() + "\" " +
-                            "\"$\{ENVIRONMENT_CREDENTIALS_DIR}/aws-ssh-crt.pem\" || return $?",
-                        "  [[ -f \"$\{ENVIRONMENT_CREDENTIALS_DIR}/aws-ssh-prv.pem.plaintext\" ]] && ",
+                            "\"$\{pem_file}\" || return $?",
+                        "  [[ -f \"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}/.aws-ssh-prv.pem.plaintext\" ]] && ",
                         "    { encrypt_file" + " " +
                                "\"" + regionId + "\"" + " " +
                                "segment" + " " +
-                               "\"$\{ENVIRONMENT_CREDENTIALS_DIR}/aws-ssh-prv.pem.plaintext\"" + " " +
-                               "\"$\{ENVIRONMENT_CREDENTIALS_DIR}/aws-ssh-prv.pem\" || return $?; }",
+                               "\"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}/.aws-ssh-prv.pem.plaintext\"" + " " +
+                               "\"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}/.aws-ssh-prv.pem\" || return $?; }",
                         "  return 0"
                         "}",
                         "#",
@@ -62,7 +65,7 @@
                         "    delete_ssh_credentials " + " " +
                             "\"" + regionId + "\" " +
                             "\"" + formatEnvironmentFullName() + "\" || return $?",
-                        "    delete_pki_credentials \"$\{ENVIRONMENT_CREDENTIALS_DIR}\" || return $?",
+                        "    delete_pki_credentials \"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}\" || return $?",
                         "    ;;",
                         "  create|update)",
                         "    manage_ssh_credentials || return $?",

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -189,21 +189,13 @@
 [#-- Name prefixes --]
 [#assign shortNamePrefixes = [] ]
 [#assign fullNamePrefixes = [] ]
-[#assign cmdbLookupPrefixes = [] ]
+[#assign cmdbProductLookupPrefixes = [] ]
 [#assign segmentQualifiers = [] ]
 
 [#-- Standard inputs --]
 [#assign blueprintObject = blueprint?eval]
 
 [#assign settingsObject = settings?eval ]
-
-[#-- Legacy credentials formats had a top level Credentials attribute --]
-[#assign credentialsObject =
-    credentials?has_content?then(credentials?eval, {}) ]
-[#assign credentialsObject += credentialsObject.Credentials!{} ]
-
-[#assign appSettingsObject =
-    appsettings?has_content?then(appsettings?eval, {}) ]
 
 [#assign stackOutputsList =
     stackOutputs?has_content?then(stackOutputs?eval, []) ]
@@ -279,7 +271,7 @@
 
     [#assign shortNamePrefixes += [productId] ]
     [#assign fullNamePrefixes += [productName] ]
-    [#assign cmdbLookupPrefixes += [[productName, "shared", "default"]] ]
+    [#assign cmdbProductLookupPrefixes += ["shared"] ]
 
 [/#if]
 
@@ -294,8 +286,8 @@
     [#assign segmentName = segmentObject.Name]
     [#assign segments += {segmentId : segmentObject} ]
 
-    [#if segmentObject.Environment?? || blueprintObject.Environment?? ]
-        [#assign environmentId = (blueprintObject.Environment.Id)!segmentObject.Environment]
+    [#if blueprintObject.Environment?? ]
+        [#assign environmentId = blueprintObject.Environment.Id ]
         [#assign environmentObject = environments[environmentId]]
         [#assign environmentName = environmentObject.Name]
         [#assign categoryId = segmentObject.Category!environmentObject.Category]
@@ -304,20 +296,20 @@
 
         [#assign shortNamePrefixes += [environmentId] ]
         [#assign fullNamePrefixes += [environmentName] ]
-        [#assign segmentQualifiers += [environmentId, environmentName] ]
+        [#assign segmentQualifiers += [environmentId, environmentName, segmentId, segmentName] ]
 
-        [#if (segmentName != environmentName) &&
-              (segmentName != "default") ]
-              [#assign shortNamePrefixes += [segmentId] ]
-              [#assign fullNamePrefixes += [segmentName] ]
-              [#assign segmentQualifiers += [segmentId, segmentName] ]
+        [#assign cmdbProductLookupPrefixes +=
+            [
+                ["shared", segmentName],
+                environmentName,
+                [environmentName, segmentName]
+            ] ]
+
+        [#if (segmentName != "default") ]
+            [#assign shortNamePrefixes += [segmentId] ]
+            [#assign fullNamePrefixes += [segmentName] ]
         [/#if]
 
-        [#assign cmdbLookupPrefixes +=
-            [
-                [productName, "shared", segmentName],
-                [productName, environmentName, segmentName]
-            ] ]
     [/#if]
 
     [#assign vpc = getExistingReference(formatVPCId())]

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -34,6 +34,7 @@
 
             [#list occurrence.Occurrences![] as subOccurrence]
 
+                [#assign core = subOccurrence.Core ]
                 [#assign solution = subOccurrence.Configuration.Solution ]
                 [#assign resources = subOccurrence.State.Resources ]
 
@@ -47,17 +48,18 @@
 
                 [#assign lbSecurityGroupIds += [securityGroupId] ]
 
-                [#assign source = (portMappings[solution.Mapping].Source)!"" ]
-                [#assign destination = (portMappings[solution.Mapping].Destination)!"" ]
+                [#assign mapping = solution.Mapping!core.SubComponent.Name ]
+                [#assign source = (portMappings[mapping].Source)!"" ]
+                [#assign destination = (portMappings[mapping].Destination)!"" ]
                 [#assign sourcePort = (ports[source])!{} ]
                 [#assign destinationPort = (ports[destination])!{} ]
-
-                [#assign portProtocols += [ sourcePort.Protocol ] ]
-                [#assign portProtocols += [ destinationPort.Protocol] ]
 
                 [#if !(sourcePort?has_content && destinationPort?has_content)]
                     [#continue ]
                 [/#if]
+
+                [#assign portProtocols += [ sourcePort.Protocol ] ]
+                [#assign portProtocols += [ destinationPort.Protocol] ]
 
                 [#assign cidr= getGroupCIDRs(solution.IPAddressGroups) ]
 

--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -31,8 +31,6 @@
         
         [#assign userPoolUpdateCommand = "updateUserPool" ]            
     
-        [@cfDebug listMode appSettingsObject false /]
-
         [#assign emailVerificationMessage =
             getOccurrenceSettingValue(occurrence, ["UserPool", "EmailVerificationMessage"], true) ]
 


### PR DESCRIPTION
Introduce an environment directory layer between product and segment
to support multi-segment products.

Rename appsettings to settings, solutions to solutionsv2, and
credentials to operations.

Support a reserved environment of "shared" to support sharing
across all instances of the same segment across environments, as well as
across all segments of all environments.

A segment of "default" will not appear in names, in much the same way as
an instance or version of "default" does not appear in names.

Support for appsettings and credentials has been removed as these have
been superceded by the settings support.

Refactor upgrade support to separate the upgrade process from the cleanup
process.

Remove the automatic migration of ALB config to ensure it is explicit as to
what is expected. Rework the LB support for EC2 and its config along the
same lines.

Use the ignoring of "dot" files to make ssh credentials invisible by
default to the app.

The commit also includes some general tidyup such as the use of FUNCNAME
as part of temporary directory creation, and removal of the functions to
manipulate CMDB files (this is now done in the affected templates).