### PR TITLE
Codeontap task container configuration

### DIFF
--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -242,13 +242,13 @@
             [#if solution.UseTaskRole]
                 [#assign roleId = resources["taskrole"].Id ]
                 [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(roleId)]
-                    [@createRole
-                        mode=listMode
-                        id=roleId
-                        trustedServices=["ecs-tasks.amazonaws.com"]
-                    /]
+                    [#assign managedPolicy = []]
 
                     [#list containers as container]
+                        [#if container.ManagedPolicy?has_content ]
+                            [#assign managedPolicy += container.ManagedPolicy ]
+                        [/#if]
+
                         [#if container.Policy?has_content]
                             [#assign policyId = formatDependentPolicyId(taskId, container.Id) ]
                             [@createPolicy
@@ -275,6 +275,13 @@
                             [#assign dependencies += [policyId] ]
                         [/#if]
                     [/#list]
+
+                    [@createRole
+                        mode=listMode
+                        id=roleId
+                        trustedServices=["ecs-tasks.amazonaws.com"]
+                        managedArns=managedPolicy
+                    /]
                 [/#if]
             [#else]
                 [#assign roleId = "" ]

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -249,6 +249,16 @@
     [/#if]
 [/#macro]
 
+[#macro ManagedPolicy arns...]
+    [#if (containerListMode!"") == "model"]
+        [#assign context += 
+            {
+                "ManagedPolicy" : (context.ManagedPolicy![]) + asFlattenedArray(arns)
+            }
+        ]
+    [/#if]
+[/#macro]
+
 [#assign ECS_DEFAULT_MEMORY_LIMIT_MULTIPLIER=1.5 ]
 
 [#function defaultEnvironment occurrence]

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -489,7 +489,8 @@
                 "DefaultCoreVariables" : true,
                 "DefaultEnvironmentVariables" : true,
                 "DefaultLinkVariables" : true,
-                "Policy" : standardPolicies(task)
+                "Policy" : standardPolicies(task),
+                "Privileged" : container.Privileged
             } +
             attributeIfContent("LogGroup", containerLogGroup) +
             attributeIfContent("ImageVersion", container.Version) +

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -211,6 +211,16 @@
     [/#if]
 [/#macro]
 
+[#macro WorkingDirectory workingDirectory ]
+        [#if ((containerListMode!"") == "model")]
+        [#assign context +=
+            {
+                "WorkingDirectory" : workingDirectory
+            }
+        ]
+    [/#if]
+[/#macro]
+
 [#macro Volume name containerPath hostPath="" readOnly=false]
     [#if (containerListMode!"") == "model"]
         [#assign context +=

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -507,7 +507,8 @@
                 container.MemoryReservation*ECS_DEFAULT_MEMORY_LIMIT_MULTIPLIER
             ) +
             attributeIfContent("PortMappings", containerPortMappings) +
-            attributeIfContent("IngressRules", ingressRules)
+            attributeIfContent("IngressRules", ingressRules) +
+            attributeIfContent("RunCapabilities", container.RunCapabilities)
         ]
 
         [#-- Add in container specifics including override of defaults --]

--- a/aws/templates/container/container_codeontap.ftl
+++ b/aws/templates/container/container_codeontap.ftl
@@ -12,6 +12,8 @@
         [@Volume "codeontap" "/var/opt/codeontap/" settings["CODEONTAPVOLUME"] /]
     [/#if]  
 
+    [@Volume "dockerstore" "/var/lib/docker/vfs/dir/" settings["AWSPROFILEVOLUME"] + "/docker-images" /]
+
     [#if settings["AWSPROFILEVOLUME"]?has_content ]
         [#assign awsProfilePath = "/var/opt/awsprofile/" ]
 

--- a/aws/templates/container/container_codeontap.ftl
+++ b/aws/templates/container/container_codeontap.ftl
@@ -1,6 +1,9 @@
 [#case "codeontap"]
     [#assign settings = context.DefaultEnvironment]
 
+    [#assign dockerStageDir = settings["DOCKER_STAGE_DIR"]!"/tmp" ]
+    [#assign dockerHostDaemon = settings["DOCKER_HOST_DAEMON"]!"/var/run/docker.sock" ]
+
     [@Attributes image="gen3-jenkins-slave" /]
     
     [@DefaultLinkVariables enabled=false /]
@@ -8,12 +11,11 @@
     [@DefaultEnvironmentVariables enabled=false /]
 
     [@Settings {
-        "AWS_AUTOMATION_USER" : "ROLE"
+        "AWS_AUTOMATION_USER" : "ROLE",
+        "DOCKER_STAGE_DIR" : dockerStageDir
     }/]
-    
-    [#assign dockerStageDir = settings["DOCKER_STAGE_DIR"]!"/tmp" ]
 
-    [@Volume "dockerDaemon" "/var/run/docker.sock" settings["DOCKER_HOST_DAEMON"]!"/var/run/docker.sock" /]
+    [@Volume "dockerDaemon" "/var/run/docker.sock" dockerHostDaemon  /]
     [@Volume "dockerStage" dockerStageDir dockerStageDir /]
 
     [#-- Validate that the appropriate settings have been provided for the container to work --]

--- a/aws/templates/container/container_codeontap.ftl
+++ b/aws/templates/container/container_codeontap.ftl
@@ -1,7 +1,11 @@
 [#case "codeontap"]
     [#assign settings = context.DefaultEnvironment]
 
-    [@Attributes image="gen3-jenkins-slave" version="latest" /]
+    [@Attributes image="gen3-jenkins-slave" /]
+    
+    [@DefaultLinkVariables enabled=false /]
+    [@DefaultCoreVariables enabled=false /]
+    [@DefaultEnvironmentVariables enabled=false /]
 
     [#-- Validate that the appropriate settings have been provided for the container to work --]
     [#if settings["CODEONTAPVOLUME"]?has_content ]

--- a/aws/templates/container/container_codeontap.ftl
+++ b/aws/templates/container/container_codeontap.ftl
@@ -13,6 +13,8 @@
         "AWS_AUTOMATION_USER" : "ROLE"
     }/]
 
+    [@Volume "dockerlib" "/var/lib/docker/" "/cache/" + core.Name + "/" + getContainerName(container) + "/dockerlib/" /]
+
     [#-- Validate that the appropriate settings have been provided for the container to work --]
     [#if settings["CODEONTAPVOLUME"]?has_content ]
         [@Volume "codeontap" "/var/opt/codeontap/" settings["CODEONTAPVOLUME"] /]

--- a/aws/templates/container/container_codeontap.ftl
+++ b/aws/templates/container/container_codeontap.ftl
@@ -9,11 +9,12 @@
 
     [@Settings {
         "JAVA_OPTS" : "-Dhudson.remoting.Launcher.pingIntervalSec=1200",
-        "ENABLE_DOCKER" : "true",
         "AWS_AUTOMATION_USER" : "ROLE"
     }/]
 
-    [@Volume "dockerlib" "/var/lib/docker/" "/cache/" + core.Name + "/" + getContainerName(container) + "/dockerlib/" /]
+    [#if settings["ENABLE_DOCKER"] ]
+        [@Volume "dockerlib" "/var/lib/docker/" "/cache/" + core.Name + "/" + getContainerName(container) + "/dockerlib/" /]
+    [/#if]
 
     [#-- Validate that the appropriate settings have been provided for the container to work --]
     [#if settings["CODEONTAPVOLUME"]?has_content ]

--- a/aws/templates/container/container_codeontap.ftl
+++ b/aws/templates/container/container_codeontap.ftl
@@ -9,9 +9,9 @@
 
     [@Settings {
         "JAVA_OPTS" : "-Dhudson.remoting.Launcher.pingIntervalSec=1200",
-        "ENABLE_DOCKER" : "true"
-    }
-    /]
+        "ENABLE_DOCKER" : "true",
+        "AWS_AUTOMATION_USER" : "ROLE"
+    }/]
 
     [#-- Validate that the appropriate settings have been provided for the container to work --]
     [#if settings["CODEONTAPVOLUME"]?has_content ]

--- a/aws/templates/container/container_codeontap.ftl
+++ b/aws/templates/container/container_codeontap.ftl
@@ -12,6 +12,13 @@
         [@Volume "codeontap" "/var/opt/codeontap/" settings["CODEONTAPVOLUME"] /]
     [/#if]  
 
+    [#if settings["AWSPROFILEVOLUME"]?has_content ]
+        [#assign awsProfilePath = "/var/opt/awsprofile/" ]
+
+        [@Volume "awsprofile" awsProfilePath settings["AWSPROFILEVOLUME"] /]
+        [@Variable "AWS_CONFIG_FILE" awsProfilePath + "config" /]
+    [/#if]
+
     [#if settings["AWS_AUTOMATION_POLICIES"]?has_content ]
         [@ManagedPolicy settings["AWS_AUTOMATION_POLICIES"]?split(",") /]
     [#else]

--- a/aws/templates/container/container_codeontap.ftl
+++ b/aws/templates/container/container_codeontap.ftl
@@ -8,13 +8,13 @@
     [@DefaultEnvironmentVariables enabled=false /]
 
     [@Settings {
-        "JAVA_OPTS" : "-Dhudson.remoting.Launcher.pingIntervalSec=1200",
         "AWS_AUTOMATION_USER" : "ROLE"
     }/]
+    
+    [#assign dockerStageDir = settings["DOCKER_STAGE_DIR"]!"/tmp" ]
 
-    [#if settings["ENABLE_DOCKER"] ]
-        [@Volume "dockerlib" "/var/lib/docker/" "/cache/" + core.Name + "/" + getContainerName(container) + "/dockerlib/" /]
-    [/#if]
+    [@Volume "dockerDaemon" "/var/run/docker.sock" settings["DOCKER_HOST_DAEMON"]!"/var/run/docker.sock" /]
+    [@Volume "dockerStage" dockerStageDir dockerStageDir /]
 
     [#-- Validate that the appropriate settings have been provided for the container to work --]
     [#if settings["CODEONTAPVOLUME"]?has_content ]

--- a/aws/templates/container/container_codeontap.ftl
+++ b/aws/templates/container/container_codeontap.ftl
@@ -12,10 +12,12 @@
         [@Volume "codeontap" "/var/opt/codeontap/" settings["CODEONTAPVOLUME"] /]
     [/#if]  
 
-    [@Policy
-        globalAdministratorAccess()
-    /]
-
-    [@ManagedPolicy settings["AWS_AUTOMATION_POLICIES"]?split(",") /]
+    [#if settings["AWS_AUTOMATION_POLICIES"]?has_content ]
+        [@ManagedPolicy settings["AWS_AUTOMATION_POLICIES"]?split(",") /]
+    [#else]
+        [@Policy
+            globalAdministratorAccess()
+        /]
+    [/#if]
 
     [#break]

--- a/aws/templates/container/container_codeontap.ftl
+++ b/aws/templates/container/container_codeontap.ftl
@@ -7,12 +7,16 @@
     [@DefaultCoreVariables enabled=false /]
     [@DefaultEnvironmentVariables enabled=false /]
 
+    [@Settings {
+        "JAVA_OPTS" : "-Dhudson.remoting.Launcher.pingIntervalSec=1200",
+        "ENABLE_DOCKER" : "true"
+    }
+    /]
+
     [#-- Validate that the appropriate settings have been provided for the container to work --]
     [#if settings["CODEONTAPVOLUME"]?has_content ]
         [@Volume "codeontap" "/var/opt/codeontap/" settings["CODEONTAPVOLUME"] /]
     [/#if]  
-
-    [@Volume "dockerstore" "/var/lib/docker/vfs/dir/" settings["AWSPROFILEVOLUME"] + "/docker-images" /]
 
     [#if settings["AWSPROFILEVOLUME"]?has_content ]
         [#assign awsProfilePath = "/var/opt/awsprofile/" ]

--- a/aws/templates/container/container_codeontap.ftl
+++ b/aws/templates/container/container_codeontap.ftl
@@ -16,4 +16,6 @@
         globalAdministratorAccess()
     /]
 
+    [@ManagedPolicy settings["AWS_AUTOMATION_POLICIES"]?split(",") /]
+
     [#break]

--- a/aws/templates/container/container_jenkins.ftl
+++ b/aws/templates/container/container_jenkins.ftl
@@ -5,7 +5,8 @@
 
     [@Settings {
             "ECS_ARN" :  getExistingReference(ecsId),
-            "MAXMEMORY" : container.MemoryReservation
+            "MAXMEMORY" : container.MemoryReservation,
+            "JAVA_OPTS" : "-Dhudson.slaves.ChannelPinger.pingIntervalSeconds=1200 -Dhudson.slaves.ChannelPinger.pingTimeoutSeconds=30" 
         }
     /]
 

--- a/aws/templates/container/container_redirector.ftl
+++ b/aws/templates/container/container_redirector.ftl
@@ -1,5 +1,9 @@
 [#case "redirector"]
 
+    [@DefaultLinkVariables enabled=false /]
+    [@DefaultCoreVariables enabled=false /]
+    [@DefaultEnvironmentVariables enabled=false /]
+
     [@Attributes image="redirector" /]
 
     [#break]

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -36,7 +36,11 @@
         {
             "Name" : "RunCapabilities",
             "Default" : []
-        }
+        },
+        {
+            "Name" : "Privileged",
+            "Default" : false
+        },
         {
             "Name" : ["MaximumMemory", "MemoryMaximum", "MaxMemory"]
         },

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -34,6 +34,10 @@
             "Default" : false
         },
         {
+            "Name" : "RunCapabilities",
+            "Default" : []
+        }
+        {
             "Name" : ["MaximumMemory", "MemoryMaximum", "MaxMemory"]
         },
         {

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -94,6 +94,19 @@
                     "Name" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
+                },
+                {
+                    "Name" : "DockerUsers",
+                    "Subobjects" : true,
+                    "Children" : [
+                        {
+                            "Name" : "UserName"
+                        },
+                        {
+                            "Name" : "UID",
+                            "Mandatory" : true
+                        }
+                    ]
                 }
             ],
             "Components" : [

--- a/aws/templates/resource/resource_ec2.ftl
+++ b/aws/templates/resource/resource_ec2.ftl
@@ -260,7 +260,16 @@
     ]
 [/#function]
 
-[#function getInitConfigECSAgent ecsId defaultLogDriver ignoreErrors=false ]
+[#function getInitConfigECSAgent ecsId defaultLogDriver dockerUsers=[] ignoreErrors=false ]
+    [#local dockerUsersEnv = "" ]
+
+    [#if dockerUsers?has_content ] 
+        [#list dockerUsers as userName,details ]
+            [#local dockerUsersEnv += details.UserName?has_content?then(details.UserName,userName) + ":" + details.UID + "," ]
+        [/#list] 
+    [/#if]
+    [#local dockerUsersEnv = dockerUsersEnv?remove_ending(",")]
+
     [#return 
         {
         "ecs": {
@@ -278,7 +287,11 @@
                         "env" : {
                             "ECS_CLUSTER" : getReference(ecsId),
                             "ECS_LOG_DRIVER" : defaultLogDriver
-                        },
+                        } +
+                        attributeIfContent(
+                            "DOCKER_USERS",
+                            dockerUsersEnv
+                        ),
                         "ignoreErrors" : ignoreErrors
                     }
                 }

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -96,7 +96,7 @@
                                         }
                                     ) +
                 attributeIfTrue("Privileged", container.Privileged, container.Privileged!"") + 
-                attributeIfContent("WorkingDirectory", container.WorkingDirectory)
+                attributeIfContent("WorkingDirectory", container.WorkingDirectory!"")
             ]
         ]
     [/#list]

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -88,14 +88,14 @@
                 attributeIfContent("Memory", container.MaximumMemory!"") +
                 attributeIfContent("Cpu", container.Cpu!"") +
                 attributeIfContent("PortMappings", portMappings) + 
-                attributeIfContent("LinuxParameters", container.RunCapabilities, 
+                attributeIfContent("LinuxParameters", container.RunCapabilities![], 
                                         {
                                             "Capabilities" : {
-                                                "Add" : container.RunCapabilities
+                                                "Add" : container.RunCapabilities![]
                                             }
                                         }
                                     ) +
-                attributeIfTrue("Privileged", container.Privileged, container.Privileged)
+                attributeIfTrue("Privileged", container.Privileged, container.Privileged!"")
             ]
         ]
     [/#list]

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -87,7 +87,14 @@
                 attributeIfContent("ExtraHosts", extraHosts) +
                 attributeIfContent("Memory", container.MaximumMemory!"") +
                 attributeIfContent("Cpu", container.Cpu!"") +
-                attributeIfContent("PortMappings", portMappings) 
+                attributeIfContent("PortMappings", portMappings) + 
+                attributeIfContent("LinuxParameters", container.RunCapabilities, 
+                                        {
+                                            "Capabilities" : {
+                                                "Add" : container.RunCapabilities
+                                            }
+                                        }
+                                    )
             ]
         ]
     [/#list]

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -94,7 +94,8 @@
                                                 "Add" : container.RunCapabilities
                                             }
                                         }
-                                    )
+                                    ) +
+                attributeIfTrue("Privileged", container.Privileged, container.Privileged)
             ]
         ]
     [/#list]

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -95,7 +95,8 @@
                                             }
                                         }
                                     ) +
-                attributeIfTrue("Privileged", container.Privileged, container.Privileged!"")
+                attributeIfTrue("Privileged", container.Privileged, container.Privileged!"") + 
+                attributeIfContent("WorkingDirectory", container.WorkingDirectory)
             ]
         ]
     [/#list]

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -29,7 +29,7 @@
         [#assign configSets =  
                 getInitConfigDirectories() + 
                 getInitConfigBootstrap(component.Role!"") +
-                getInitConfigECSAgent(ecsId, defaultLogDriver) ]
+                getInitConfigECSAgent(ecsId, defaultLogDriver, solution.DockerUsers) ]
         
         [#assign efsMountPoints = {}]
     


### PR DESCRIPTION
A few changes required for the codeontap task container 

- Remove all standard environment variables to prevent issues with environment variables defined during codeontap process
- Add ManagedPolicy Container fragment macro to attach predefined polices to task role
- Add codeontap container configuration to use a comma separated list env variable AWS_AUTOMATION_POLICIES to attach managed policies which have been defined for switching roles to other accounts 
- Add new AWSProfile volume to codeontap container which is used for a persistent aws cli config file. Config file maps to /var/opt/awsprofile/config and sets AWS_CONFIG_PROFILE variable to match
- Add the ability to configure Privileged mode to containers so that they can access the host (required for docker in docker scenarios) 
- Add the ability to add run capabilities which are more fine grained ways to access the host OS.