### PR TITLE
Fix for load balancer lookup in containers

### DIFF
--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -341,19 +341,20 @@
                 } ]
 
             [#-- Ports should only be defined if connecting to a load balancer --]
-            [#local loadBalancer = containerLinks[port.LB.LinkName]]
-            [#local containerPortMapping +=
-                {
-                    "LoadBalancer" :
-                        {
-                            "Link" : loadBalancer.Name,
-                            "TargetGroup" : loadBalancer.TargetGroup!"",
-                            "Priority" : port.LB.Priority,
-                            "Path" : loadBalancer.TargetPath!""
-                        }
-                }
-            ]
-            [#local containerPortMappings += [containerPortMapping] ]
+            [#list lbLink as key,loadBalancer]
+                [#local containerPortMapping +=
+                    {
+                        "LoadBalancer" :
+                            {
+                                "Link" : loadBalancer.Name,
+                                "TargetGroup" : loadBalancer.TargetGroup!"",
+                                "Priority" : port.LB.Priority,
+                                "Path" : loadBalancer.TargetPath!""
+                            }
+                    }
+                ]
+                [#local containerPortMappings += [containerPortMapping] ]
+            [/#list]
         [/#list]
 
         [#local logDriver =


### PR DESCRIPTION
Minor fix to save looking up a link that is generated as part of the same function. 
