### PR TITLE
Add idle timeout configuration to LB component

### DIFF
--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -36,6 +36,10 @@
                     "Default" : "application"
                 },
                 {
+                    "Name" : "IdleTimeout", 
+                    "Default" : 60
+                }
+                {
                     "Name" : "HealthCheckPort",
                     "Default" : ""
                 }

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -19,6 +19,7 @@
             [#assign lbSecurityGroupIds = [] ]
 
             [#assign engine = solution.Engine]
+            [#assign idleTimeout = solution.IdleTimeout]
 
             [#assign healthCheckPort = "" ]
             [#if engine == "classic" ]
@@ -173,7 +174,8 @@
                         securityGroups=lbSecurityGroupIds
                         logs=lbLogs
                         type=engine
-                        bucket=operationsBucket /]
+                        bucket=operationsBucket
+                        idleTimeout=idleTimeout /]
                     [#break]
                 
                 [#case "classic"]
@@ -200,6 +202,7 @@
                         securityGroups=lbSecurityGroupIds 
                         logs=lbLogs 
                         bucket=operationsBucket 
+                        idleTimeout=idleTimeout
                      /]
                 [#break]
             [/#switch ]


### PR DESCRIPTION
Adds the ability to configure the idle timeout on an LB component. The default is currently set to 60 seconds which can be a problem for long running tasks that don't send back progress updates. 