### PR TITLE
add + to password blacklist

### DIFF
--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -164,7 +164,7 @@ function generateComplexString() {
   # String suitable for a password - Alphanumeric and special characters
   local length="$1"; shift
 
-  echo "$(dd bs=256 count=1 if=/dev/urandom | base64 | env LC_CTYPE=C tr -dc '[:punct:][:alnum:]' | tr -d '@"/'  | fold -w "${length}" | head -n 1)" || return $?
+  echo "$(dd bs=256 count=1 if=/dev/urandom | base64 | env LC_CTYPE=C tr -dc '[:punct:][:alnum:]' | tr -d '@"/+'  | fold -w "${length}" | head -n 1)" || return $?
 }
 
 function generateSimpleString() {


### PR DESCRIPTION
In a url a + is often converted to %20 which is a space. So when passing the password to something like Django the password is interpreted as a space instead of a + and so login fails. 