### PR TITLE
ECS Remove Delegated Domain and add Task run Configuration

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -905,7 +905,7 @@
                 [#break]
 
             [#case "task"]
-                [#local result = getTaskState(occurrence)]
+                [#local result = getTaskState(occurrence, parentOccurrence)]
                 [#break]
 
             [#case "userpool"]

--- a/aws/templates/container/container_jenkins.ftl
+++ b/aws/templates/container/container_jenkins.ftl
@@ -3,8 +3,6 @@
    
     [#assign settings = context.DefaultEnvironment]
 
-    [@Policy ecsTaskAllPermission() /]
-    
     [@Settings {
             "ECS_ARN" :  getExistingReference(ecsId),
             "MAXMEMORY" : container.MemoryReservation

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -246,6 +246,7 @@
     [#local solution = occurrence.Configuration.Solution ]
 
     [#local taskId = formatResourceId(AWS_ECS_TASK_RESOURCE_TYPE, core.Id) ]
+    [#local taskName = core.Name]
 
     [#return
         {
@@ -256,6 +257,7 @@
                 },
                 "task" : {
                     "Id" : taskId,
+                    "Name" : taskName,
                     "Type" : AWS_ECS_TASK_RESOURCE_TYPE
                 }
             } +

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -343,7 +343,7 @@
             "Roles" : {
                 "Inbound" : {},
                 "Outbound" : {
-                    "run" :  ecsTaskRunPermission(ecsId, taskId) +
+                    "run" :  ecsTaskRunPermission(ecsId) +
                         solution.UseTaskRole?then(
                             iamPassRolePermission(
                                 getExistingReference(taskRoleId, ARN_ATTRIBUTE_TYPE)
@@ -362,12 +362,11 @@
             "ecs",
             formatRelativePath(
                 "cluster",
-                    getReference(ecsId)
+                getReference(ecsId)
             )
         )
     ]
 [/#function]
-
 
 [#-- Container --]
 

--- a/aws/templates/policy/policy_ecs.ftl
+++ b/aws/templates/policy/policy_ecs.ftl
@@ -20,7 +20,7 @@
     ]
 [/#function]
 
-[#function ecsTaskRunPermission ecsId taskId ]
+[#function ecsTaskRunPermission ecsId ]
 
     [#local clusterArn = formatEcsClusterArn(ecsId)]
     [#return
@@ -38,20 +38,11 @@
             getPolicyStatement(
                 [
                     "ecs:RunTask",
-                    "ecs:StartTask"
-                ],
-                getReference(taskId),
-                {
-                    "ArnEquals" :{
-                        "ecs:cluster" : clusterArn 
-                    }
-                }
-            ),
-            getPolicyStatement(
-                [
+                    "ecs:StartTask",
                     "ecs:StopTask"
                 ],
                 "*",
+                "",
                 {
                     "ArnEquals" :{
                         "ecs:cluster" : clusterArn

--- a/aws/templates/policy/policy_ecs.ftl
+++ b/aws/templates/policy/policy_ecs.ftl
@@ -13,9 +13,50 @@
                     "ecs:StopTask",
                     "ecs:ListContainerInstances",
                     "ecs:RunTask",
-                    "ecs:StopTask",
 		            "ecs:DescribeTasks"
                 ]
+            )
+        ]
+    ]
+[/#function]
+
+[#function ecsTaskRunPermission ecsId taskId ]
+
+    [#local clusterArn = formatEcsClusterArn(ecsId)]
+    [#return
+        [
+            getPolicyStatement(
+                [
+                    "ecs:ListClusters",
+                    "ecs:DescribeContainerInstances",
+                    "ecs:ListTaskDefinitions",
+                    "ecs:DescribeTaskDefinition",
+                    "ecs:DescribeTasks",
+                    "ecs:ListContainerInstances"
+                ]
+            ),
+            getPolicyStatement(
+                [
+                    "ecs:RunTask",
+                    "ecs:StartTask"
+                ],
+                getReference(taskId),
+                {
+                    "ArnEquals" :{
+                        "ecs:cluster" : clusterArn 
+                    }
+                }
+            ),
+            getPolicyStatement(
+                [
+                    "ecs:StopTask"
+                ],
+                "*",
+                {
+                    "ArnEquals" :{
+                        "ecs:cluster" : clusterArn
+                    }
+                }
             )
         ]
     ]

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -1,6 +1,6 @@
 [#-- ECS --]
 
-[#macro createECSTask mode id containers networkMode="" delegatedDeployment=false role="" dependencies=""]
+[#macro createECSTask mode id name containers networkMode="" fixedName=false role="" dependencies=""]
 
     [#local definitions = [] ]
     [#local volumes = [] ]
@@ -97,24 +97,17 @@
         } + 
         attributeIfContent("Volumes", volumes)  + 
         attributeIfContent("TaskRoleArn", role, getReference(role, ARN_ATTRIBUTE_TYPE)) + 
-        attributeIfContent("NetworkMode", networkMode)
+        attributeIfContent("NetworkMode", networkMode) + 
+        attributeIfTrue("Family", fixedName, name )
     ]
 
-    [#if delegatedDeployment ]
-        [#-- Allows for container definitions to be written to a config file for processing by another service (e.g. Jenkins) --]
-        [@cfConfig
-            mode=listMode
-            content=taskProperties
-        /]
-    [#else]
-        [@cfResource
-            mode=mode
-            id=id
-            type="AWS::ECS::TaskDefinition"
-            properties=taskProperties
-            dependencies=dependencies
-        /]
-    [/#if]
+    [@cfResource
+        mode=mode
+        id=id
+        type="AWS::ECS::TaskDefinition"
+        properties=taskProperties
+        dependencies=dependencies
+    /]
 [/#macro]
 
 [#macro createECSService mode id ecsId desiredCount taskId loadBalancers networkMode="" subnets=[] securityGroups=[] roleId="" dependencies=""]


### PR DESCRIPTION
Delegated deployment was added to codeontap so that we could use the jenkins ecs agent plugin which ran ECS tasks on demand. This essentially required us to build an ECS tasks definition and pass it to the Jenkins server so it could create the task definition itself.

The plugin has been now updated so that you can specify an existing task definition to use and Jenkins will then use it.

This PR removes the DelegatedDeploy Task configuration and instead adds an overall capability for components to run/start an ECS task. Linking to a task with the role run will provide 2 Attributes 
 - ECSHOST - The ARN of the ECS host the Task belongs to 
 - DEFINITION - The family name of the TaskDefinition 

DEFINITION is only available if the task has a fixed family name as this allows for the task to be updated without the calling service having to deal with a changing task definition. So a task now has a new configuration option 
- FixedName (booleen - default false) - This sets the family name to the occurrence name for the Task Definition. When you apply this option when Cloudformation updates the task definition instead of replacing the task definition it creates a new revision of the task definition instead. This is useful when you have reasonably fixed task definitions that don't change often. 

The link also provided permissions to the component to Run and start the task on the cluster and also to stop any tasks on the cluster ( can't filter tasks based on their definition) 