### PR TITLE
Add Encrypted variable prefix option to RDS Password Generation

### DIFF
--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -47,10 +47,14 @@
                     {
                         "Name" : "MasterUserName",
                         "Default" : "root"
-                    }
+                    },
                     {
                         "Name" : "CharacterLength",
                         "Default" : 20
+                    },
+                    {
+                        "Name" : "VariablePrefix",
+                        "Default" : ""
                     }
                 ]
             },

--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -53,7 +53,7 @@
                         "Default" : 20
                     },
                     {
-                        "Name" : "VariablePrefix",
+                        "Name" : "EncryptionScheme",
                         "Default" : ""
                     }
                 ]

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -69,7 +69,13 @@
             [#assign rdsUsername = solution.GenerateCredentials.MasterUserName]
             [#assign rdsPasswordLength = solution.GenerateCredentials.CharacterLength]
             [#assign rdsPassword = "DummyPassword" ]
-            [#assign rdsEncryptedPassword = getExistingReference(rdsId, GENERATEDPASSWORD_ATTRIBUTE_TYPE)]
+            [#assign rdsEncryptedPassword = (
+                getExistingReference(
+                    rdsId, 
+                    GENERATEDPASSWORD_ATTRIBUTE_TYPE)
+                )?remove_beginning(
+                    solution.GenerateCredentials.VariablePrefix
+                )]
         [#else]
             [#assign rdsUsername = attributes.USERNAME ]
             [#assign rdsPassword = attributes.PASSWORD ]
@@ -312,7 +318,7 @@
                         "create_pseudo_stack" + " " +
                         "\"RDS Master Password\"" + " " +
                         "\"$\{password_pseudo_stack_file}\"" + " " +
-                        "\"" + rdsId + "Xgeneratedpassword\" \"$\{encrypted_master_password}\" || return $?",
+                        "\"" + rdsId + "Xgeneratedpassword\" \"" + solution.GenerateCredentials.VariablePrefix + "$\{encrypted_master_password}\" || return $?",
                         "info \"Generating URL... \"",
                         "rds_url=\"$(get_rds_url" +
                         " \"" + engine + "\" " +
@@ -328,7 +334,7 @@
                         "create_pseudo_stack" + " " +
                         "\"RDS Connection URL\"" + " " +
                         "\"$\{url_pseudo_stack_file}\"" + " " +
-                        "\"" + rdsId + "Xurl\" \"$\{encrypted_rds_url}\" || return $?",
+                        "\"" + rdsId + "Xurl\" \"" + solution.GenerateCredentials.VariablePrefix + "$\{encrypted_rds_url}\" || return $?",
                         "}",
                         "password_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-password-pseudo-stack.json\" ",
                         "url_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-url-pseudo-stack.json\" ",
@@ -364,7 +370,7 @@
                         "create_pseudo_stack" + " " +
                         "\"RDS Connection URL\"" + " " +
                         "\"$\{url_pseudo_stack_file}\"" + " " +
-                        "\"" + rdsId + "Xurl\" \"$\{encrypted_rds_url}\" || return $?",
+                        "\"" + rdsId + "Xurl\" \"" + solution.GenerateCredentials.VariablePrefix + "$\{encrypted_rds_url}\" || return $?",
                         "}",
                         "url_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-url-pseudo-stack.json\" ",
                         "reset_master_password || return $?"

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -74,7 +74,7 @@
                     rdsId, 
                     GENERATEDPASSWORD_ATTRIBUTE_TYPE)
                 )?remove_beginning(
-                    solution.GenerateCredentials.VariablePrefix
+                    solution.GenerateCredentials.EncryptionScheme
                 )]
         [#else]
             [#assign rdsUsername = attributes.USERNAME ]
@@ -318,7 +318,7 @@
                         "create_pseudo_stack" + " " +
                         "\"RDS Master Password\"" + " " +
                         "\"$\{password_pseudo_stack_file}\"" + " " +
-                        "\"" + rdsId + "Xgeneratedpassword\" \"" + solution.GenerateCredentials.VariablePrefix + "$\{encrypted_master_password}\" || return $?",
+                        "\"" + rdsId + "Xgeneratedpassword\" \"" + solution.GenerateCredentials.EncryptionScheme + "$\{encrypted_master_password}\" || return $?",
                         "info \"Generating URL... \"",
                         "rds_url=\"$(get_rds_url" +
                         " \"" + engine + "\" " +
@@ -334,7 +334,7 @@
                         "create_pseudo_stack" + " " +
                         "\"RDS Connection URL\"" + " " +
                         "\"$\{url_pseudo_stack_file}\"" + " " +
-                        "\"" + rdsId + "Xurl\" \"" + solution.GenerateCredentials.VariablePrefix + "$\{encrypted_rds_url}\" || return $?",
+                        "\"" + rdsId + "Xurl\" \"" + solution.GenerateCredentials.EncryptionScheme + "$\{encrypted_rds_url}\" || return $?",
                         "}",
                         "password_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-password-pseudo-stack.json\" ",
                         "url_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-url-pseudo-stack.json\" ",
@@ -370,7 +370,7 @@
                         "create_pseudo_stack" + " " +
                         "\"RDS Connection URL\"" + " " +
                         "\"$\{url_pseudo_stack_file}\"" + " " +
-                        "\"" + rdsId + "Xurl\" \"" + solution.GenerateCredentials.VariablePrefix + "$\{encrypted_rds_url}\" || return $?",
+                        "\"" + rdsId + "Xurl\" \"" + solution.GenerateCredentials.EncryptionScheme + "$\{encrypted_rds_url}\" || return $?",
                         "}",
                         "url_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-url-pseudo-stack.json\" ",
                         "reset_master_password || return $?"

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -64,6 +64,9 @@
         [#assign rdsOptionGroupId = resources["optionGroup"].Id ]
 
         [#assign rdsDatabaseName = solution.DatabaseName!productName]
+        [#assign passwordEncryptionScheme = (solution.GenerateCredentials.EncryptionScheme?has_content)?then(
+                solution.GenerateCredentials.EncryptionScheme?ensure_ends_with(":"),
+                "" )]
 
         [#if solution.GenerateCredentials.Enabled ]
             [#assign rdsUsername = solution.GenerateCredentials.MasterUserName]
@@ -74,7 +77,7 @@
                     rdsId, 
                     GENERATEDPASSWORD_ATTRIBUTE_TYPE)
                 )?remove_beginning(
-                    solution.GenerateCredentials.EncryptionScheme
+                    passwordEncryptionScheme
                 )]
         [#else]
             [#assign rdsUsername = attributes.USERNAME ]
@@ -318,7 +321,7 @@
                         "create_pseudo_stack" + " " +
                         "\"RDS Master Password\"" + " " +
                         "\"$\{password_pseudo_stack_file}\"" + " " +
-                        "\"" + rdsId + "Xgeneratedpassword\" \"" + solution.GenerateCredentials.EncryptionScheme + "$\{encrypted_master_password}\" || return $?",
+                        "\"" + rdsId + "Xgeneratedpassword\" \"" + passwordEncryptionScheme + "$\{encrypted_master_password}\" || return $?",
                         "info \"Generating URL... \"",
                         "rds_url=\"$(get_rds_url" +
                         " \"" + engine + "\" " +
@@ -334,7 +337,7 @@
                         "create_pseudo_stack" + " " +
                         "\"RDS Connection URL\"" + " " +
                         "\"$\{url_pseudo_stack_file}\"" + " " +
-                        "\"" + rdsId + "Xurl\" \"" + solution.GenerateCredentials.EncryptionScheme + "$\{encrypted_rds_url}\" || return $?",
+                        "\"" + rdsId + "Xurl\" \"" + passwordEncryptionScheme + "$\{encrypted_rds_url}\" || return $?",
                         "}",
                         "password_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-password-pseudo-stack.json\" ",
                         "url_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-url-pseudo-stack.json\" ",
@@ -370,7 +373,7 @@
                         "create_pseudo_stack" + " " +
                         "\"RDS Connection URL\"" + " " +
                         "\"$\{url_pseudo_stack_file}\"" + " " +
-                        "\"" + rdsId + "Xurl\" \"" + solution.GenerateCredentials.EncryptionScheme + "$\{encrypted_rds_url}\" || return $?",
+                        "\"" + rdsId + "Xurl\" \"" + passwordEncryptionScheme + "$\{encrypted_rds_url}\" || return $?",
                         "}",
                         "url_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-url-pseudo-stack.json\" ",
                         "reset_master_password || return $?"


### PR DESCRIPTION
Allows you to add a prefix to the encrypted strings created as part of the password generation process (e.g. base64:). This is used by some products to determine if the environment variable is encrypted or not. 

