### PR TITLE
Add IP Address group control to  container ports

### DIFF
--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -38,7 +38,7 @@
 
                 [#assign ecsSecurityGroupId = resources["securityGroup"].Id ]
                 [#assign ecsSecurityGroupName = resources["securityGroup"].Name ]
-                
+
             [/#if] 
 
             [#if core.Type == ECS_SERVICE_COMPONENT_TYPE]
@@ -195,10 +195,26 @@
                                         cidr=securityGroupSources
                                         groupId=ecsSecurityGroupId
                                     /]
-                                [/#if]    
-                            
-                            [/#if]
+                                [/#if]  
+                                
+                            [/#if]  
                         [/#list]
+                        [#if container.IngressRules?has_content ]
+                            [#list container.IngressRules as ingressRule ]
+                                [@createSecurityGroupIngress
+                                        mode=listMode
+                                        id=formatContainerSecurityGroupIngressId(
+                                                ecsSecurityGroupId,
+                                                container,
+                                                ingressRule.port,
+                                                replaceAlphaNumericOnly(ingressRule.cidr)
+                                            )
+                                        port=ingressRule.port
+                                        cidr=ingressRule.cidr
+                                        groupId=ecsSecurityGroupId
+                                    /]
+                            [/#list]
+                        [/#if]
                     [/#list]
 
                     [@createECSService

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -367,14 +367,23 @@
                 [/#list]
             [#else]
                 [#if port.IPAddressGroups?has_content]
-                    [#list getGroupCIDRs(port.IPAddressGroups ) as cidr]
-                        [#local ingressRules += [ {
-                            "port" : port.DynamicHostPort?then(0,contentIfContent(
-                                                                            port.Container!"",
-                                                                            port.Name )),
-                            "cidr" : cidr
-                        }]]
-                    [/#list]
+                    [#if solution.NetworkMode == "awsvpc" ]
+                        [#list getGroupCIDRs(port.IPAddressGroups ) as cidr]
+                            [#local ingressRules += [ {
+                                "port" : port.DynamicHostPort?then(0,contentIfContent(
+                                                                                port.Container!"",
+                                                                                port.Name )),
+                                "cidr" : cidr
+                            }]]
+                        [/#list]
+                    [#else]
+                        [@cfException
+                            mode=listMode
+                            description="Port IP Address Groups not supported for network type"
+                            context=container
+                            detail=port /]
+                        [#continue]
+                    [/#if]
                 [/#if]
             [/#if]
         [/#list]

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -319,50 +319,64 @@
     [#list solution.Containers?values as container]
         [#local containerPortMappings = [] ]
         [#local containerLinks = container.Links ]
+        [#local ingressRules = []]
 
         [#list container.Ports?values as port]
 
-            [#local lbLink = getLBLink( task, port )]
-            
-            [#if isDuplicateLink(containerLinks, lbLink) ]
-                [@cfException
-                    mode=listMode
-                    description="Duplicate Link Name"
-                    context=containerLinks
-                    detail=lbLink /]
-                [#continue]
-            [/#if]
+            [#if port.LB.Configured] 
+                [#local lbLink = getLBLink( task, port )]
+                
+                [#if isDuplicateLink(containerLinks, lbLink) ]
+                    [@cfException
+                        mode=listMode
+                        description="Duplicate Link Name"
+                        context=containerLinks
+                        detail=lbLink /]
+                    [#continue]
+                [/#if]
 
-            [#-- Treat the LB link like any other - this will also detect --]
-            [#-- if the target is missing                                 --]
-            [#local containerLinks += lbLink]
+                [#-- Treat the LB link like any other - this will also detect --]
+                [#-- if the target is missing                                 --]
+                [#local containerLinks += lbLink]
 
-            [#local containerPortMapping =
-                {
-                    "ContainerPort" :
-                        contentIfContent(
-                            port.Container!"",
-                            port.Name
-                        ),
-                    "HostPort" : port.Name,
-                    "DynamicHostPort" : port.DynamicHostPort
-                } ]
-
-            [#-- Ports should only be defined if connecting to a load balancer --]
-            [#list lbLink as key,loadBalancer]
-                [#local containerPortMapping +=
+                [#local containerPortMapping =
                     {
-                        "LoadBalancer" :
-                            {
-                                "Link" : loadBalancer.Name,
-                                "TargetGroup" : loadBalancer.TargetGroup!"",
-                                "Priority" : port.LB.Priority,
-                                "Path" : loadBalancer.TargetPath!""
-                            }
-                    }
-                ]
-                [#local containerPortMappings += [containerPortMapping] ]
-            [/#list]
+                        "ContainerPort" :
+                            contentIfContent(
+                                port.Container!"",
+                                port.Name
+                            ),
+                        "HostPort" : port.Name,
+                        "DynamicHostPort" : port.DynamicHostPort
+                    } ]
+
+                [#-- Ports should only be defined if connecting to a load balancer --]
+                [#list lbLink as key,loadBalancer]
+                    [#local containerPortMapping +=
+                        {
+                            "LoadBalancer" :
+                                {
+                                    "Link" : loadBalancer.Name,
+                                    "TargetGroup" : loadBalancer.TargetGroup!"",
+                                    "Priority" : port.LB.Priority,
+                                    "Path" : loadBalancer.TargetPath!""
+                                }
+                        }
+                    ]
+                    [#local containerPortMappings += [containerPortMapping] ]
+                [/#list]
+            [#else]
+                [#if port.IPAddressGroups?has_content]
+                    [#list getGroupCIDRs(port.IPAddressGroups ) as cidr]
+                        [#local ingressRules += [ {
+                            "port" : port.DynamicHostPort?then(0,contentIfContent(
+                                                                            port.Container!"",
+                                                                            port.Name )),
+                            "cidr" : cidr
+                        }]]
+                    [/#list]
+                [/#if]
+            [/#if]
         [/#list]
 
         [#local logDriver =
@@ -473,7 +487,8 @@
                 !container.MaximumMemory??,
                 container.MemoryReservation*ECS_DEFAULT_MEMORY_LIMIT_MULTIPLIER
             ) +
-            attributeIfContent("PortMappings", containerPortMappings)
+            attributeIfContent("PortMappings", containerPortMappings) +
+            attributeIfContent("IngressRules", ingressRules)
         ]
 
         [#-- Add in container specifics including override of defaults --]

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -52,6 +52,10 @@
                 {
                     "Name" : "LB",
                     "Children" : lbChildConfiguration
+                },
+                {
+                    "Name" : "IPAddressGroups",
+                    "Default" : []
                 }
             ]
         },
@@ -286,7 +290,9 @@
                     "Name" : core.FullName,
                     "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
                 }),
-            "Attributes" : {},
+            "Attributes" : {
+                "Name" : core.Name
+            },
             "Roles" : {
                 "Inbound" : {},
                 "Outbound" : {}


### PR DESCRIPTION
Allows for IP address group rules to be specified on a container port without a load balancer. 

This is useful in scenarios where a container registers with another service and its IP address is included in the registration and two way communication is required (both initiating) 

Also adds a name attribute as a placeholder attribute on services. This allows you to link to a service and access its settings/config via a container fragment.

please merge before #363 as this PR will cause conflicts with it.
