### PR TITLE
Support option of creating lambda log group

### DIFF
--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -114,6 +114,10 @@
                         "Default" : true
                     }
                 ]
+            },
+            {
+                "Name" : "PredefineLogGroup",
+                "Default" : false
             }
         ]
     }
@@ -154,6 +158,11 @@
                     "Id" : id,
                     "Name" : core.FullName,
                     "Type" : AWS_LAMBDA_FUNCTION_RESOURCE_TYPE
+                },
+                "lg" : {
+                    "Id" : formatLogGroupId(core.Id),
+                    "Name" : formatAbsolutePath("aws", "lambda", core.FullName),
+                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
                 }
             },
             "Attributes" : {


### PR DESCRIPTION
While the log group name for lambda is currently fixed, the log group is
only created when the first lambda message is written.

This prevents the creation of log filters until the lambda runs.

To mitigate this, support the option of manually creating the group with
the AWS required name before creating the function.

Hopefully at some stage AWS will permit customer control of the lambda
log name, so this code positions the framework for this in the future.