### PR TITLE
Add fix for circular references in links

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -73,6 +73,16 @@
     ]
 [/#function]
 
+[#function removeValueFromArray array string ]
+    [#local result = [] ]
+    [#list array as item ]
+        [#if item != string ]
+            [#local result += [ item ] ]
+        [/#if]
+    [/#list]
+    [#return result]
+[/#function]
+
 [#function asSerialisableString arg]
     [#if arg?is_hash || arg?is_sequence ]
         [#return getJSON(arg) ]

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -97,7 +97,7 @@
                                     ) +
                 attributeIfTrue("Privileged", container.Privileged, container.Privileged!"") + 
                 attributeIfContent("WorkingDirectory", container.WorkingDirectory!"") + 
-                attributeIfContent("Links", networkLinks)
+                attributeIfContent("Links", removeValueFromArray(networkLinks, container.Name) )
             ]
         ]
     [/#list]


### PR DESCRIPTION
Add minor fix which makes sure that when using container network links that it doesn't create a link for its self.