### PR TITLE
Correct default certificate qualification for production

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1302,7 +1302,7 @@
     "Qualifiers": {
       "prod": {
         "IncludeInHost": {
-          "Segment": false
+          "Environment": false
         }
       }
     }


### PR DESCRIPTION
With introduction of environment, the production qualifier should refer to environment not segment.