### PR TITLE
Force use of local time on unzip

### DIFF
--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -805,7 +805,9 @@ function syncFilesToBucket() {
     if [[ -f "${file}" ]]; then
       case "$(fileExtension "${file}")" in
         zip)
-          unzip "${file}" -d "${tmp_dir}"
+          # Always use local time to force redeploy of files
+          # in case we are reverting to an earlier version
+          unzip -DD "${file}" -d "${tmp_dir}"
           ;;
         *)
           cp "${file}" "${tmp_dir}"


### PR DESCRIPTION
aws s3 sync command has some odd behaviour in terms of timestamp
comparisons when file sizes are the same, so ensure all files are copied
by using the local (presumably current) time.