### PR TITLE
Make API Gateway Container fragments optional

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -56,10 +56,12 @@
         ]
 
         [#-- Add in container specifics including override of defaults --]
-        [#assign containerListMode = "model"]
-        [#assign containerId = formatContainerFragmentId(occurrence, context)]
-        [#include containerList?ensure_starts_with("/")]
-        
+        [#if solution.Container?has_content ]
+            [#assign containerListMode = "model"]
+            [#assign containerId = formatContainerFragmentId(occurrence, context)]
+            [#include containerList?ensure_starts_with("/")]
+        [/#if]
+
         [#assign stageVariables += getFinalEnvironment(occurrence, context).Environment ]
 
         [#assign userPoolArns = [] ]

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -31,7 +31,10 @@
 [#assign componentConfiguration +=
     {
         APIGATEWAY_COMPONENT_TYPE : [
-            "Container",
+            {
+                "Container",
+                "Default" : ""
+            },
             {
                 "Name" : "Links",
                 "Default" : {}


### PR DESCRIPTION
Currently Container fragments are automatically applied on application level components. This can create issues for components with the same component name but different types (API Gateways and their matching lambdas) 

This makes container fragments explicit for API Gateways