### PR TITLE
ECS awsvpc networking and Network Load balancer Support

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1022,6 +1022,19 @@
         "Timeout": "5"
       }
     },
+    "httpredirect" : {
+      "Port" : 80,
+      "Protocol" : "HTTP",
+      "IPProtocol" : "tcp",
+      "HealthCheck" : {
+        "Path" : "/",
+        "HealthyThreshold" : "2",
+        "UnhealthyThreshold" : "3",
+        "Interval" : "30",
+        "Timeout" : "5",
+        "SuccessCodes" : "301"
+      }
+    },
     "https": {
       "Port": 443,
       "Protocol": "HTTPS",
@@ -1189,6 +1202,10 @@
     "httpalt": {
       "Source": "http",
       "Destination": "httpalt"
+    },
+    "httpredirect" : {
+      "Source" : "http",
+      "Destination" : "httpredirect"
     },
     "https": {
       "Source": "https",

--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -157,8 +157,9 @@
 
                                 [#if securityGroupSources?is_enumerable ]
                                     
-                                    [#list securityGroupSources as source ]
-                                        [#assign securityGroupCIDR = getGroupCIDRs([source])]
+                                    [#assign securityGroupCIDRs = getGroupCIDRs(securityGroupSources)]
+                                    [#list securityGroupCIDRs as source ]
+                                        
                                         [@createSecurityGroupIngress
                                             mode=listMode
                                             id=
@@ -169,10 +170,10 @@
                                                         "dynamic",
                                                         ports[portMapping.HostPort].Port
                                                     ),
-                                                    source
+                                                    replaceAlphaNumericOnly(source)
                                                 )
                                             port=portMapping.DynamicHostPort?then(0, portMapping.HostPort)
-                                            cidr=securityGroupCIDR
+                                            cidr=source
                                             groupId=ecsSecurityGroupId
                                     /]
                                     [/#list]

--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -143,6 +143,8 @@
                         taskId=taskId
                         loadBalancers=loadBalancers
                         roleId=ecsServiceRoleId
+                        networkMode=solution.NetworkMode
+                        
                         dependencies=dependencies
                     /]
                 [/#if]
@@ -228,6 +230,7 @@
                     id=taskId
                     containers=containers
                     role=roleId
+                    networkMode=solution.NetworkMode
                     dependencies=dependencies
                     delegatedDeployment=solution.DelegateDeployment
                 /]

--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -23,12 +23,37 @@
             [#assign taskId = resources["task"].Id ]
             [#assign containers = getTaskContainers(occurrence, subOccurrence) ]
 
+            [#assign lbTargetType = ""]
+
+            [#if solution.NetworkMode == "awsvpc" ]
+                        
+                [#assign subnets = multiAZ?then(
+                    getSubnets(tier),
+                    getSubnets(tier)[0..0]
+                )]
+
+                [#assign lbTargetType = "ip" ]
+
+                [#assign ecsSecurityGroupId = resources["securityGroup"].Id ]
+                [#assign ecsSecurityGroupName = resources["securityGroup"].Name ]
+                
+            [/#if] 
+
             [#if core.Type == ECS_SERVICE_COMPONENT_TYPE]
 
                 [#assign serviceId = resources["service"].Id  ]
                 [#assign serviceDependencies = []]
 
                 [#if deploymentSubsetRequired("ecs", true)]
+
+                    [#if solution.NetworkMode == "awsvpc" ]
+                        [@createSecurityGroup
+                            mode=listMode
+                            tier=tier
+                            component=component
+                            id=ecsSecurityGroupId
+                            name=ecsSecurityGroupName /]
+                    [/#if]
 
                     [#assign loadBalancers = [] ]
                     [#assign dependencies = [] ]
@@ -61,7 +86,9 @@
                                                             name=formatName(linkCore.FullName,loadBalancer.TargetGroup)
                                                             tier=linkCore.Tier
                                                             component=linkCore.Component
-                                                            destination=ports[portMapping.HostPort] /]
+                                                            destination=ports[portMapping.HostPort]
+                                                            targetType=lbTargetType
+                                                            /]
 
                                                         [#assign listenerRuleId = formatALBListenerRuleId(link, loadBalancer.TargetGroup) ]
                                                         [@createListenerRule
@@ -89,6 +116,20 @@
                                                 [#break]
                                                 
                                             [#case "classic"]
+
+                                                [#if solution.NetworkMode == "awsvpc" ]
+                                                    [@cfException
+                                                        mode=listMode
+                                                        description="Network mode not compatible with LB"
+                                                        context=
+                                                            {
+                                                                "Description" : "The current container network mode is not compatible with this load balancer engine",
+                                                                "NetworkMode" : solution.NetworkMode,
+                                                                "LBEngine" : linkAttributes["ENGINE"]
+                                                            }
+                                                    /]
+                                                [/#if]
+
                                                 [#assign lbId =  linkAttributes["LB"] ]
                                                 [#-- Classic ELB's register the instance so we only need 1 registration --]
                                                 [#-- TODO: Change back to += when AWS allows multiple load balancer registrations per container --]

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -276,7 +276,15 @@
                     "Id" : formatDependentRoleId(taskId),
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
                 }    
-            ),
+            ) + 
+            attributeIfTrue(
+                "securityGroup",
+                solution.NetworkMode == "awsvpc",
+                {
+                    "Id" : formatResourceId( AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE, core.Id ),
+                    "Name" : core.FullName,
+                    "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
+                }),
             "Attributes" : {},
             "Roles" : {
                 "Inbound" : {},

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -377,9 +377,10 @@
                 occurrence.Core.Version.Id)]
 [/#function]
 
-[#function formatContainerSecurityGroupIngressId resourceId container portRange]
+[#function formatContainerSecurityGroupIngressId resourceId container portRange source=""]
     [#return formatDependentSecurityGroupIngressId(
                 resourceId,
                 getContainerId(container),
-                portRange)]
+                portRange,
+                source)]
 [/#function]

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -135,6 +135,10 @@
             {
                 "Name" : "TaskLogGroup",
                 "Default" : true
+            },
+            {
+                "Name" : "NetworkMode",
+                "Default" : ""
             }
         ],
         ECS_TASK_COMPONENT_TYPE : [
@@ -227,7 +231,9 @@
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
                 }
             ),
-            "Attributes" : {},
+            "Attributes" : {
+                
+            },
             "Roles" : {
                 "Inbound" : {},
                 "Outbound" : {}

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -59,6 +59,10 @@
             },
             {
                 "Name" : "Mapping"
+            },
+            {
+                "Name" : "TargetType",
+                "Default" : "instance"
             }
         ]
     }]

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -87,8 +87,7 @@
                 attributeIfContent("ExtraHosts", extraHosts) +
                 attributeIfContent("Memory", container.MaximumMemory!"") +
                 attributeIfContent("Cpu", container.Cpu!"") +
-                attributeIfContent("PortMappings", portMappings) + 
-                attributeIfContent("NetworkMode", networkMode)
+                attributeIfContent("PortMappings", portMappings) 
             ]
         ]
     [/#list]
@@ -97,7 +96,8 @@
         "ContainerDefinitions" : definitions
         } + 
         attributeIfContent("Volumes", volumes)  + 
-        attributeIfContent("TaskRoleArn", role, getReference(role, ARN_ATTRIBUTE_TYPE))
+        attributeIfContent("TaskRoleArn", role, getReference(role, ARN_ATTRIBUTE_TYPE)) + 
+        attributeIfContent("NetworkMode", networkMode)
     ]
 
     [#if delegatedDeployment ]
@@ -141,8 +141,7 @@
             } + 
             valueIfContent(
                 {
-                    "LoadBalancers" : loadBalancers![],
-                    "Role" : getReference(roleId)
+                    "LoadBalancers" : loadBalancers![]
                 },
                 loadBalancers![]) +
             valueIfTrue(
@@ -155,6 +154,12 @@
                     }
                 },
                 networkMode == "awsvpc"
+            ) + 
+            valueIfTrue(
+                {
+                    "Role" : getReference(roleId)
+                },
+                (loadBalancers![])?has_content && networkMode != "awsvpc"
             )
         dependencies=dependencies
     /]

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -88,7 +88,7 @@
                 attributeIfContent("Memory", container.MaximumMemory!"") +
                 attributeIfContent("Cpu", container.Cpu!"") +
                 attributeIfContent("PortMappings", portMappings) + 
-                attributeIfContent("NetworkMode". networkMode)
+                attributeIfContent("NetworkMode", networkMode)
             ]
         ]
     [/#list]
@@ -117,7 +117,7 @@
     [/#if]
 [/#macro]
 
-[#macro createECSService mode id ecsId desiredCount taskId loadBalancers networkMode="" subnetIds=[] securityGroupIds=[] roleId="" dependencies=""]
+[#macro createECSService mode id ecsId desiredCount taskId loadBalancers networkMode="" subnets=[] securityGroups=[] roleId="" dependencies=""]
 
     [@cfResource
         mode=mode
@@ -145,16 +145,16 @@
                     "Role" : getReference(roleId)
                 },
                 loadBalancers![]) +
-            (networkMode == "awsvpc")?then(
+            valueIfTrue(
                 {
                     "NetworkConfiguration" : {
                         "AwsvpcConfiguration" : {
-                            "SecurityGroups" : getReferences( securityGroupIds )
-                            "Subnets" : getReferences( subnetIds ) 
+                            "SecurityGroups" : securityGroups,
+                            "Subnets" : subnets
                         }
                     }
                 },
-                {}
+                networkMode == "awsvpc"
             )
         dependencies=dependencies
     /]

--- a/aws/templates/resource/resource_lb.ftl
+++ b/aws/templates/resource/resource_lb.ftl
@@ -136,7 +136,7 @@
     /]
 [/#macro]
 
-[#macro createTargetGroup mode id name tier component destination]
+[#macro createTargetGroup mode id name tier component destination targetType=""]
     [@cfResource
         mode=mode
         id=id
@@ -164,7 +164,13 @@
                 {
                     "Matcher" : { "HttpCode" : (destination.HealthCheck.SuccessCodes)!"" }
                 },
-                (destination.HealthCheck.SuccessCodes)!"")
+                (destination.HealthCheck.SuccessCodes)!"") + 
+            valueIfContent(
+                {
+                    "TargetType" : targetType
+                },
+                targetType
+            )
         tags= getCfTemplateCoreTags(name, tier, component)
         outputs=ALB_TARGET_GROUP_OUTPUT_MAPPINGS
     /]

--- a/aws/templates/resource/resource_lb.ftl
+++ b/aws/templates/resource/resource_lb.ftl
@@ -145,7 +145,6 @@
             {
                 "HealthCheckPort" : (destination.HealthCheck.Port)!"traffic-port",
                 "HealthCheckProtocol" : (destination.HealthCheck.Protocol)!destination.Protocol,
-                "HealthCheckPath" : destination.HealthCheck.Path,
                 "HealthCheckIntervalSeconds" : destination.HealthCheck.Interval,
                 "HealthCheckTimeoutSeconds" : destination.HealthCheck.Timeout,
                 "HealthyThresholdCount" : destination.HealthCheck.HealthyThreshold,
@@ -165,11 +164,17 @@
                     "Matcher" : { "HttpCode" : (destination.HealthCheck.SuccessCodes)!"" }
                 },
                 (destination.HealthCheck.SuccessCodes)!"") + 
-            valueIfContent(
+            valueIfTrue(
                 {
                     "TargetType" : targetType
                 },
-                targetType
+                targetType == "ip"
+            ) + 
+            valueIfContent(
+                {
+                    "HealthCheckPath" : (destination.HealthCheck.Path)!""
+                },
+                (destination.HealthCheck.Path)!""
             )
         tags= getCfTemplateCoreTags(name, tier, component)
         outputs=ALB_TARGET_GROUP_OUTPUT_MAPPINGS

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -533,6 +533,18 @@
                     "CIDR" : segmentCIDR
                 } ]
             [#break]
+        
+        [#case "_localnet"]
+        [#case "_localnet_"]
+        [#case "__localnet__"]
+            [#return
+            {
+                "Id" : groupId,
+                "Name" : groupId,
+                "IsOpen" : false,
+                "CIDR" : [ segmentObject.Network.CIDR.Address + "/" + segmentObject.Network.CIDR.Mask ]
+            } ]
+            [#break]
 
         [#default]
             [#if (ipAddressGroups[groupId]!{})?has_content ]

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -54,6 +54,8 @@
                 [#assign sourcePort = (ports[source])!{} ]
                 [#assign destinationPort = (ports[destination])!{} ]
 
+                [#assign targetType = solution.TargetType ]
+
                 [#if !(sourcePort?has_content && destinationPort?has_content)]
                     [#continue ]
                 [/#if]
@@ -96,7 +98,8 @@
                             name=targetGroupName
                             tier=tier
                             component=component
-                            destination=destinationPort /]
+                            destination=destinationPort
+                            targetType=targetType /]
 
                         [@createALBListener
                             mode=listMode


### PR DESCRIPTION
This PR has a few networking/ load balancing changes 

- Add support for the awsvpc ECS container network mode 
  - This creates an eni for each container in a service which bypasses the host network adapter. This removes issues with exposing the same port on multiple containers since each container has its own IP 
  - **Configuration** - ECS Service Component
     - NetworkMode - setting the network mode to awsvpc enables awsvpc for all containers within the service (defaults to "" which is the standard ecs network mode) 
- Add Target Type to LB 
  - When using awsvpc mode you can't use the instance target type for an ALB or NLB target group since this just goes off the first adapter on the instance that responds. Instead you need to specify the IP address of the ENI for the specific container 
   - **Configuration**  LB Port SubComponent
     - TargetType - set to ip to change the target group for a given port mapping to IP mode. Defaults to instance 
- Add Network Load balancer Security group configuration
   - When creating a network load balancer you cannot specify a security group on the load balancer itself. Instead it uses the security groups of its targets ( https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-register-targets.html#target-security-groups )
  - To ensure we are honouring the LB IPaddress groups we need to get the IPAddressGroups specified on the load balancer and apply them to the security group for the load balancing target. We also need to include the local VPC network so that the load balancer health probes can check the targets 
- Change container ingress rule from 0.0.0.0/0 to the security group of the load balancer. 
   - 0.0.0.0/0 works ok since its inside the VPC but since its easy for us to get the security group lets follow security best practice and only allow access to the container from the load balancer
- Add _localnet reserved IPAddress Groups 
  - returns the vpc local network 
- Add httpredirect standard port 
  - The redirector container should only be treated as successful if its health check returns a 301 error not a 200, so we need to have a separate port/health check where this is defined. 
   
        