### PR TITLE
compute Cluster refinements 

### DIFF
--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -295,14 +295,15 @@
                     {
                         "AutoScalingRollingUpdate" : {
                             "WaitOnResourceSignals" : true,
-                            "MinInstancesInService" : solution.MinUpdateInstances
+                            "MinInstancesInService" : solution.MinUpdateInstances,
+                            "PauseTime" : "PT" + solution.UpdatePauseTime
                         }
                     }
                 )   
                 creationPolicy={
                     "ResourceSignal" : {
                         "Count" : desiredCapacity,
-                        "Timeout" : "PT15M"
+                        "Timeout" : "PT" + solution.StartupTimeout
                     }
                 }
             /]

--- a/aws/templates/id/id_computecluster.ftl
+++ b/aws/templates/id/id_computecluster.ftl
@@ -19,6 +19,14 @@
                 "Default" : false
             },
             {
+                "Name" : "UpdatePauseTime",
+                "Default" : "5M"
+            },
+            {
+                "Name" : "StartupTimeout",
+                "Default" : "15M"
+            },
+            {
                 "Name" : "DockerHost",
                 "Default" : false
             },

--- a/aws/templates/resource/resource_ec2.ftl
+++ b/aws/templates/resource/resource_ec2.ftl
@@ -238,6 +238,7 @@
                     },
                     "02RunInitScript" : {
                         "command" : "/opt/codeontap/run_scripts.sh",
+                        "cwd" : "/opt/codeontap/scripts/",
                         "ignoreErrors" : ignoreErrors
                     } + 
                     attributeIfContent(


### PR DESCRIPTION
Set the working directory for running the scripts deployment. Allows for relative referencing of scripts. 
Also adds control over the timeout and pause time for deployment and creation