### PR TITLE
No LB Type attribute if want default

### DIFF
--- a/aws/templates/resource/resource_lb.ftl
+++ b/aws/templates/resource/resource_lb.ftl
@@ -69,9 +69,13 @@
             {
                 "Subnets" : getSubnets(tier),
                 "Scheme" : (tier.Network.RouteTable == "external")?then("internet-facing","internal"),
-                "Type" : type,
                 "Name" : shortName
             } +
+            attributeIfTrue(
+                "Type",
+                type != "application",
+                type
+            ) +
             attributeIfTrue(
                 "LoadBalancerAttributes",
                 logs && type == "application",


### PR DESCRIPTION
This is an experimental patch to not provide the type attribute if the
value is the default (application), in order to see if this stops the
triggering of a replacement rather than an update.