### PR TITLE
Fix LB output mappings and link processing for compute cluster

### DIFF
--- a/aws/templates/resource/resource_lb.ftl
+++ b/aws/templates/resource/resource_lb.ftl
@@ -100,7 +100,7 @@
             )
             
         tags=getCfTemplateCoreTags(name, tier, component)
-        outputs=ALB_OUTPUT_MAPPINGS
+        outputs=LB_OUTPUT_MAPPINGS
     /]
 [/#macro]
 
@@ -250,7 +250,7 @@
                 name,
                 tier,
                 component)
-        outputs=ALB_OUTPUT_MAPPINGS
+        outputs=LB_OUTPUT_MAPPINGS
         dependencies=dependencies
     /]
 [/#macro]


### PR DESCRIPTION
Update the processing order for LB ports to make sure the links are added to the environment variables

Fix for LB output mappings after LB refactoring. 