### PR TITLE
Reinstate allowance for missing subcomponents

### DIFF
--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -606,7 +606,7 @@ function findGen3Dirs() {
       declare -gx ${prefix}ENVIRONMENT_SHARED_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/${environment}
       declare -gx ${prefix}ENVIRONMENT_SHARED_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/${environment}
       declare -gx ${prefix}ENVIRONMENT_SHARED_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}
-      debug "ENVIRONMENT_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}"
+      debug "ENVIRONMENT_DIR=$(getGen3Env "PRODUCT_SOLUTIONS_DIR" "${prefix}")/${environment}"
 
       if [[ -n "${segment}" ]]; then
 
@@ -618,7 +618,7 @@ function findGen3Dirs() {
         declare -gx ${prefix}SEGMENT_BUILDS_DIR=$(getGen3Env     "PRODUCT_SETTINGS_DIR"   "${prefix}")/${environment}/${segment}
         declare -gx ${prefix}SEGMENT_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/${environment}/${segment}
         declare -gx ${prefix}SEGMENT_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}/${segment}
-        debug "SEGMENT_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}/${segment}"
+        debug "SEGMENT_DIR=$(getGen3Env "PRODUCT_SOLUTIONS_DIR" "${prefix}")/${environment}/${segment}"
       fi
     fi
   fi

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1426,7 +1426,7 @@
                         [#if ((typeObject[subComponent.Component])!{})?is_hash ]
                             [#local subComponentInstances =
                                 (typeObject[subComponent.Component].Components)!
-                                (typeObject[subComponent.Component])
+                                (typeObject[subComponent.Component])!{}
                             ]
                         [#else]
                             [@cfException


### PR DESCRIPTION
It is possible to have a parent component not not its subcomponents
(e.g. ECS with services but no tasks), so reinstate the support for
this.

Also correct the debug trace to show solutions dirs for ENVIRONMENT and
SEGMENT rther than opertions dirs.