### PR TITLE
S3 Public Bucket Access

### DIFF
--- a/aws/templates/id/id_s3.ftl
+++ b/aws/templates/id/id_s3.ftl
@@ -115,7 +115,7 @@
                     },
                     {
                         "Name" : "Permissions",
-                        "Default" "ro"
+                        "Default" : "ro"
                     },
                     {
                         "Name" : "IPAddressGroups",
@@ -123,7 +123,7 @@
                     },
                     {
                         "Name" : "Prefix",
-                        "Default" : "*"
+                        "Default" : ""
                     }
                 ]
             }
@@ -157,7 +157,8 @@
                         "Id" : formatResourceId(AWS_S3_BUCKET_POLICY_RESOURCE_TYPE, core.Id),
                         "Type" : AWS_S3_BUCKET_POLICY_RESOURCE_TYPE
                     }
-                }
+                },
+                {}
             ),
             "Attributes" : {
                 "NAME" : getExistingReference(id, NAME_ATTRIBUTE_TYPE),

--- a/aws/templates/id/id_s3.ftl
+++ b/aws/templates/id/id_s3.ftl
@@ -105,6 +105,27 @@
                         "Default": ""
                     }
                 ]
+            },
+            {
+                "Name" : "PublicAccess",
+                "Children" : [
+                    {
+                        "Name" : "Enabled",
+                        "Default" : false
+                    },
+                    {
+                        "Name" : "Permissions",
+                        "Default" "ro"
+                    },
+                    {
+                        "Name" : "IPAddressGroups",
+                        "Default" : [ "_localnet" ]
+                    },
+                    {
+                        "Name" : "Prefix",
+                        "Default" : "*"
+                    }
+                ]
             }
             "Style",
             "Notifications"
@@ -113,6 +134,7 @@
     
 [#function getS3State occurrence]
     [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
 
     [#local id = formatOccurrenceS3Id(occurrence)]
     [#local name = formatOccurrenceBucketName(occurrence) ]
@@ -128,7 +150,15 @@
                             name),
                     "Type" : AWS_S3_RESOURCE_TYPE
                 }
-            },
+            } +
+            solution.PublicAccess.Enabled?then(
+                {
+                    "bucketpolicy" : {
+                        "Id" : formatResourceId(AWS_S3_BUCKET_POLICY_RESOURCE_TYPE, core.Id),
+                        "Type" : AWS_S3_BUCKET_POLICY_RESOURCE_TYPE
+                    }
+                }
+            ),
             "Attributes" : {
                 "NAME" : getExistingReference(id, NAME_ATTRIBUTE_TYPE),
                 "FQDN" : getExistingReference(id, DNS_ATTRIBUTE_TYPE),


### PR DESCRIPTION
Adds the ability to make a solution S3 bucket publicly accessible through bucket policy 
Configuration
- PublicAccess
   - Enabled 
       - default: false 
   - IPAddressGruops 
       - default: _localnet
   - Permissions 
       - default: ro (read only) 
       - Possible options: rw (read write), wo (write only) 
   - Prefix 
        - default "" 
        - add a prefix to the object policy 

