### PR TITLE
Compute Cluster  docker style entrypoint script 

### DIFF
--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -301,15 +301,15 @@
                     }
                 )   
                 creationPolicy=
-                (solution.UseInitAsService != true )?then(
-                    {
-                        "ResourceSignal" : {
-                            "Count" : desiredCapacity,
-                            "Timeout" : "PT" + solution.StartupTimeout
-                        }
-                    },
-                    {}
-                )    
+                    (solution.UseInitAsService != true )?then(
+                        {
+                            "ResourceSignal" : {
+                                "Count" : desiredCapacity,
+                                "Timeout" : "PT" + solution.StartupTimeout
+                            }
+                        },
+                        {}
+                    )    
             /]
                     
             [#assign imageId = dockerHost?then(

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -74,9 +74,7 @@
 
         [#assign environmentVariables += getFinalEnvironment(occurrence, environmentContext).Environment ]
 
-        [#assign configSets += 
-            getInitConfigScriptsDeployment(scriptsFile, environmentVariables, false) +
-            getInitConfigEnvFacts(environmentVariables, false)]
+        [#assign configSets +=  getInitConfigEnvFacts(environmentVariables, false) ]
 
         [#assign ingressRules = []]
 
@@ -198,6 +196,8 @@
             [/#switch]
         [/#list]
 
+        [#assign configSets += getInitConfigScriptsDeployment(scriptsFile, environmentVariables, solution.UseInitAsService, false)]
+
         [#if deploymentSubsetRequired(COMPUTECLUSTER_COMPONENT_TYPE, true)]
 
             [@createComponentSecurityGroup
@@ -294,18 +294,22 @@
                     },
                     {
                         "AutoScalingRollingUpdate" : {
-                            "WaitOnResourceSignals" : true,
+                            "WaitOnResourceSignals" : (solution.UseInitAsService != true),
                             "MinInstancesInService" : solution.MinUpdateInstances,
                             "PauseTime" : "PT" + solution.UpdatePauseTime
                         }
                     }
                 )   
-                creationPolicy={
-                    "ResourceSignal" : {
-                        "Count" : desiredCapacity,
-                        "Timeout" : "PT" + solution.StartupTimeout
+                creationPolicy=
+                (solution.UseInitAsService == true )?then(
+                    {},
+                    {
+                        "ResourceSignal" : {
+                            "Count" : desiredCapacity,
+                            "Timeout" : "PT" + solution.StartupTimeout
+                        }
                     }
-                }
+                )    
             /]
                     
             [#assign imageId = dockerHost?then(
@@ -324,7 +328,7 @@
                 imageId=imageId
                 routeTable=tier.Network.RouteTable
                 configSet=configSetName
-                enableCfnSignal=true
+                enableCfnSignal=(solution.UseInitAsService != true)
                 environmentId=environmentId
             /]
         [/#if]

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -301,14 +301,14 @@
                     }
                 )   
                 creationPolicy=
-                (solution.UseInitAsService == true )?then(
-                    {},
+                (solution.UseInitAsService != true )?then(
                     {
                         "ResourceSignal" : {
                             "Count" : desiredCapacity,
                             "Timeout" : "PT" + solution.StartupTimeout
                         }
-                    }
+                    },
+                    {}
                 )    
             /]
                     

--- a/aws/templates/id/id_computecluster.ftl
+++ b/aws/templates/id/id_computecluster.ftl
@@ -11,6 +11,10 @@
                 "Children" : linkChildrenConfiguration
             },
             {
+                "Name" : "UseInitAsService",
+                "Default" : false
+            },
+            {
                 "Name" : "MinUpdateInstances",
                 "Default" : 1
             }

--- a/aws/templates/resource/resource_ec2.ftl
+++ b/aws/templates/resource/resource_ec2.ftl
@@ -186,7 +186,7 @@
     ]
 [/#function]
 
-[#function getInitConfigScriptsDeployment scriptsFile envVariables={} ignoreErrors=false ]
+[#function getInitConfigScriptsDeployment scriptsFile envVariables={} shutDownOnCompletion=false ignoreErrors=false ]
     [#return 
         {
             "scripts" : {
@@ -246,7 +246,15 @@
                         envVariables,
                         envVariables
                     )
-                }
+                } + shutDownOnCompletion?then(
+                    {
+                        "03ShutDownInstance" : {
+                            "command" : "shutdown -P +10",
+                            "ignoreErrors" : ignoreErrors
+                        }
+                    },
+                    {}
+                )
             }
         }
     ]


### PR DESCRIPTION
Adds the ability to treat the init.sh script like a docker entrypoint script which makes the script run to keep the process running constantly. 

When the init.sh script stops a shutdown command is run on the instance which forces the replacement of the instance in the autoscale group. This follows the idea of docker containers. 

