### PR TITLE
Add settings to stage Variables for API Gateway Deployments

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -12,7 +12,7 @@
         [#assign resources = occurrence.State.Resources ]
         [#assign attributes = occurrence.State.Attributes ]
         [#assign roles = occurrence.State.Roles]
-        
+
         [#assign apiId      = resources["apigateway"].Id]
         [#assign apiName    = resources["apigateway"].Name]
 

--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -9,10 +9,11 @@
 
         [#assign core = occurrence.Core ]
         [#assign solution = occurrence.Configuration.Solution ]
+        [#assign settings = occurrence.Configuration.Settings ]
         [#assign resources = occurrence.State.Resources ]
         [#assign attributes = occurrence.State.Attributes ]
         [#assign roles = occurrence.State.Roles]
-
+        
         [#assign apiId      = resources["apigateway"].Id]
         [#assign apiName    = resources["apigateway"].Name]
 
@@ -33,6 +34,25 @@
             ]
         ]
         [#assign stageVariables = {} ]
+
+        [#assign containerId =
+            solution.Container?has_content?then(
+                solution.Container,
+                getComponentId(component)
+            ) ]
+        
+        [#assign environmentContext =
+            {
+                "DefaultEnvironment" : defaultEnvironment(occurrence),
+                "Environment" : {},
+                "Links" : getLinkTargets(occurrence),
+                "DefaultCoreVariables" : false,
+                "DefaultEnvironmentVariables" : true,
+                "DefaultLinkVariables" : false
+            }
+        ]
+        [#assign stageVariables += getFinalEnvironment(occurrence, environmentContext).Environment ]
+
         [#assign userPoolArns = [] ]
 
         [#list solution.Links?values as link]

--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -9,7 +9,6 @@
 
         [#assign core = occurrence.Core ]
         [#assign solution = occurrence.Configuration.Solution ]
-        [#assign settings = occurrence.Configuration.Settings ]
         [#assign resources = occurrence.State.Resources ]
         [#assign attributes = occurrence.State.Attributes ]
         [#assign roles = occurrence.State.Roles]
@@ -34,12 +33,6 @@
             ]
         ]
         [#assign stageVariables = {} ]
-
-        [#assign containerId =
-            solution.Container?has_content?then(
-                solution.Container,
-                getComponentId(component)
-            ) ]
         
         [#assign environmentContext =
             {


### PR DESCRIPTION
Adds the standard application settings configuration to API Gateway as Stage Variables. Stage Variables work like environment variables for API Gateeway and can be referenced in API Gateway swagger specs, to include external authentication endpoints or references to upstream endpoints. 