### PR TITLE
Revert to segment based ssh keypairs

### DIFF
--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -1043,17 +1043,15 @@ EOF
           for pem_file in "${pem_files[@]}"; do
             local file_name="$(fileName "${pem_file}")"
             local segment_dir="$(filePath "${pem_file}")"
-            local environment_dir="$(filePath "${segment_dir}")"
 
-            # Move the file so it can be shared by all segments in the environment
-            # Also make it invisible to the generation process
-            debug "Moving ${pem_file} to ${environment_dir}/.${file_name} ..."
-            mv "${pem_file}" "${environment_dir}/.${file_name}"
+            # Move the pem files to make them invisible to the generation process
+            debug "Moving ${pem_file} to ${segment_dir}/.${file_name} ..."
+            mv "${pem_file}" "${segment_dir}/.${file_name}"
 
-            local environment_ignore_file="${environment_dir}/.gitignore"
-            if [[ ! -f "${environment_ignore_file}" ]]; then
-              debug "Creating ${environment_ignore_file} ..."
-              cat << EOF > "${environment_ignore_file}"
+            local segment_ignore_file="${segment_dir}/.gitignore"
+            if [[ ! -f "${segment_ignore_file}" ]]; then
+              debug "Creating ${segment_ignore_file} ..."
+              cat << EOF > "${segment_ignore_file}"
 *.plaintext
 *.decrypted
 *.ppk

--- a/aws/templates/id/id_ec2.ftl
+++ b/aws/templates/id/id_ec2.ftl
@@ -6,6 +6,7 @@
 [#assign AWS_EC2_AUTO_SCALE_GROUP_RESOURCE_TYPE = "asg" ]
 [#assign AWS_EC2_LAUNCH_CONFIG_RESOURCE_TYPE = "launchConfig" ]
 [#assign AWS_EC2_NETWORK_INTERFACE_RESOURCE_TYPE = "eni" ]
+[#assign AWS_EC2_KEYPAIR_RESOURCE_TYPE = "keypair" ]
 
 [#function formatEC2InstanceId tier component extensions...]
     [#return formatComponentResourceId(
@@ -65,6 +66,12 @@
                 tier,
                 component,
                 port.Port?c)]
+[/#function]
+
+[#function formatEC2KeyPairId extensions...]
+    [#return formatSegmentResourceId(
+                AWS_EC2_KEYPAIR_RESOURCE_TYPE,
+                extensions)]
 [/#function]
 
 [#-- Components --]

--- a/aws/templates/segment/segment_cmk.ftl
+++ b/aws/templates/segment/segment_cmk.ftl
@@ -4,7 +4,7 @@
         [#-- TODO: Get rid of inconsistent id usage --]
         [#assign cmkId = formatSegmentCMKTemplateId()]
         [#assign cmkAliasId = formatSegmentCMKAliasId(cmkId)]
-    
+
         [@createCMK
             mode=listMode
             id=cmkId
@@ -14,14 +14,14 @@
                     getPolicyStatement(
                         "kms:*",
                         "*",
-                        { 
+                        {
                             "AWS": formatAccountPrincipalArn()
                         }
                     )
                 ]
             outputId=formatSegmentCMKId()
         /]
-        
+
         [@createCMKAlias
             mode=listMode
             id=cmkAliasId
@@ -40,33 +40,57 @@
                         "  info \"Checking SSH credentials ...\"",
                         "  #",
                         "  # Create SSH credential for the segment",
-                        "  mkdir -p \"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}\"",
-                        "  create_pki_credentials \"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}\" || return $?",
+                        "  mkdir -p \"$\{SEGMENT_OPERATIONS_DIR}\"",
+                        "  create_pki_credentials \"$\{SEGMENT_OPERATIONS_DIR}\" || return $?",
                         "  #",
-                        "  # Update the credential",
-                        "  pem_file=\"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}/aws-ssh-crt.pem\"",
-                        "  [[ -f \"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}/.aws-ssh-crt.pem\" ]] &&",
-                        "    pem_file=\"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}/.aws-ssh-crt.pem\"",
-                        "  update_ssh_credentials" + " " +
+                        "  # Update the credential if required",
+                        "  if ! check_ssh_credentials" + " " +
                             "\"" + regionId + "\" " +
-                            "\"" + formatEnvironmentFullName() + "\" " +
-                            "\"$\{pem_file}\" || return $?",
-                        "  [[ -f \"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}/.aws-ssh-prv.pem.plaintext\" ]] && ",
-                        "    { encrypt_file" + " " +
-                               "\"" + regionId + "\"" + " " +
-                               "segment" + " " +
-                               "\"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}/.aws-ssh-prv.pem.plaintext\"" + " " +
-                               "\"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}/.aws-ssh-prv.pem\" || return $?; }",
+                             "\"$\{key_pair_name}\"; then",
+                        "    pem_file=\"$\{SEGMENT_OPERATIONS_DIR}/.aws-ssh-crt.pem\"",
+                        "    update_ssh_credentials" + " " +
+                               "\"" + regionId + "\" " +
+                               "\"$\{key_pair_name}\" " +
+                               "\"$\{pem_file}\" || return $?",
+                        "    [[ -f \"$\{SEGMENT_OPERATIONS_DIR}/.aws-ssh-prv.pem.plaintext\" ]] && ",
+                        "      { encrypt_file" + " " +
+                                 "\"" + regionId + "\"" + " " +
+                                 "segment" + " " +
+                                 "\"$\{SEGMENT_OPERATIONS_DIR}/.aws-ssh-prv.pem.plaintext\"" + " " +
+                                 "\"$\{SEGMENT_OPERATIONS_DIR}/.aws-ssh-prv.pem\" || return $?; }",
+                        "  fi",
+                        "  #",
+                        "  create_pseudo_stack" + " " +
+                             "\"SSH Key Pair\"" + " " +
+                             "\"$\{key_pair_pseudo_stack_file}\"" + " " +
+                             "\"keypairXsegmentXname\" \"$\{key_pair_name}\" || return $?",
+                        "  #",
+                        "  show_ssh_credentials" + " " +
+                             "\"" + regionId + "\" " +
+                             "\"$\{key_pair_name}\"",
+                        "  #",
                         "  return 0"
                         "}",
                         "#",
+                        "key_pair_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-keypair-pseudo-stack.json\" ",
+                        "#",
+                        "# Determine the required key pair name",
+                        "# Legacy support for existing keypairs for default segments",
+                        "key_pair_name=\"" + formatName(productName, environmentName, segmentName) + "\"",
+                        valueIfTrue(
+                          "  check_ssh_credentials" + " " +
+                               "\"" + regionId + "\" " +
+                               "\"" + formatEnvironmentFullName() + "\" && key_pair_name=\"" + formatEnvironmentFullName() + "\"",
+                          segmentName == "default",
+                          "#"),
+                        "#",
                         "case $\{STACK_OPERATION} in",
-                        "#  delete)",
-                        "#    delete_ssh_credentials " + " " +
+                        "  delete)",
+                        "    delete_ssh_credentials " + " " +
                             "\"" + regionId + "\" " +
-                            "\"" + formatEnvironmentFullName() + "\" || return $?",
-                        "#    delete_pki_credentials \"$\{ENVIRONMENT_SHARED_OPERATIONS_DIR}\" || return $?",
-                        "#    ;;",
+                            "\"$\{key_pair_name}\" || return $?",
+                        "    delete_pki_credentials \"$\{SEGMENT_OPERATIONS_DIR}\" || return $?",
+                        "    ;;",
                         "  create|update)",
                         "    manage_ssh_credentials || return $?",
                         "    ;;",
@@ -92,12 +116,12 @@
                     "  oai_canonical_id=$(jq -r \".S3CanonicalUserId\" < \"$\{oai_file}\") || return $?",
                     "  create_pseudo_stack" + " " +
                          "\"Cloudfront Origin Access Identity\"" + " " +
-                         "\"$\{pseudo_stack_file}\"" + " " +
+                         "\"$\{oai_pseudo_stack_file}\"" + " " +
                          "\"cfaccessXs3XsegmentXops\" \"$\{oai_id}\"" + " " +
                          "\"cfaccessXs3XsegmentXopsXcanonicalid\" \"$\{oai_canonical_id}\" || return $?"
                     "}"
                     "#",
-                    "pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-pseudo-stack.json\" ",
+                    "oai_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-pseudo-stack.json\" ",
                     "case $\{STACK_OPERATION} in",
                     "  delete)",
                     "  delete_oai_credentials" + " " +

--- a/aws/templates/segment/segment_cmk.ftl
+++ b/aws/templates/segment/segment_cmk.ftl
@@ -59,11 +59,10 @@
                                  "\"$\{SEGMENT_OPERATIONS_DIR}/.aws-ssh-prv.pem.plaintext\"" + " " +
                                  "\"$\{SEGMENT_OPERATIONS_DIR}/.aws-ssh-prv.pem\" || return $?; }",
                         "  fi",
-                        "  #",
-                        "  create_pseudo_stack" + " " +
-                             "\"SSH Key Pair\"" + " " +
-                             "\"$\{key_pair_pseudo_stack_file}\"" + " " +
-                             "\"keypairXsegmentXname\" \"$\{key_pair_name}\" || return $?",
+                        "  #"
+                      ] +
+                      pseudoStackOutputScript("SSH Key Pair", {"keypairXsegmentXname" : "$\{key_pair_name}"}, "keypair-pseudo") +
+                      [
                         "  #",
                         "  show_ssh_credentials" + " " +
                              "\"" + regionId + "\" " +
@@ -71,8 +70,6 @@
                         "  #",
                         "  return 0"
                         "}",
-                        "#",
-                        "key_pair_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-keypair-pseudo-stack.json\" ",
                         "#",
                         "# Determine the required key pair name",
                         "# Legacy support for existing keypairs for default segments",
@@ -113,13 +110,17 @@
                         "\"$\{oai_file}\" || return $?",
                     "  #",
                     "  oai_id=$(jq -r \".Id\" < \"$\{oai_file}\") || return $?",
-                    "  oai_canonical_id=$(jq -r \".S3CanonicalUserId\" < \"$\{oai_file}\") || return $?",
-                    "  create_pseudo_stack" + " " +
-                         "\"Cloudfront Origin Access Identity\"" + " " +
-                         "\"$\{oai_pseudo_stack_file}\"" + " " +
-                         "\"cfaccessXs3XsegmentXops\" \"$\{oai_id}\"" + " " +
-                         "\"cfaccessXs3XsegmentXopsXcanonicalid\" \"$\{oai_canonical_id}\" || return $?"
-                    "}"
+                    "  oai_canonical_id=$(jq -r \".S3CanonicalUserId\" < \"$\{oai_file}\") || return $?"
+                ] +
+                pseudoStackOutputScript(
+                    "Cloudfront Origin Access Identity",
+                    {
+                        "cfaccessXs3XsegmentXops" : "$\{oai_id}",
+                        "cfaccessXs3XsegmentXopsXcanonicalid" : "$\{oai_canonical_id}"
+                    }
+                ) +
+                [
+                    "}",
                     "#",
                     "oai_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-pseudo-stack.json\" ",
                     "case $\{STACK_OPERATION} in",

--- a/aws/templates/segment/segment_vpc.ftl
+++ b/aws/templates/segment/segment_vpc.ftl
@@ -473,12 +473,7 @@
                 type="AWS::AutoScaling::LaunchConfiguration"
                 properties=
                     {
-                        "KeyName":
-                            valueIfTrue(
-                                formatEnvironmentFullName(),
-                                sshPerEnvironment,
-                                productName
-                            ),
+                        "KeyName": getExistingReference(formatEC2KeyPairId(), NAME_ATTRIBUTE_TYPE),
                         "ImageId": regionObject.AMIs.Centos.EC2,
                         "InstanceType": processorProfile.Processor,
                         "SecurityGroups" : [ getReference(sshToProxySecurityGroupId) ],
@@ -788,12 +783,7 @@
                         type="AWS::AutoScaling::LaunchConfiguration"
                         properties=
                             {
-                                "KeyName":
-                                    valueIfTrue(
-                                        formatEnvironmentFullName(),
-                                        sshPerEnvironment,
-                                        productName
-                                    ),
+                                "KeyName": getExistingReference(formatEC2KeyPairId(), NAME_ATTRIBUTE_TYPE),
                                 "ImageId": regionObject.AMIs.Centos.NAT,
                                 "InstanceType": processorProfile.Processor,
                                 "SecurityGroups" : (sshEnabled && !sshStandalone)?then(

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -391,12 +391,7 @@
                                 "IamInstanceProfile" : { "Ref" : ec2InstanceProfileId },
                                 "InstanceInitiatedShutdownBehavior" : "stop",
                                 "InstanceType": processorProfile.Processor,
-                                "KeyName":
-                                    valueIfTrue(
-                                        formatEnvironmentFullName(),
-                                        sshPerEnvironment,
-                                        productName
-                                    ),
+                                "KeyName": getExistingReference(formatEC2KeyPairId(), NAME_ATTRIBUTE_TYPE),
                                 "Monitoring" : false,
                                 "NetworkInterfaces" : [
                                     {

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -318,12 +318,7 @@
                 properties=
                     getBlockDevices(storageProfile) +
                     {
-                        "KeyName":
-                            valueIfTrue(
-                                formatEnvironmentFullName(),
-                                sshPerEnvironment,
-                                productName
-                            ),
+                        "KeyName": getExistingReference(formatEC2KeyPairId(), NAME_ATTRIBUTE_TYPE),
                         "ImageId": regionObject.AMIs.Centos.ECS,
                         "InstanceType": processorProfile.Processor,
                         "SecurityGroups" : 

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -816,19 +816,27 @@ function delete_pki_credentials() {
 
 # -- SSH --
 
+function check_ssh_credentials() {
+  local region="$1"; shift
+  local name="$1"; shift
+
+  aws --region "${region}" ec2 describe-key-pairs --key-name "${name}" > /dev/null 2>&1
+}
+
+function show_ssh_credentials() {
+  local region="$1"; shift
+  local name="$1"; shift
+
+  aws --region "${region}" ec2 describe-key-pairs --key-name "${name}"
+}
+
 function update_ssh_credentials() {
   local region="$1"; shift
   local name="$1"; shift
   local crt_file="$1"; shift
 
-  local crt_content=
-
-  aws --region "${region}" ec2 describe-key-pairs --key-name "${name}" > /dev/null 2>&1 ||
-    { crt_content=$(dos2unix < "${crt_file}" | awk 'BEGIN {RS="\n"} /^[^-]/ {printf $1}'); \
-    aws --region "${region}" ec2 import-key-pair --key-name "${name}" --public-key-material "${crt_content}"; }
-
-  # Show the current credential
-  aws --region "${region}" ec2 describe-key-pairs --key-name "${name}"
+  local crt_content=$(dos2unix < "${crt_file}" | awk 'BEGIN {RS="\n"} /^[^-]/ {printf $1}')
+  aws --region "${region}" ec2 import-key-pair --key-name "${name}" --public-key-material "${crt_content}"
 }
 
 function delete_ssh_credentials() {


### PR DESCRIPTION
In order to avoid complexities associated with managing environment
based ssh keypairs, revert to using segment based keypairs.

In order not to affect legacy environments, segments of default will
check if a keypair already exists without the segment, and if so, the
segment-less name will continue to be used.