### PR TITLE
Add Support for Cognito Auth with Application Load Balancers

### DIFF
--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -159,7 +159,7 @@
                             id=formatDependentSecurityGroupIngressId(
                                 resources["securityGroup"].Id
                                 link.Id)
-                            port=link.DestinationPort
+                            port=linkTargetAttributes["DESTINATION_PORT"]
                             cidr=linkTargetResources["sg"].Id
                             groupId=computeClusterSecurityGroupId /]
                     [/#if]

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -159,7 +159,7 @@
                             id=formatDependentSecurityGroupIngressId(
                                 resources["securityGroup"].Id
                                 link.Id)
-                            port=link.Port
+                            port=link.DestinationPort
                             cidr=linkTargetResources["sg"].Id
                             groupId=computeClusterSecurityGroupId /]
                     [/#if]

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -169,37 +169,9 @@
                         [#case "application"]
                         [#case "network"]
                             [#if link.TargetGroup?has_content ]
-                                [#assign targetId = (linkTargetResources["targetgroups"][link.TargetGroup].Id) ]
-                                [#if targetId?has_content]
-
-                                    [#if deploymentSubsetRequired(COMPUTECLUSTER_COMPONENT_TYPE, true)]
-                                        [#if isPartOfCurrentDeploymentUnit(targetId)]
-
-                                            [@createTargetGroup
-                                                mode=listMode
-                                                id=targetId
-                                                name=formatName(linkTargetCore.FullName,link.TargetGroup)
-                                                tier=link.Tier
-                                                component=link.Component
-                                                destination=ports[link.Port]
-                                            /]
-                                            [#assign listenerRuleId = formatALBListenerRuleId(occurrence, link.TargetGroup) ]
-                                            [@createListenerRule
-                                                mode=listMode
-                                                id=listenerRuleId
-                                                listenerId=linkTargetResources["listener"].Id
-                                                actions=getListenerRuleForwardAction(targetId)
-                                                conditions=getListenerRulePathCondition(link.TargetPath)
-                                                priority=link.Priority!100
-                                                dependencies=targetId
-                                            /]
-
-                                            [#assign componentDependencies += [targetId]]
-
-                                        [/#if]
-                                        [#assign targetGroups += [ getReference(targetId, ARN_ATTRIBUTE_TYPE) ] ]
-                                    [/#if]
-                                [/#if]
+                                [#assign targetId = (linkTargetResources["targetgroup"].Id) ]
+                                [#assign targetGroups += [ getReference(targetId, ARN_ATTRIBUTE_TYPE) ] ]
+                                
                             [/#if]
                             [#break]
 

--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -81,35 +81,7 @@
                                                 [#assign securityGroupSources = linkConfiguration.IPAddressGroups + [ "_localnet" ] ]
 
                                             [#case "application" ]
-                                                [#assign targetId = (linkResources["targetgroups"][loadBalancer.TargetGroup].Id)!"" ]
-                                                [#if !targetId?has_content]
-                                                    [#assign targetId = formatALBTargetGroupId(link, loadBalancer.TargetGroup) ]
-
-                                                    [#if isPartOfCurrentDeploymentUnit(targetId)]
-
-                                                        [@createTargetGroup
-                                                            mode=listMode
-                                                            id=targetId
-                                                            name=formatName(linkCore.FullName,loadBalancer.TargetGroup)
-                                                            tier=linkCore.Tier
-                                                            component=linkCore.Component
-                                                            destination=ports[portMapping.HostPort]
-                                                            targetType=lbTargetType
-                                                            /]
-
-                                                        [#assign listenerRuleId = formatALBListenerRuleId(link, loadBalancer.TargetGroup) ]
-                                                        [@createListenerRule
-                                                            mode=listMode
-                                                            id=listenerRuleId
-                                                            listenerId=linkResources["listener"].Id
-                                                            actions=getListenerRuleForwardAction(targetId)
-                                                            conditions=getListenerRulePathCondition(loadBalancer.Path)
-                                                            priority=loadBalancer.Priority!100
-                                                            dependencies=targetId
-                                                        /]
-                                                        [#assign dependencies += [listenerRuleId] ]
-                                                    [/#if]
-                                                [/#if]
+                                                [#assign targetId = (linkResources["targetgroup"].Id)!"" ]
 
                                                 [#assign loadBalancers +=
                                                     [

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1891,8 +1891,7 @@
         } +
         attributeIfTrue("Instance", port.LB.Instance??, port.LB.Instance!"") +
         attributeIfTrue("Version",  port.LB.Version??, port.LB.Version!"") +
-        attributeIfContent("PortMapping",  portMapping) + 
-        attributeIfContent("DestinationPort" , port.Name)
+        attributeIfContent("PortMapping",  portMapping) 
     ]
     [@cfDebug listMode { targetLinkName : targetLink } false /]
 

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1887,64 +1887,11 @@
             "Name" : targetLinkName,
             "Tier" : targetTierId,
             "Component" : targetComponentId,
-            "Priority" : port.LB.Priority
         } +
         attributeIfTrue("Instance", port.LB.Instance??, port.LB.Instance!"") +
         attributeIfTrue("Version",  port.LB.Version??, port.LB.Version!"") +
         attributeIfContent("PortMapping",  portMapping)
     ]
-
-    [#-- This lookup is purely to determine the correct attributes for the link   --]
-    [#-- The calling code should still check that the target link actually exists --]
-    [#-- using the value returned by this function                                --]
-    [#if targetTierId?has_content && targetComponentId?has_content]
-        [#local targetLoadBalancer = getLinkTarget(occurrence, targetLink) ]
-
-        [@cfDebug listMode targetLoadBalancer false /]
-
-        [#if targetLoadBalancer?has_content ]
-
-            [#local targetGroup = port.LB.TargetGroup]
-
-            [#if (ports[targetLoadBalancer.State.Attributes["PORT"]].Protocol) != "TCP" ]
-                [#local targetPath = port.LB.Path]
-            [#else]
-                [#local targetPath = "" ]
-            [/#if]
-
-            [#if targetPath?has_content]
-                [#-- target group name must be provided if path provided --]
-                [#if !targetGroup?has_content]
-                    [@cfException
-                        listMode "No target group for provided path" occurrence /]
-                    [#local targetGroup = "default" ]
-                [/#if]
-            [#else]
-                [#if !targetGroup?has_content]
-                    [#-- Create target group for container if it --]
-                    [#-- is versioned and load balancer isn't    --]
-                    [#if core.Version.Name?has_content &&
-                            !targetLoadBalancer.Core.Version.Name?has_content]
-                        [#local targetPath = "/" + core.Version.Name + "/*" ]
-                        [#local targetGroup = core.Version.Name ]
-                    [#else]
-                        [#local targetGroup = "default" ]
-                        [#local targetPath = ""]
-                    [/#if]
-                [/#if]
-            [/#if]
-
-            [#local targetLink +=
-                attributeIfContent(
-                    "TargetPath",
-                    targetPath
-                ) +
-                attributeIfContent(
-                    "TargetGroup",
-                    targetGroup
-                )]
-        [/#if]
-    [/#if]
 
     [@cfDebug listMode { targetLinkName : targetLink } false /]
 

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1887,12 +1887,13 @@
             "Name" : targetLinkName,
             "Tier" : targetTierId,
             "Component" : targetComponentId,
+            "Priority" : port.LB.Priority
         } +
         attributeIfTrue("Instance", port.LB.Instance??, port.LB.Instance!"") +
         attributeIfTrue("Version",  port.LB.Version??, port.LB.Version!"") +
-        attributeIfContent("PortMapping",  portMapping)
+        attributeIfContent("PortMapping",  portMapping) + 
+        attributeIfContent("DestinationPort" , port.Name)
     ]
-
     [@cfDebug listMode { targetLinkName : targetLink } false /]
 
     [#return { targetLinkName : targetLink } ]

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -53,6 +53,19 @@
                 "Default" : false
             },
             {
+                "Name" : "OAuth",
+                "Children" : [
+                    {
+                        "Name" : "Scopes",
+                        "Default" : [ "openid" ]
+                    },
+                    {
+                        "Name" : "Flows",
+                        "Default" : [ "code" ]
+                    }
+                ]
+            },
+            {
                 "Name" : "PasswordPolicy",
                 "Children" : [
                     {
@@ -147,6 +160,7 @@
                 "USER_POOL" : getReference(userPoolId),
                 "IDENTITY_POOL" : getReference(identityPoolId),
                 "CLIENT" : getReference(userPoolClientId),
+                "CLIENTSECRET" : getReference(userPoolClientId, PASSWORD_ATTRIBUTE_TYPE),
                 "REGION" : regionId
             },
             "Roles" : {

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -66,12 +66,25 @@
             },
             {
                 "Name" : "Priority",
-                "Default" : "default"
+                "Default" : 100
             },
             {
                 "Name" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration
+            },
+            {
+                "Name" : "Authentication",
+                "Children" : [
+                    {
+                        "Name" : "SessionCookieName",
+                        "Default" : "AWSELBAuthSessionCookie"
+                    },
+                    {
+                        "Name" : "SessionTimeout",
+                        "Default" : 604800
+                    }
+                ]
             }
         ]
     }]
@@ -119,7 +132,6 @@
     [#local lbId = parentState.Resources["lb"].Id]
 
     [#local sourcePort = (ports[portMappings[solution.Mapping!core.SubComponent.Name].Source])!{} ]
-
     [#local listenerId = formatResourceId(AWS_ALB_LISTENER_RESOURCE_TYPE, parentCore.Id, sourcePort) ]
 
     [#local path = (solution.Path == "default")?then(
@@ -137,6 +149,10 @@
         [#local fqdn = internalFqdn ]
         [#local scheme ="http" ]
     [/#if]
+
+    [#local url = scheme + "://" + fqdn  ]
+    [#local internalUrl = scheme + "://" + internalFqdn ]
+    
     [#return
         {
             "Resources" : {
@@ -163,10 +179,12 @@
                 "LB" : lbId,
                 "ENGINE" : engine,
                 "FQDN" : fqdn,
-                "URL" : scheme + "://" + fqdn + path,
+                "URL" : url + path,
                 "INTERNAL_FQDN" : internalFqdn,
-                "INTERNAL_URL" : scheme + "://" + internalFqdn + path,
-                "PORT" : sourcePort.Name
+                "INTERNAL_URL" : internalUrl + path,
+                "PORT" : sourcePort.Name,
+                "AUTH_CALLBACK_URL" : url + "/oauth2/idpresponse",
+                "AUTH_CALLBACK_INTERNAL_URL" : internalUrl + "/oauth2/idpresponse"
             },
             "Roles" : {
                 "Inbound" : {},

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -132,6 +132,7 @@
     [#local lbId = parentState.Resources["lb"].Id]
 
     [#local sourcePort = (ports[portMappings[solution.Mapping!core.SubComponent.Name].Source])!{} ]
+    [#local destinationPort = (ports[portMappings[solution.Mapping!core.SubComponent.Name].Destination])!{} ]
     [#local listenerId = formatResourceId(AWS_ALB_LISTENER_RESOURCE_TYPE, parentCore.Id, sourcePort) ]
 
     [#local path = (solution.Path == "default")?then(
@@ -183,6 +184,8 @@
                 "INTERNAL_FQDN" : internalFqdn,
                 "INTERNAL_URL" : internalUrl + path,
                 "PORT" : sourcePort.Name,
+                "SOURCE_PORT" : sourcePort.Name,
+                "DESTINATION_PORT" : destinationPort.Name,
                 "AUTH_CALLBACK_URL" : url + "/oauth2/idpresponse",
                 "AUTH_CALLBACK_INTERNAL_URL" : internalUrl + "/oauth2/idpresponse"
             },

--- a/aws/templates/resource/resource_cognito.ftl
+++ b/aws/templates/resource/resource_cognito.ftl
@@ -24,6 +24,9 @@
         },
         NAME_ATTRIBUTE_TYPE : { 
             "Attribute" : "Name" 
+        },
+        PASSWORD_ATTRIBUTE_TYPE : {
+            "Attribute" : "ClientSecret"
         }
     }
 ]

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -77,6 +77,17 @@
                 [#case LB_PORT_COMPONENT_TYPE]
                     [#assign targetGroupPermission = true]
 
+                    [#if deploymentSubsetRequired(EC2_COMPONENT_TYPE, true)]
+                        [@createSecurityGroupIngress
+                            mode=listMode
+                            id=formatDependentSecurityGroupIngressId(
+                                resources["securityGroup"].Id
+                                link.Id)
+                            port=link.DestinationPort
+                            cidr=linkTargetResources["sg"].Id
+                            groupId=ec2SecurityGroupId /]
+                    [/#if]
+
                     [#switch linkTargetAttributes["ENGINE"]]
 
                         [#case "application"]

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -82,38 +82,10 @@
                         [#case "application"]
                         [#case "network"]
                             [#if link.TargetGroup?has_content ]
-                                [#assign targetId = (linkTargetResources["targetgroups"][link.TargetGroup].Id) ]
-                                [#if targetId?has_content]
-
-                                    [#if deploymentSubsetRequired("ec2", true)]
-                                        [#if isPartOfCurrentDeploymentUnit(targetId)]
-
-                                            [@createTargetGroup
-                                                mode=listMode
-                                                id=targetId
-                                                name=formatName(linkTargetCore.FullName,link.TargetGroup)
-                                                tier=link.Tier
-                                                component=link.Component
-                                                destination=ports[link.Port]
-                                            /]
-                                            [#assign listenerRuleId = formatALBListenerRuleId(occurrence, link.TargetGroup) ]
-                                            [@createListenerRule
-                                                mode=listMode
-                                                id=listenerRuleId
-                                                listenerId=linkTargetResources["listener"].Id
-                                                actions=getListenerRuleForwardAction(targetId)
-                                                conditions=getListenerRulePathCondition(link.TargetPath)
-                                                priority=link.Priority!100
-                                                dependencies=targetId
-                                            /]
-
-                                            [#assign componentDependencies += [targetId]]
-
-                                        [/#if]
-                                        [#assign configSets +=
-                                            getInitConfigLBTargetRegistration(targetId)]
-                                    [/#if]
-                                [/#if]
+                            
+                                [#assign targetId = (linkTargetResources["targetgroup"].Id) ]
+                                [#assign configSets += getInitConfigLBTargetRegistration(targetId)]
+                                            
                             [/#if]
                             [#break]
 

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -83,7 +83,7 @@
                             id=formatDependentSecurityGroupIngressId(
                                 resources["securityGroup"].Id
                                 link.Id)
-                            port=link.DestinationPort
+                            port=linkTargetAttributes["DESTINATION_PORT"]
                             cidr=linkTargetResources["sg"].Id
                             groupId=ec2SecurityGroupId /]
                     [/#if]

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -89,6 +89,7 @@
 
             [#if !(sourcePort?has_content && destinationPort?has_content)]
                 [#continue ]
+            [/#if]
 
             [#list solution.Links?values as link]
                 [#if link?is_hash]

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -6,92 +6,227 @@
             deploymentUnit) as occurrence]
 
         [@cfDebug listMode occurrence false /]
+      
+        [#assign solution = occurrence.Configuration.Solution ]
+        [#assign resources = occurrence.State.Resources ]
 
-        [#if deploymentSubsetRequired("alb", true) ]
+        [#assign lbId = resources["lb"].Id ]
+        [#assign lbName = resources["lb"].Name ]
+        [#assign lbShortName = resources["lb"].ShortName ]
+        [#assign lbLogs = solution.Logs ]
+        [#assign lbSecurityGroupIds = [] ]
 
-            [#assign solution = occurrence.Configuration.Solution ]
-            [#assign resources = occurrence.State.Resources ]
+        [#assign engine = solution.Engine]
 
-            [#assign lbId = resources["lb"].Id ]
-            [#assign lbName = resources["lb"].Name ]
-            [#assign lbShortName = resources["lb"].ShortName ]
-            [#assign lbLogs = solution.Logs ]
-            [#assign lbSecurityGroupIds = [] ]
+        [#assign healthCheckPort = "" ]
+        [#if engine == "classic" ]
+            [#if solution.HealthCheckPort?has_content ]
+                [#assign healthCheckPort = ports[solution.HealthCheckPort]]
+            [#else]
+                [@cfPreconditionFailed listMode "solution_lb" {} "No health check port provided" /]    
+            [/#if]
+        [/#if]
+
+        [#assign portProtocols = [] ]
+        [#assign classicListeners = []]
+        [#assign ingressRules = [] ]
+
+        [#list occurrence.Occurrences![] as subOccurrence]
+
+            [#assign core = subOccurrence.Core ]
+            [#assign solution = subOccurrence.Configuration.Solution ]
+            [#assign resources = subOccurrence.State.Resources ]
 
             [#assign engine = solution.Engine]
             [#assign idleTimeout = solution.IdleTimeout]
+            [#assign listenerId = resources["listener"].Id ]
+    
+            [#assign securityGroupId = resources["sg"].Id]
+            [#assign securityGroupName = resources["sg"].Name]
 
-            [#assign healthCheckPort = "" ]
-            [#if engine == "classic" ]
-                [#if solution.HealthCheckPort?has_content ]
-                    [#assign healthCheckPort = ports[solution.HealthCheckPort]]
-                [#else]
-                    [@cfPreconditionFailed listMode "solution_lb" {} "No health check port provided" /]    
-                [/#if]
+            [#assign targetGroupId = resources["targetgroup"].Id]
+            [#assign targetGroupName = resources["targetgroup"].Name]
+
+            [#assign lbSecurityGroupIds += [securityGroupId] ]
+
+            [#assign mapping = solution.Mapping!core.SubComponent.Name ]
+            [#assign source = (portMappings[mapping].Source)!"" ]
+            [#assign destination = (portMappings[mapping].Destination)!"" ]
+            [#assign sourcePort = (ports[source])!{} ]
+            [#assign destinationPort = (ports[destination])!{} ]
+
+            [#assign path = (solution.Path == "default")?then("", solution.Path)]
+
+            [#assign listenerRuleId = resources["listenerRule"].Id ]
+            [#assign listenerRuleConditions = getListenerRulePathCondition(path)]
+            [#assign listenerRuleConfig = {}]
+            [#assign listenerRuleCommand = "createListenerRule" ]
+
+            [#if !(sourcePort?has_content && destinationPort?has_content)]
+                [#continue ]
             [/#if]
 
-            [#assign portProtocols = [] ]
-            [#assign classicListeners = []]
+            [#assign portProtocols += [ sourcePort.Protocol ] ]
+            [#assign portProtocols += [ destinationPort.Protocol] ]
 
-            [#list occurrence.Occurrences![] as subOccurrence]
+            [#assign cidr= getGroupCIDRs(solution.IPAddressGroups) ]
 
-                [#assign core = subOccurrence.Core ]
-                [#assign solution = subOccurrence.Configuration.Solution ]
-                [#assign resources = subOccurrence.State.Resources ]
+            [#-- Internal ILBs may not have explicit IP Address Groups --]
+            [#assign cidr =
+                cidr?has_content?then(
+                    cidr,
+                    (tier.Network.RouteTable == "external")?then(
+                        [],
+                        segmentObject.Network.CIDR.Address + "/" + segmentObject.Network.CIDR.Mask
+                    )) ]
 
-                [#assign listenerId = resources["listener"].Id ]
 
-                [#assign securityGroupId = resources["sg"].Id]
-                [#assign securityGroupName = resources["sg"].Name]
+            [#assign certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers, sourcePort.Id, sourcePort.Name) ]
+            [#assign hostName = getHostName(certificateObject, subOccurrence) ]
+            [#assign certificateId = formatDomainCertificateId(certificateObject, hostName) ]
 
-                [#assign targetGroupId = resources["targetgroups"]["default"].Id]
-                [#assign targetGroupName = resources["targetgroups"]["default"].Name]
+            [#assign targetType = solution.TargetType ]
 
-                [#assign lbSecurityGroupIds += [securityGroupId] ]
+            [#if !(sourcePort?has_content && destinationPort?has_content)]
+                [#continue ]
 
-                [#assign mapping = solution.Mapping!core.SubComponent.Name ]
-                [#assign source = (portMappings[mapping].Source)!"" ]
-                [#assign destination = (portMappings[mapping].Destination)!"" ]
-                [#assign sourcePort = (ports[source])!{} ]
-                [#assign destinationPort = (ports[destination])!{} ]
+            [#list solution.Links?values as link]
+                [#if link?is_hash]
+                    [#assign linkTarget = getLinkTarget(occurrence, link) ]
 
-                [#assign targetType = solution.TargetType ]
+                    [@cfDebug listMode linkTarget false /]
 
-                [#if !(sourcePort?has_content && destinationPort?has_content)]
-                    [#continue ]
+                    [#if !linkTarget?has_content]
+                        [#continue]
+                    [/#if]
+
+                    [#assign linkTargetCore = linkTarget.Core ]
+                    [#assign linkTargetConfiguration = linkTarget.Configuration ]
+                    [#assign linkTargetResources = linkTarget.State.Resources ]
+                    [#assign linkTargetAttributes = linkTarget.State.Attributes ]
+
+                    [#switch linkTargetCore.Type]
+
+                        [#case USERPOOL_COMPONENT_TYPE] 
+                            [#assign cognitoIntegration = true ]
+                            [#assign userPoolId = linkTargetResources["userpool"].Id ]
+                            [#assign userPoolClientId = linkTargetResources["client"].Id ]
+                            [#assign userPoolDomain = linkTargetResources["userpool"].HostName ]
+                            [#assign listenerRuleConfig = 
+                                {
+                                    "Conditions" : listenerRuleConditions,
+                                    "Priority" : solution.Priority,
+                                    "Actions" : [
+                                        {
+                                            "Type" : "authenticate-cognito",
+                                            "AuthenticateCognitoConfig" : {
+                                                "UserPoolArn" : getExistingReference(userPoolId, ARN_ATTRIBUTE_TYPE),
+                                                "UserPoolClientId" : getExistingReference(userPoolClientId),
+                                                "UserPoolDomain" : userPoolDomain,
+                                                "SessionCookieName" : solution.Authentication.SessionCookieName,
+                                                "SessionTimeout" : solution.Authentication.SessionTimeout,
+                                                "Scope" : linkTargetConfiguration.OAuthScope,
+                                                "OnUnauthenticatedRequest" : "authenticate"
+                                            },
+                                            "Order" : 1
+                                        },
+                                        {
+                                            "Type": "forward",
+                                            "TargetGroupArn" : getReference(targetGroupId, ARN_ATTRIBUTE_TYPE),
+                                            "Order" : 2
+                                        }
+                                    ]
+                                }]  
+                            [#break]
+                    [/#switch]
                 [/#if]
+            [/#list]
 
-                [#assign portProtocols += [ sourcePort.Protocol ] ]
-                [#assign portProtocols += [ destinationPort.Protocol] ]
+            [#if engine == "application" || engine == "classic" ]
+                [@createSecurityGroup
+                    mode=listMode
+                    id=securityGroupId
+                    name=securityGroupName
+                    tier=tier
+                    component=component
+                    ingressRules=[ {"Port" : sourcePort.Port, "CIDR" : cidr} ]/]
+            [/#if]
 
-                [#assign cidr= getGroupCIDRs(solution.IPAddressGroups) ]
+            [#switch engine ]
+                [#case "application"]
+                [#case "network"]
 
-                [#-- Internal ILBs may not have explicit IP Address Groups --]
-                [#assign cidr =
-                    cidr?has_content?then(
-                        cidr,
-                        (tier.Network.RouteTable == "external")?then(
-                            [],
-                            segmentObject.Network.CIDR.Address + "/" +segmentObject.Network.CIDR.Mask
-                        )) ]
+                    [#if path == "default" ]
+                        [#if deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
+                            [@createALBListener
+                                mode=listMode
+                                id=listenerId
+                                port=sourcePort
+                                albId=lbId
+                                defaultTargetGroupId=targetGroupId
+                                certificateId=certificateId /]
+                        [/#if]
+                    [/#if]
 
-                [#assign certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers, sourcePort.Id, sourcePort.Name) ]
-                [#assign hostName = getHostName(certificateObject, subOccurrence) ]
-                [#assign certificateId = formatDomainCertificateId(certificateObject, hostName) ]
+                    [#if listenerRuleConfig?has_content ]
 
-                [#if engine == "application" || engine == "classic" ]
-                    [@createSecurityGroup
-                        mode=listMode
-                        id=securityGroupId
-                        name=securityGroupName
-                        tier=tier
-                        component=component
-                        ingressRules=[{"Port" : sourcePort.Port, "CIDR" : cidr}] /]
-                [/#if]
+                        [#if deploymentSubsetRequired("cli", false)]
 
-                [#switch engine ]
-                    [#case "application"]
-                    [#case "network"]
+                            [@cfCli 
+                                mode=listMode
+                                id=listenterRuleId
+                                command=listenerRuleCommand
+                                content=listenerRuleConfig
+                            /]
+
+                        [/#if]
+
+                        [#if deploymentSubsetRequired("epilogue", false) && cliConfigRequired ]
+                            [@cfScript
+                                mode=listMode
+                                content= (getExistingReference(listenterId)?has_content)?then(
+                                        [
+                                            "case $\{STACK_OPERATION} in",
+                                            "  create|update)",
+                                            "       # Get cli config file",
+                                            "       split_cli_file \"$\{CLI}\" \"$\{tmpdir}\" || return $?", 
+                                            "       # Apply CLI level updates to ELB listener",
+                                            "       info \"Applying cli level configurtion\""
+                                            "       listener_rule_arn=$( create_elbv2_rule" +
+                                            "       \"" + region + "\" " + 
+                                            "       \"" + getExistingReference(listenterId) + "\" " + 
+                                            "       \"$\{tmpdir}/cli-" + 
+                                                    listenterRuleId + "-" + listenerRuleCommand + ".json\")"
+                                            "       create_pseudo_stack" + " " +
+                                            "       \"LB Listener Rule\"" + " " +
+                                            "       \"$\{url_pseudo_stack_file}\"" + " " +
+                                            "       \"" + listenterRuleId + "Xarn\" \"$\{listener_rule_arn}\" || return $?",
+                                            "   ;;",
+                                            "   esac"
+                                        ],
+                                        [
+                                            "warning \"Please run another update to complete the configuration\""
+                                        ]
+                                    )
+                            /]
+                        [/#if]
+
+                    [#else]
+
+                        [#if deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
+                            [@createListenerRule
+                                mode=listMode
+                                id=listenerRuleId
+                                listenerId=listenerId
+                                actions=getListenerRuleForwardAction(targetGroupId)
+                                conditions=listenerRuleConditions
+                                priority=solution.Priority
+                                dependencies=targetId /]
+                        [/#if]
+
+                    [/#if]
+                    
+                    [#if deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
 
                         [@createTargetGroup
                             mode=listMode
@@ -99,71 +234,64 @@
                             name=targetGroupName
                             tier=tier
                             component=component
-                            destination=destinationPort
-                            targetType=targetType /]
-
-                        [@createALBListener
-                            mode=listMode
-                            id=listenerId
-                            port=sourcePort
-                            albId=lbId
-                            defaultTargetGroupId=targetGroupId
-                            certificateId=certificateId /]
-                        [#break]
-
-                    [#case "classic"]
-                        [#assign classicListeners +=
-                            [
-                                {
-                                    "LoadBalancerPort" : sourcePort.Port,
-                                    "Protocol" : sourcePort.Protocol,
-                                    "InstancePort" : destinationPort.Port,
-                                    "InstanceProtocol" : destinationPort.Protocol
-                                }  +
-                                attributeIfTrue(
-                                    "SSLCertificateId",
-                                    sourcePort.Certificate!false,
-                                    getReference(certificateId, ARN_ATTRIBUTE_TYPE, regionId)
-                                ) 
-                            ]
-                        ]
-                        
-                        [#break]
-                [/#switch]
-            [/#list]
-
-            [#-- Port Protocol Validation --]
-            [#assign InvalidProtocol = false]
-            [#switch engine ]
-                [#case "network" ]
-                    [#if portProtocols?seq_contains("HTTP") || portProtocols?seq_contains("HTTPS") ]
-                        [#assign InvalidProtocol = true]
+                            destination=destinationPort /]
                     [/#if]
                     [#break]
-                [#case "application" ]
-                    [#if portProtocols?seq_contains("TCP") ]
-                        [#assign InvalidProtocol = true]
-                    [/#if]
+
+                [#case "classic"]
+                    [#assign classicListeners +=
+                        [
+                            {
+                                "LoadBalancerPort" : sourcePort.Port,
+                                "Protocol" : sourcePort.Protocol,
+                                "InstancePort" : destinationPort.Port,
+                                "InstanceProtocol" : destinationPort.Protocol
+                            }  +
+                            attributeIfTrue(
+                                "SSLCertificateId",
+                                sourcePort.Certificate!false,
+                                getReference(certificateId, ARN_ATTRIBUTE_TYPE, regionId)
+                            ) 
+                        ]
+                    ]
+                    
                     [#break]
             [/#switch]
+        [/#list]
 
-            [#if InvalidProtocol ]
-                    [@cfException
-                        mode=listMode
-                        description="Invalid protocol found for engine type"
-                        context=
-                            {
-                                "LB" : lbName,
-                                "Engine" : engine,
-                                "Protocols" : portProtocols
-                            }
-                    /]
-            [/#if]
+        [#-- Port Protocol Validation --]
+        [#assign InvalidProtocol = false]
+        [#switch engine ]
+            [#case "network" ]
+                [#if portProtocols?seq_contains("HTTP") || portProtocols?seq_contains("HTTPS") ]
+                    [#assign InvalidProtocol = true]
+                [/#if]
+                [#break]
+            [#case "application" ]
+                [#if portProtocols?seq_contains("TCP") ]
+                    [#assign InvalidProtocol = true]
+                [/#if]
+                [#break]
+        [/#switch]
 
-            [#switch engine ]
-                [#case "network"]
-                [#case "application"]
+        [#if InvalidProtocol ]
+                [@cfException
+                    mode=listMode
+                    description="Invalid protocol found for engine type"
+                    context=
+                        {
+                            "LB" : lbName,
+                            "Engine" : engine,
+                            "Protocols" : portProtocols
+                        }
+                /]
+        [/#if]
 
+        [#switch engine ]
+            [#case "network"]
+            [#case "application"]
+
+                [#if deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
                     [@createALB
                         mode=listMode
                         id=lbId
@@ -205,7 +333,34 @@
                         idleTimeout=idleTimeout
                      /]
                 [#break]
-            [/#switch ]
-        [/#if]
+                å
+            [#case "classic"]
+            
+                    [#if deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
+                        [#assign healthCheck = {
+                            "Target" : healthCheckPort.HealthCheck.Protocol!healthCheckPort.Protocol + ":" 
+                                        + (healthCheckPort.HealthCheck.Port!healthCheckPort.Port)?c + healthCheckPort.HealthCheck.Path!"",
+                            "HealthyThreshold" : healthCheckPort.HealthCheck.HealthyThreshold,
+                            "UnhealthyThreshold" : healthCheckPort.HealthCheck.UnhealthyThreshold,
+                            "Interval" : healthCheckPort.HealthCheck.Interval,
+                            "Timeout" : healthCheckPort.HealthCheck.Timeout
+                        }]
+
+                        [@createClassicLB 
+                            mode=listMode 
+                            id=lbId 
+                            name=lbName 
+                            shortName=lbShortName
+                            tier=tier
+                            component=component 
+                            listeners=classicListeners 
+                            healthCheck=healthCheck 
+                            securityGroups=lbSecurityGroupIds 
+                            logs=lbLogs 
+                            bucket=operationsBucket 
+                        /]
+                    [/#if]
+            [#break]
+        [/#switch ]
     [/#list]
 [/#if]

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -246,10 +246,11 @@
                                                         "       \"" + region + "\" " + 
                                                         "       \"" + getExistingReference(listenerId) + "\" " + 
                                                         "       \"$\{tmpdir}/cli-" + 
-                                                                listenerRuleId + "-" + listenerRuleCommand + ".json\")"
+                                                                listenerRuleId + "-" + listenerRuleCommand + ".json\")",
+                                                        "       pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-pseudo-stack.json\" ",
                                                         "       create_pseudo_stack" + " " +
                                                         "       \"LB Listener Rule\"" + " " +
-                                                        "       \"$\{url_pseudo_stack_file}\"" + " " +
+                                                        "       \"$\{pseudo_stack_file}\"" + " " +
                                                         "       \"" + listenerRuleId + "Xarn\" \"$\{listener_rule_arn}\" || return $?"
                                                     ]
                                                 ) +

--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -177,6 +177,10 @@
                         [/#switch]
                     [/#if]
                 [#break]
+                [#case LB_PORT_COMPONENT_TYPE]
+                    [#if linkTargetResources[LB_PORT_COMPONENT_TYPE].Deployed]
+                    [/#if]
+                [#break]
             [/#switch]
         [/#list]
 

--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -29,8 +29,11 @@
         [#assign userPoolTriggerConfig = {}]
         [#assign userPoolManualTriggerConfig = {}]
         [#assign smsConfig = {}]
-        
-        [#assign userPoolUpdateCommand = "updateUserPool" ]     
+        [#assign callbackUrls = []]
+        [#assign logoutUrls = []]
+
+        [#assign userPoolUpdateCommand = "updateUserPool" ]
+        [#assign userPoolClientUpdateCommand = "updateUserPoolClient" ]     
         [#assign userPoolDomainCommand = "setDomainUserPool" ]       
     
         [#assign emailVerificationMessage =
@@ -88,6 +91,14 @@
             [#assign linkTargetAttributes = linkTarget.State.Attributes]
 
             [#switch linkTargetCore.Type]
+                [#case LB_PORT_COMPONENT_TYPE]
+                    [#assign callbackUrls += [
+                        linkTargetAttributes["AUTH_CALLBACK_URL"],
+                        linkTargetAttributes["AUTH_CALLBACK_INTERNAL_URL"]
+                        ]
+                    ]
+                    [#break]
+
                 [#case LAMBDA_FUNCTION_COMPONENT_TYPE]
 
                     [#if linkTargetResources[LAMBDA_FUNCTION_COMPONENT_TYPE].Deployed]
@@ -403,6 +414,25 @@
                 command=userPoolDomainCommand
                 content=userPoolDomain
             /]
+
+            [#assign updateUserPoolClient = 
+                {
+                    "CallbackURLs": callbackUrls,
+                    "LogoutURLs": logoutUrls,
+                    "AllowedOAuthFlows": solution.OAuth.Flows,
+                    "AllowedOAuthScopes": solution.OAuth.Scopes,
+                    "AllowedOAuthFlowsUserPoolClient": true,
+                    "SupportedIdentityProviders" : [ "COGNITO" ]
+                }
+            ]
+
+            [@cfCli
+                mode=listMode
+                id=userPoolClientId
+                command=userPoolClientUpdateCommand
+                content=updateUserPoolClient
+            /]
+
         [/#if]
         
         [#if deploymentSubsetRequired("prologue", false)]
@@ -438,23 +468,36 @@
             [@cfScript
                 mode=listMode
                 content=(getExistingReference(userPoolId)?has_content)?then(
+                    [
+                        " # Get cli config file",
+                        " split_cli_file \"$\{CLI}\" \"$\{tmpdir}\" || return $?", 
+                        "case $\{STACK_OPERATION} in",
+                        "  create|update)",
+                        "       # Manage Userpool client",
+                        "       update_userpool_client" +
+                        "       \"" + region + "\" " + 
+                        "       \"" + getExistingReference(userPoolId) + "\" " + 
+                        "       \"" + getExistingReference(userPoolClientId) + "\" " + 
+                        "       \"$\{tmpdir}/cli-" + 
+                            userPoolClientId + "-" + userPoolClientUpdateCommand + ".json\" || return $?"
+                    ] +
                     [#-- Some Userpool Lambda triggers are not available via Cloudformation but are available via CLI --]
                     (userPoolManualTriggerConfig?has_content)?then(
                         [
-                            "case $\{STACK_OPERATION} in",
-                            "  create|update)",
                             "       # Add Manual Cognito Triggers",
                             "       info \"Adding Cognito Triggers that are not part of cloudformation\""
                             "       update_cognito_userpool" +
                             " \"" + region + "\" " + 
                             " \"" + getExistingReference(userPoolId) + "\" " + 
                             " \"$\{tmpdir}/cli-" + 
-                            userPoolId + "-" + userPoolUpdateCommand + ".json\" || return $?",
-                            "       ;;",
-                            "       esac"
+                            userPoolId + "-" + userPoolUpdateCommand + ".json\" || return $?"
                         ],
                         []
-                    ) ,
+                    )+
+                    [
+                        "       ;;",
+                        "       esac"
+                    ],
                     [
                         "warning \"Please run another update to complete the configuration\""
                     ]


### PR DESCRIPTION
Adds support for a load balancer to authenticate clients using a cognito user pool (https://aws.amazon.com/blogs/aws/built-in-authentication-in-alb/) 

To support this a number of changes are required 
- UserPools
  - Configuration
     - OAuth - Scopes - The oAuth scopes presented to the client - Default openid
     - OAuth - Flows - The oAuth flows used for authentication - Default code (authorisation code grant) 
- LoadBalancer - Port
    - Configuration 
         - Path - The client side path which will match to a specific target group or action - Default default
         - Priority - If a rule needs to be created the priority of the rule against other rules ( lowest wins) - Default 100 
         - Links - Adds standard links
         - Authentication - SessionCookieName - The cookie used to determine if authentication is required - Default AWSELBAuthSessionCookie
         - Authentication - SessionTimeout - Default 7 days
- Consolidation of  all load balancing configuration into the LB solution. Paths can now be defined using multiple Port Mappings that use the same mapping. A default port mapping must be created in order to create additional  paths 
Example: 
```
                    "LB" : {
                        "Logs" : true,
                        "Engine" : "application",
                        "PortMappings" : {
                            "http" : {
                                "TargetType" : "ip"
                            },
                            "https" : {
                                "Links" : {
                                    "feed-userpool" : {
                                        "Tier" : "app",
                                        "Component" : "feed-userpool",
                                        "Instance" : "",
                                        "Version" : ""
                                    }
                                }
                            },
                            "httpsadmin" : {
                                "Mapping" : "https",
                                "Path" : "/admin"
                            }
                        },
                        "Instances" : {
                            "default" : {
                                "DeploymentUnits" : ["redirector-elb"]
                            }
                        },
                        "IPAddressGroups" : ["global"]
                    }
```
- In this LB configuration the http and httpsadmin both use the same mapping (the https gets its mapping from its key name). The httpsadmin has a path set and a Mapping set. The Path rule doesn't create a listener or security group and uses the default ports listener and security group.

- A target (ec2, computecluster, container) needs to link to the LB Port, this link will provide the target group that the target needs to register to. The target is responsible for registering to the target group and the client side configuration is looked after by the LB. 

- To enable Cognito Authentication two links are required, one from the user pool to the LB and one from the LB to the userpool. The Userpool to LB link gets the callbackURLs required by cognito and the LB to Userpool link configures the listener rule to enable the authentication. 

- When using LB user pool must have "ClientGenerateSecret" set to true 