### PR TITLE
Broaden registry permissions for shared builds

### DIFF
--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -103,7 +103,10 @@
                 policies=
                     [
                         getPolicyDocument(
-                            s3ReadPermission(scriptsPath) +
+                            s3ReadPermission( 
+                                formatRelativePath( 
+                                    getRegistryEndPoint("scripts", occurrence),
+                                    getRegistryPrefix("scripts", occurrence) ) )+
                             s3ListPermission(codeBucket) +
                             s3ReadPermission(codeBucket) +
                             s3ListPermission(operationsBucket) +


### PR DESCRIPTION
When using shared build permissions the local build unit was being used for S3 permissions which meant it couldn't get to the build reference. This broadens the S3 get access to the scripts registry 