### PR TITLE
Correct handling of environment setting value escaping

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -73,6 +73,14 @@
     ]
 [/#function]
 
+[#function asSerialisableString arg]
+    [#if arg?is_hash || arg?is_sequence ]
+        [#return getJSON(arg) ]
+    [#else]
+        [#return arg ]
+    [/#if]
+[/#function]
+
 [#function getDescendent object default path...]
     [#local descendent=object]
     [#list asFlattenedArray(path) as part]
@@ -825,7 +833,7 @@
             [#case EC2_COMPONENT_TYPE]
                 [#local result = getEC2State(occurrence)]
                 [#break]
-            
+
             [#case COMPUTECLUSTER_COMPONENT_TYPE]
                 [#local result = getComputeClusterState(occurrence)]
                 [#break]
@@ -1219,11 +1227,11 @@
                 [#continue]
             [/#if]
             [#if sensitive && value.Sensitive!false]
-                [#local result += { key : valueIfTrue("****", obfuscate, value.Value)} ]
+                [#local result += { key : valueIfTrue("****", obfuscate, asSerialisableString(value.Value))} ]
                 [#continue]
             [/#if]
             [#if (!sensitive) && !(value.Sensitive!false)]
-                [#local result += { key : value.Value} ]
+                [#local result += { key : asSerialisableString(value.Value)} ]
                 [#continue]
             [/#if]
         [#else]
@@ -2195,12 +2203,12 @@
 [#function pseudoStackOutputScript description outputs filesuffix="pseudo" ]
     [#local outputString = ""]
     [#list outputs as key,value ]
-        [#local outputString += 
-          "\"" + key + "\" \"" + value + "\" " 
+        [#local outputString +=
+          "\"" + key + "\" \"" + value + "\" "
         ]
     [/#list]
 
-    [#return 
+    [#return
         [
             "create_pseudo_stack" + " " +
             "\"" + description + "\"" + " " +

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -57,7 +57,7 @@
     [#return
         setDescendent(
             context,
-            (value?is_hash || value?is_sequence)?then(getJSON(value, true), value),
+            asSerialisableString(value),
             formatSettingName(name)
             "Environment") ]
 [/#function]
@@ -251,10 +251,9 @@
 
 [#assign ECS_DEFAULT_MEMORY_LIMIT_MULTIPLIER=1.5 ]
 
-[#function defaultEnvironment occurrence mode=""]
+[#function defaultEnvironment occurrence]
     [#return
         occurrence.Configuration.Environment.General +
-        attributeIfContent("APP_RUN_MODE", mode) +
         occurrence.Configuration.Environment.Build +
         occurrence.Configuration.Environment.Sensitive
     ]
@@ -437,13 +436,13 @@
                 "Mode" : getContainerMode(container),
                 "LogDriver" : logDriver,
                 "LogOptions" : logOptions,
-                "DefaultEnvironment" :
-                    defaultEnvironment(task, getContainerMode(container)) +
+                "DefaultEnvironment" : defaultEnvironment(task),
+                "Environment" :
                     {
+                        "APP_RUN_MODE" : getContainerMode(container),
                         "AWS_REGION" : regionId,
                         "AWS_DEFAULT_REGION" : regionId
                     },
-                "Environment" : {},
                 "Links" : getLinkTargets(task, containerLinks),
                 "DefaultCoreVariables" : true,
                 "DefaultEnvironmentVariables" : true,


### PR DESCRIPTION
Ensure component environment sections only contain strings.

Rework handling of run mode for docker containers and AWS region so it is not affected
by the DefaultEnvironmentVariables setting.