### PR TITLE
Add custom header support for API Gateway Cloudfront

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -242,7 +242,7 @@
                             getOccurrenceSettingValue(
                                 occurrence,
                                 ["APIGateway","API","AccessKey"]))) ]
-                [#assign defaultCacheBehaviour = getCFAPIGatewayCacheBehaviour(origin) ]
+                [#assign defaultCacheBehaviour = getCFAPIGatewayCacheBehaviour(origin, solution.CloudFront.CustomHeaders) ]
                 [#assign restrictions = {} ]
                 [#if solution.CloudFront.CountryGroups?has_content]
                     [#list asArray(solution.CloudFront.CountryGroups) as countryGroup]

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -59,6 +59,10 @@
                         "Default" : []
                     },
                     {
+                        "Name" : "CustomHeaders",
+                        "Default" : []
+                    },
+                    {
                         "Name" : "Mapping",
                         "Default" : false
                     }

--- a/aws/templates/resource/resource_cf.ftl
+++ b/aws/templates/resource/resource_cf.ftl
@@ -114,7 +114,7 @@
     ]
 [/#function]
 
-[#function getCFAPIGatewayCacheBehaviour origin]
+[#function getCFAPIGatewayCacheBehaviour origin customHeaders=[]]
     [#return
         getCFCacheBehaviour(
             origin,
@@ -151,7 +151,7 @@
                     "Authorization",
                     "Origin",
                     "Referer"
-                ],
+                ] + customHeaders,
                 "QueryString" : true
             }
         )


### PR DESCRIPTION
Some API's require custom keys for authorisation purposes. Since cloudfront whitelists the allowed headers this allows for custom headers to be passed in at the solution level. 