### PR TITLE
Correct logic of linking to LB

### DIFF
--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -323,6 +323,15 @@
         [#list container.Ports?values as port]
 
             [#local lbLink = getLBLink( task, port )]
+            
+            [#if isDuplicateLink(containerLinks, lbLink) ]
+                [@cfException
+                    mode=listMode
+                    description="Duplicate Link Name"
+                    context=containerLinks
+                    detail=lbLink /]
+                [#continue]
+            [/#if]
 
             [#-- Treat the LB link like any other - this will also detect --]
             [#-- if the target is missing                                 --]

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -44,7 +44,7 @@
                 {
                     "Type" : LB_PORT_COMPONENT_TYPE,
                     "Component" : "PortMappings",
-                    "Link" : "Port"
+                    "Link" : ["PortMapping","Port"]
                 }
             ]
         },
@@ -144,7 +144,8 @@
                 "FQDN" : fqdn,
                 "URL" : scheme + "://" + fqdn,
                 "INTERNAL_FQDN" : internalFqdn,
-                "INTERNAL_URL" : scheme + "://" + internalFqdn
+                "INTERNAL_URL" : scheme + "://" + internalFqdn,
+                "PORT" : sourcePort.Name
             },
             "Roles" : {
                 "Inbound" : {},

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -24,7 +24,7 @@
             "Name" : ["Task", "Subcomponent"]
         },
         {
-            "Name" : ["Port", "Subcomponent"]
+            "Name" : ["PortMapping", "Port", "Subcomponent"]
         },
         {
             "Name" : ["Mount", "Subcomponent"]
@@ -142,11 +142,7 @@
             "Default" : ""
         },
         {
-            "Name" : "Port",
-            "Default" : ""
-        },
-        {
-            "Name" : "PortMapping",
+            "Name" : ["PortMapping", "Port"],
             "Default" : ""
         },
         {

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -25,8 +25,8 @@
         [#assign targetGroupPermission = false ]
 
         [#assign configSetName = componentType ]
-        [#assign configSets =  
-                getInitConfigDirectories() + 
+        [#assign configSets =
+                getInitConfigDirectories() +
                 getInitConfigBootstrap(component.Role!"") +
                 getInitConfigPuppet() ]
 
@@ -37,7 +37,16 @@
 
         [#list solution.Ports?values as port ]
             [#if port.LB.Configured]
-                [#assign links += getLBLink(occurrence, port)]
+                [#assign lbLink = getLBLink(occurrence, port)]
+                [#if isDuplicateLink(links, lbLink) ]
+                    [@cfException
+                        mode=listMode
+                        description="Duplicate Link Name"
+                        context=links
+                        detail=lbLink /]
+                    [#continue]
+                [/#if]
+                [#assign links += lbLink]
             [#else]
                 [#assign portCIDRs = getGroupCIDRs(port.IPAddressGroups) ]
                 [#if portCIDRs?has_content]
@@ -110,17 +119,17 @@
 
                         [#case "classic" ]
                             [#assign lbId =  linkTargetAttributes["LB"] ]
-                            [#assign configSets += 
+                            [#assign configSets +=
                                 getInitConfigLBClassicRegistration(lbId)]
                             [#break]
                         [/#switch]
                     [#break]
                 [#case EFS_MOUNT_COMPONENT_TYPE]
-                    [#assign configSets += 
+                    [#assign configSets +=
                         getInitConfigEFSMount(
-                            linkTargetCore.Id, 
-                            linkTargetAttributes.EFS, 
-                            linkTargetAttributes.DIRECTORY, 
+                            linkTargetCore.Id,
+                            linkTargetAttributes.EFS,
+                            linkTargetAttributes.DIRECTORY,
                             link.Id
                         )]
                     [#break]


### PR DESCRIPTION
In order that LB linking can be handled like any other subcomponent,
switch from linking on the basis of source port to linking on the basis
of the subcomponent id, which for an LB is the port mapping.

Also update link support to prefer the use of "PortMapping" to "Port"
for linking. This has meant adding the ability for checking multiple
Link attribute names when linking to a subcomponent to keep backwards
compatability with existing configs that are using "Port" rather than
"PortMapping".