### PR TITLE
Update Application components to same name for context settings

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -40,7 +40,7 @@
                 getComponentId(component)
             ) ]
 
-        [#assign environmentContext =
+        [#assign context =
             {
                 "Id" : containerId,
                 "Name" : containerId,
@@ -57,10 +57,10 @@
 
         [#-- Add in container specifics including override of defaults --]
         [#assign containerListMode = "model"]
-        [#assign containerId = formatContainerFragmentId(occurrence, environmentContext)]
+        [#assign containerId = formatContainerFragmentId(occurrence, context)]
         [#include containerList?ensure_starts_with("/")]
-
-        [#assign stageVariables += getFinalEnvironment(occurrence, environmentContext).Environment ]
+        
+        [#assign stageVariables += getFinalEnvironment(occurrence, context).Environment ]
 
         [#assign userPoolArns = [] ]
 

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -52,7 +52,7 @@
                 getComponentId(component)
             ) ]
 
-        [#assign environmentContext =
+        [#assign context =
             {
                 "Id" : containerId,
                 "Name" : containerId,
@@ -69,10 +69,10 @@
 
         [#-- Add in container specifics including override of defaults --]
         [#assign containerListMode = "model"]
-        [#assign containerId = formatContainerFragmentId(occurrence, environmentContext)]
+        [#assign containerId = formatContainerFragmentId(occurrence, context)]
         [#include containerList?ensure_starts_with("/")]
 
-        [#assign environmentVariables += getFinalEnvironment(occurrence, environmentContext).Environment ]
+        [#assign environmentVariables += getFinalEnvironment(occurrence, context).Environment ]
 
         [#assign configSets += 
             getInitConfigScriptsDeployment(scriptsFile, environmentVariables, false) +


### PR DESCRIPTION
When processing a container fragment some of the processing expects a variable called context. This change makes the context property consistent across application components. 