### PR TITLE
Move encryption prefix handling to run time instead of psuedo stack

### DIFF
--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -96,8 +96,8 @@
 
     [#if solution.GenerateCredentials.Enabled ]
         [#local masterUsername = solution.GenerateCredentials.MasterUserName ]
-        [#local masterPassword = encryptionScheme + getExistingReference(id, GENERATEDPASSWORD_ATTRIBUTE_TYPE) ]
-        [#local url = encryptionScheme + getExistingReference(id, URL_ATTRIBUTE_TYPE) ]
+        [#local masterPassword = getExistingReference(id, GENERATEDPASSWORD_ATTRIBUTE_TYPE)?ensure_starts_with(encryptionScheme) ]
+        [#local url = getExistingReference(id, URL_ATTRIBUTE_TYPE)?ensure_starts_with(encryptionScheme) ]
     [#else]
         [#-- don't flag an error if credentials missing but component is not enabled --]
         [#local masterUsername = getOccurrenceSettingValue(occurrence, "MASTER_USERNAME", !solution.Enabled) ]

--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -90,11 +90,14 @@
     [#local fqdn = getExistingReference(id, DNS_ATTRIBUTE_TYPE)]
     [#local port = getExistingReference(id, PORT_ATTRIBUTE_TYPE)]
     [#local name = getExistingReference(id, DATABASENAME_ATTRIBUTE_TYPE)]
+    [#local encryptionScheme = solution.EncryptionScheme?has_content?then(
+                        solution.EncryptionScheme?ensure_ends_with(":"),
+                        "" )]
 
     [#if solution.GenerateCredentials.Enabled ]
         [#local masterUsername = solution.GenerateCredentials.MasterUserName ]
-        [#local masterPassword = getExistingReference(id, GENERATEDPASSWORD_ATTRIBUTE_TYPE) ]
-        [#local url = getExistingReference(id, URL_ATTRIBUTE_TYPE) ]
+        [#local masterPassword = encryptionScheme + getExistingReference(id, GENERATEDPASSWORD_ATTRIBUTE_TYPE) ]
+        [#local url = encryptionScheme + getExistingReference(id, URL_ATTRIBUTE_TYPE) ]
     [#else]
         [#-- don't flag an error if credentials missing but component is not enabled --]
         [#local masterUsername = getOccurrenceSettingValue(occurrence, "MASTER_USERNAME", !solution.Enabled) ]

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -73,12 +73,12 @@
             [#assign rdsPasswordLength = solution.GenerateCredentials.CharacterLength]
             [#assign rdsPassword = "DummyPassword" ]
             [#assign rdsEncryptedPassword = (
-                getExistingReference(
-                    rdsId, 
-                    GENERATEDPASSWORD_ATTRIBUTE_TYPE)
-                )?remove_beginning(
-                    passwordEncryptionScheme
-                )]
+                        getExistingReference(
+                            rdsId, 
+                            GENERATEDPASSWORD_ATTRIBUTE_TYPE)
+                        )?remove_beginning(
+                            passwordEncryptionScheme
+                        )]
         [#else]
             [#assign rdsUsername = attributes.USERNAME ]
             [#assign rdsPassword = attributes.PASSWORD ]
@@ -295,6 +295,9 @@
         [#if deploymentSubsetRequired("epilogue", false)]
 
             [#assign rdsFQDN = getExistingReference(rdsId, DNS_ATTRIBUTE_TYPE)]
+
+            [#assign passwordPsuedoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-password-pseudo-stack.json\"" ]
+            [#assign urlPsuedoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-url-pseudo-stack.json\""]
             [@cfScript
                 mode=listMode
                 content=
@@ -321,7 +324,7 @@
                         "create_pseudo_stack" + " " +
                         "\"RDS Master Password\"" + " " +
                         "\"$\{password_pseudo_stack_file}\"" + " " +
-                        "\"" + rdsId + "Xgeneratedpassword\" \"" + passwordEncryptionScheme + "$\{encrypted_master_password}\" || return $?",
+                        "\"" + rdsId + "Xgeneratedpassword\" \"$\{encrypted_master_password}\" || return $?",
                         "info \"Generating URL... \"",
                         "rds_url=\"$(get_rds_url" +
                         " \"" + engine + "\" " +
@@ -337,10 +340,10 @@
                         "create_pseudo_stack" + " " +
                         "\"RDS Connection URL\"" + " " +
                         "\"$\{url_pseudo_stack_file}\"" + " " +
-                        "\"" + rdsId + "Xurl\" \"" + passwordEncryptionScheme + "$\{encrypted_rds_url}\" || return $?",
+                        "\"" + rdsId + "Xurl\" \"$\{encrypted_rds_url}\" || return $?",
                         "}",
-                        "password_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-password-pseudo-stack.json\" ",
-                        "url_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-url-pseudo-stack.json\" ",
+                        "password_pseudo_stack_file=" + passwordPsuedoStackFile,
+                        "url_pseudo_stack_file=" +  urlPsuedoStackFile,
                         "generate_master_password || return $?"
                     ],
                     []) +
@@ -373,9 +376,9 @@
                         "create_pseudo_stack" + " " +
                         "\"RDS Connection URL\"" + " " +
                         "\"$\{url_pseudo_stack_file}\"" + " " +
-                        "\"" + rdsId + "Xurl\" \"" + passwordEncryptionScheme + "$\{encrypted_rds_url}\" || return $?",
+                        "\"" + rdsId + "Xurl\" \"$\{encrypted_rds_url}\" || return $?"
                         "}",
-                        "url_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-url-pseudo-stack.json\" ",
+                        "url_pseudo_stack_file=" +  urlPsuedoStackFile,
                         "reset_master_password || return $?"
                     ],
                 []) +

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -296,8 +296,8 @@
 
             [#assign rdsFQDN = getExistingReference(rdsId, DNS_ATTRIBUTE_TYPE)]
 
-            [#assign passwordPsuedoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-password-pseudo-stack.json\"" ]
-            [#assign urlPsuedoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-url-pseudo-stack.json\""]
+            [#assign passwordPseudoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-password-pseudo-stack.json\"" ]
+            [#assign urlPseudoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-url-pseudo-stack.json\""]
             [@cfScript
                 mode=listMode
                 content=


### PR DESCRIPTION
The current implementation of the encryption prefix setup for generated credentials stored the prefix in the psuedo stack file. 

This isn't actually required and instead this should be performed at template generation time. This fix allows for passwords and URLs that have been generated with the prefix in the pseudo stack file to be left as they are. Urls that have the prefix will be automatically updated but passwords would need to be updated manually or reset the password
