### PR TITLE
Add environment file support for lambda

### DIFF
--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -305,24 +305,31 @@
     ]
 [/#function]
 
-[#function getFinalEnvironment occurrence context ]
+[#function getFinalEnvironment occurrence context asFile=false]
     [#return
         {
             "Environment" :
                 valueIfTrue(
-                    getSettingsAsEnvironment(occurrence.Configuration.Settings.Core) +
-                    getSettingsAsEnvironment(occurrence.Configuration.Settings.Build),
-                    context.DefaultCoreVariables
+                    getSettingsAsEnvironment(occurrence.Configuration.Settings.Core),
+                    context.DefaultCoreVariables || asFile
                 ) +
                 valueIfTrue(
-                    context.DefaultEnvironment,
-                    context.DefaultEnvironmentVariables
-                ) +
-                valueIfTrue(
-                    getDefaultLinkVariables(context),
-                    context.DefaultLinkVariables
-                ) +
-                context.Environment
+                    { "CONFIG_FILE" : "config/config.json"},
+                    asFile,
+                    valueIfTrue(
+                        getSettingsAsEnvironment(occurrence.Configuration.Settings.Build),
+                        context.DefaultCoreVariables
+                    ) +
+                    valueIfTrue(
+                        context.DefaultEnvironment,
+                        context.DefaultEnvironmentVariables
+                    ) +
+                    valueIfTrue(
+                        getDefaultLinkVariables(context),
+                        context.DefaultLinkVariables
+                    ) +
+                    context.Environment
+                )
         } ]
 [/#function]
 

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -118,6 +118,10 @@
             {
                 "Name" : "PredefineLogGroup",
                 "Default" : false
+            },
+            {
+                "Name" : "EnvironmentAsFile",
+                "Default" : false
             }
         ]
     }


### PR DESCRIPTION
Support an optional switch to place the environment settings in a config
file rather than as environment variables.

This avoids the limit on environment size in lambda.

Regardless of the switch, the core settings are still defined in order
that the bucket and settings prefix are available.

The variable CONFIG_FILE is also set with the relative filename of the
config file relative to the SETTINGS_PREFIX path.