### PR TITLE
Add container network linking in service definitions

### DIFF
--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -164,6 +164,10 @@
             {
                 "Name" : "NetworkMode",
                 "Default" : ""
+            },
+            {
+                "Name" : "ContainerNetworkLinks",
+                "Default" : false
             }
         ],
         ECS_TASK_COMPONENT_TYPE : [

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -1,6 +1,6 @@
 [#-- ECS --]
 
-[#macro createECSTask mode id name containers networkMode="" fixedName=false role="" dependencies=""]
+[#macro createECSTask mode id name containers networkMode="" fixedName=false role="" networkLinks=[] dependencies=""]
 
     [#local definitions = [] ]
     [#local volumes = [] ]
@@ -96,7 +96,8 @@
                                         }
                                     ) +
                 attributeIfTrue("Privileged", container.Privileged, container.Privileged!"") + 
-                attributeIfContent("WorkingDirectory", container.WorkingDirectory!"")
+                attributeIfContent("WorkingDirectory", container.WorkingDirectory!"") + 
+                attributeIfContent("Links", networkLinks)
             ]
         ]
     [/#list]


### PR DESCRIPTION
Adds a configuration option on an ECS service to add links in between the containers in a task definition.

This allows containers in the same task definition to communicate without port mappings.

The service must be using the bridge network mode to enable this feature