### PR TITLE
Fix epilouge processing to warn of multiple run requirement

### DIFF
--- a/aws/templates/solution/solution_ElasticSearch.ftl
+++ b/aws/templates/solution/solution_ElasticSearch.ftl
@@ -289,22 +289,26 @@
         [#if deploymentSubsetRequired("epilogue", false)]
             [@cfScript
                 mode=listMode
-                content=
-                    [
-                        "case $\{STACK_OPERATION} in",
-                        "  create|update)",
-                        "       # Get cli config file",
-                        "       split_cli_file \"$\{CLI}\" \"$\{tmpdir}\" || return $?", 
-                        "       # Apply CLI level updates to ES Domain",
-                        "       info \"Applying cli level configurtion\""
-                        "       update_es_domain" +
-                        "       \"" + region + "\" " + 
-                        "       \"" + getExistingReference(esId) + "\" " + 
-                        "       \"$\{tmpdir}/cli-" + 
-                        esId + "-" + esUpdateCommand + ".json\" || return $?"
-                        "   ;;",
-                        "   esac"
-                    ]  
+                content= (getExistingReference(esId)?has_content)?then(
+                        [
+                            "case $\{STACK_OPERATION} in",
+                            "  create|update)",
+                            "       # Get cli config file",
+                            "       split_cli_file \"$\{CLI}\" \"$\{tmpdir}\" || return $?", 
+                            "       # Apply CLI level updates to ES Domain",
+                            "       info \"Applying cli level configurtion\""
+                            "       update_es_domain" +
+                            "       \"" + region + "\" " + 
+                            "       \"" + getExistingReference(esId) + "\" " + 
+                            "       \"$\{tmpdir}/cli-" + 
+                            esId + "-" + esUpdateCommand + ".json\" || return $?"
+                            "   ;;",
+                            "   esac"
+                        ],
+                        [
+                            "warning \"Please run another update to complete the configuration\""
+                        ]
+                    )
             /]
         [/#if]
 

--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -404,7 +404,7 @@
         [#if deploymentSubsetRequired("epilogue", false)]
             [@cfScript
                 mode=listMode
-                content=
+                content=(getExistingReference(userPoolId)?has_content)?then(
                 [
                     "case $\{STACK_OPERATION} in",
                     "  create|update)",
@@ -433,7 +433,11 @@
                 [
                     "       ;;",
                     "       esac"
+                ],
+                [
+                    "warning \"Please run another update to complete the configuration\""
                 ]
+                )
             /]
         [/#if]
     [/#list]


### PR DESCRIPTION
For elasticsearch and userpools an epilogue script has to be run to update some settings which are not available in cloudformation. However to perform these updates you need the Id or name of the resource to perform the update which isn't available on the initial creation of the component. 

To get around this the epilogue script will provide a warning that another update  has to be made to complete the configuration.