### PR TITLE
Add Security Group management for compute cluster

### DIFF
--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -139,6 +139,17 @@
                 [#case LB_PORT_COMPONENT_TYPE]
                     [#assign targetGroupPermission = true]
 
+                    [#if deploymentSubsetRequired(COMPUTECLUSTER_COMPONENT_TYPE, true)]
+                        [@createSecurityGroupIngress
+                            mode=listMode
+                            id=formatDependentSecurityGroupIngressId(
+                                resources["securityGroup"].Id, 
+                                linkTargetCore.Id)
+                            port=link.Port 
+                            cidr=linkTargetResources["sg"].Id
+                            groupId=resources["securityGroup"].Id /]
+                    [/#if]
+
                     [#switch linkTargetAttributes["ENGINE"]]
 
                         [#case "application"]
@@ -168,7 +179,7 @@
                                                 priority=link.Priority!100
                                                 dependencies=targetId
                                             /]
-
+                                            
                                             [#assign componentDependencies += [targetId]]
 
                                         [/#if]
@@ -180,7 +191,7 @@
 
                         [#case "classic" ]
                             [#assign lbId =  linkTargetAttributes["LB"] ]                                     
-                            [#-- Classic ELB's register the instance so we only need 1 registration --]
+                            [#-- Classic ELB's register the instance so we only need 1 registration --]                            
                             [#assign loadBalancers += [ getExistingReference(lbId) ]]
                             [#break]
                         [/#switch]
@@ -205,7 +216,18 @@
                 mode=listMode
                 tier=tier
                 component=component /]
-    
+
+            [#list ingressRules as rule ] 
+                [@createSecurityGroupIngress
+                        mode=listMode
+                        id=formatDependentSecurityGroupIngressId(
+                            resources["securityGroup"].Id, 
+                            rule.Port)
+                        port=rule.Port
+                        cidr=rule.CIDR
+                        groupId=resources["securityGroup"].Id /]
+            [/#list]
+
             [#assign processorProfile = getProcessor(tier, component, "ComputeCluster")]
             
             [#assign maxSize = processorProfile.MaxPerZone]

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -142,8 +142,10 @@
                     [#if deploymentSubsetRequired(COMPUTECLUSTER_COMPONENT_TYPE, true)]
                         [@createSecurityGroupIngress
                             mode=listMode
-                            id=formatSecurityGroupIngressId(
-                                    linkTargetCore.Id)
+                            id=formatDependentSecurityGroupIngressId(
+                                resources["securityGroup"].Id
+                                link.Id,
+                                link.Port)
                             port=link.Port 
                             cidr=linkTargetResources["sg"].Id
                             groupId=resources["securityGroup"].Id /]

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -144,8 +144,7 @@
                             mode=listMode
                             id=formatDependentSecurityGroupIngressId(
                                 resources["securityGroup"].Id
-                                link.Id,
-                                link.Port)
+                                link.Id)
                             port=link.Port 
                             cidr=linkTargetResources["sg"].Id
                             groupId=resources["securityGroup"].Id /]

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -142,9 +142,8 @@
                     [#if deploymentSubsetRequired(COMPUTECLUSTER_COMPONENT_TYPE, true)]
                         [@createSecurityGroupIngress
                             mode=listMode
-                            id=formatDependentSecurityGroupIngressId(
-                                resources["securityGroup"].Id, 
-                                linkTargetCore.Id)
+                            id=formatSecurityGroupIngressId(
+                                    linkTargetCore.Id)
                             port=link.Port 
                             cidr=linkTargetResources["sg"].Id
                             groupId=resources["securityGroup"].Id /]
@@ -221,7 +220,7 @@
                 [@createSecurityGroupIngress
                         mode=listMode
                         id=formatDependentSecurityGroupIngressId(
-                            resources["securityGroup"].Id, 
+                            computeClusterSecurityGroupId,
                             rule.Port)
                         port=rule.Port
                         cidr=rule.CIDR

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1851,7 +1851,7 @@
                 port.Name
             )]
 
-    [#assign targetLinkName = formatName(
+    [#assign targetLinkKey = formatName(
             port.LB.LinkName,
             portName) ]
     [#assign targetLinkId = formatId(
@@ -1871,7 +1871,7 @@
     [#local targetLink =
         {
             "Id" : targetLinkId,
-            "Name" : targetLinkName,
+            "Name" : port.LB.LinkName,
             "Tier" : targetTierId,
             "Component" : targetComponentId,
             "Priority" : port.LB.Priority
@@ -1933,9 +1933,9 @@
         [/#if]
     [/#if]
 
-    [@cfDebug listMode { targetLinkName : targetLink } false /]
+    [@cfDebug listMode { targetLinkKey : targetLink } false /]
 
-    [#return { targetLinkName : targetLink } ]
+    [#return { targetLinkKey : targetLink } ]
 [/#function]
 
 [#-- CIDRs --]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1845,15 +1845,24 @@
     [#assign core = occurrence.Core]
     [#assign targetTierId = (port.LB.Tier) ]
     [#assign targetComponentId = (port.LB.Component) ]
-    [#assign targetLinkName = port.LB.LinkName ]
-    [#assign targetSource =
-        contentIfContent(
-            port.LB.Port,
-            valueIfContent(
+    [#assign portName = valueIfContent(
                 (portMappings[port.LB.PortMapping].Source)!"",
                 port.LB.PortMapping,
                 port.Name
-            )
+            )]
+
+    [#assign targetLinkName = formatName(
+            port.LB.LinkName,
+            portName) ]
+    [#assign targetLinkId = formatId(
+            port.LB.LinkName,
+            portName
+    )]
+
+    [#assign targetSource =
+        contentIfContent(
+            port.LB.Port,
+            portName
         ) ]
 
     [#-- Need to be careful to allow an empty value for --]
@@ -1861,7 +1870,7 @@
     [#-- correctly handled in getLinkTarget             --]
     [#local targetLink =
         {
-            "Id" : targetLinkName,
+            "Id" : targetLinkId,
             "Name" : targetLinkName,
             "Tier" : targetTierId,
             "Component" : targetComponentId,


### PR DESCRIPTION
Adds security group updates to make sure that load balancers can contact the compute nodes and also adds direct access to ports if required 