### PR TITLE
Introduce reserved IPAddressGroups

### DIFF
--- a/aws/templates/id/id_es.ftl
+++ b/aws/templates/id/id_es.ftl
@@ -24,7 +24,7 @@
             },
             {
                 "Name" : "IPAddressGroups",
-                "Default" : []
+                "Mandatory" : true
             },
             {
                 "Name" : "AdvancedOptions",

--- a/aws/templates/solution/solution_ElasticSearch.ftl
+++ b/aws/templates/solution/solution_ElasticSearch.ftl
@@ -32,17 +32,6 @@
         [#assign storageProfile = getStorage(tier, component, "ElasticSearch")]
         [#assign volume = (storageProfile.Volumes["codeontap"])!{}]
         [#assign esCIDRs = getGroupCIDRs(solution.IPAddressGroups) ]
-        [#list zones as zone]
-            [#assign zoneIP =
-                getExistingReference(
-                    formatComponentEIPId("mgmt", "nat", zone),
-                    IP_ADDRESS_ATTRIBUTE_TYPE
-                )
-            ]
-            [#if zoneIP?has_content]
-                [#assign esCIDRs += [zoneIP] ]
-            [/#if]
-        [/#list]
 
         [#if !esCIDRs?has_content ]
             [@cfException


### PR DESCRIPTION
Reserve all IP address groups starting with "_". Initially use these for
an open CIDR (_global) and the current segment nat ips (_segment).

Support a few variants with one or two "_" on either side as well.

Refactor the elastic search support accordingly.

We will likely add an _environment in future if all segments in an
environment need access to something.