### PR TITLE
Support SAN in SSL CSR generation

### DIFF
--- a/aws/createSSLCertificateRequest.sh
+++ b/aws/createSSLCertificateRequest.sh
@@ -2,17 +2,58 @@
 
 # Trigger the creation of a CSR
 
-# openssl config should be edited 
-#
-# req_extensions = v3_req # The extensions to add to a certificate request
-#
-# [ v3_req ]
-# basicConstraints = CA:FALSE
-# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
-# extendedKeyUsage = serverAuth, clientAuth
+certificate_name="$1"; shift
+cn="$1"; shift
+san="$1"; shift
 
-openssl req -new -newkey rsa:2048 -sha256 -nodes -keyout ${1}-ssl-prv.pem -out ${1}-ssl-csr.pem
+options=("-keyout" "${certificate_name}-ssl-prv.pem" "-out" "${certificate_name}-ssl-csr.pem")
+
+cat > /tmp/ssl.conf <<EOF
+[ req ]
+prompt = no
+default_bits		= 2048
+distinguished_name	= req_distinguished_name
+attributes		= req_attributes
+req_extensions = v3_req # The extensions to add to a certificate request
+
+# This sets a mask for permitted string types. There are several options.
+# default: PrintableString, T61String, BMPString.
+# pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
+# utf8only: only UTF8Strings (PKIX recommendation after 2004).
+# nombstr : PrintableString, T61String (no BMPStrings or UTF8Strings).
+# MASK:XXXX a literal mask value.
+# WARNING: ancient versions of Netscape crash on BMPStrings or UTF8Strings.
+string_mask = utf8only
+
+
+[ req_distinguished_name ]
+countryName            = AU
+stateOrProvinceName 	 = Australian Capital Territory
+localityName           = Belconnen
+organizationName       = Department of Silly Walks
+organizationalUnitName = Walks Register
+commonName			       = ${cn}
+
+[ req_attributes ]
+
+[ v3_req ]
+
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth
+EOF
+
+[[ -n "${san}" ]] && cat >> /tmp/ssl.conf <<EOF
+subjectAltName = @alt_names
+
+[alt_names]
+${san:+DNS.1 = }${san}
+
+EOF
+
+openssl req -new -newkey rsa:2048 -sha256 -nodes "${options[@]}" -config /tmp/ssl.conf
 
 # The CSR can be viewed via
 
-# openssl req -text -in {domain}-ssl-csr.pem
+# openssl req -text -in ${certificate_name}-ssl-csr.pem
+#


### PR DESCRIPTION
Include specific openssl config for SR generation inline so it is explicit and doesn't require config of installation config files