### PR TITLE
Add unzip package requirement to scripts setup

### DIFF
--- a/aws/templates/resource/resource_ec2.ftl
+++ b/aws/templates/resource/resource_ec2.ftl
@@ -188,6 +188,12 @@
     [#return 
         {
             "scripts" : {
+                "packages" : {
+                    "yum" : {
+                        "aws-cli" : [],
+                        "unzip" : []
+                    }
+                },
                 "files" :{
                     "/opt/codeontap/fetch_scripts.sh" : {
                         "content" : {


### PR DESCRIPTION
unzip doesn't appear to be installed by default on ECS based instances. So we need to make sure it is installed 