### PR TITLE
Fix lookup of lambda name attribtue

### DIFF
--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -168,7 +168,7 @@
             "Attributes" : {
                 "REGION" : regionId,
                 "ARN" : getExistingReference(id,ARN_ATTRIBUTE_TYPE),
-                "NAME" : getExistingReference(id,NAME_ATTRIBUTE_TYPE)
+                "NAME" : getExistingReference(id)
             },
             "Roles" : {
                 "Inbound" : {},


### PR DESCRIPTION
The name attribute for a lambda is provided as the Ref Attribute and doens't have its own output reference