### PR TITLE
Add external link support for Cognito LB auth

### DIFF
--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -86,7 +86,7 @@
             [/#if]
 
             [#assign linkTargetCore = linkTarget.Core]
-            [#assign linkTargetConfiguration = linkTarget.Configuration]
+            [#assign linkTargetConfiguration = linkTarget.Configuration ]
             [#assign linkTargetResources = linkTarget.State.Resources]
             [#assign linkTargetAttributes = linkTarget.State.Attributes]
 
@@ -98,7 +98,14 @@
                         ]
                     ]
                     [#break]
+                
+                [#case "external" ]
+                    [#if linkTargetAttributes["AUTH_CALLBACK_URL"]?has_content ]
+                        [#assign callbackUrls += linkTargetAttributes["AUTH_CALLBACK_URL"]?split(",") ]
+                    [/#if]
 
+                    [#break]
+                    
                 [#case LAMBDA_FUNCTION_COMPONENT_TYPE]
 
                     [#if linkTargetResources[LAMBDA_FUNCTION_COMPONENT_TYPE].Deployed]


### PR DESCRIPTION
Adds the ability to use external links to enable cognito based authentication on a load balancer. 
Also adds the reverse link to provide callback URLS to a cognito userpool