### PR TITLE
Update Network link to explicit container links

### DIFF
--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -320,7 +320,6 @@
                     networkMode=networkMode
                     dependencies=dependencies
                     fixedName=solution.FixedName
-                    networkLinks=networkLinks
                 /]
 
             [/#if]

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -526,7 +526,8 @@
             ) +
             attributeIfContent("PortMappings", containerPortMappings) +
             attributeIfContent("IngressRules", ingressRules) +
-            attributeIfContent("RunCapabilities", container.RunCapabilities)
+            attributeIfContent("RunCapabilities", container.RunCapabilities) +
+            attributeIfContent("ContainerNetworkLinks", container.ContainerNetworkLinks)
         ]
 
         [#-- Add in container specifics including override of defaults --]

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -70,6 +70,10 @@
         {
             "Name" : "Version",
             "Default" : ""
+        },
+        {
+            "Name" : "ContainerNetworkLinks",
+            "Default" : []
         }
     ]
 ]

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -1,6 +1,6 @@
 [#-- ECS --]
 
-[#macro createECSTask mode id name containers networkMode="" fixedName=false role="" networkLinks=[] dependencies=""]
+[#macro createECSTask mode id name containers networkMode="" fixedName=false role="" dependencies=""]
 
     [#local definitions = [] ]
     [#local volumes = [] ]
@@ -97,7 +97,7 @@
                                     ) +
                 attributeIfTrue("Privileged", container.Privileged, container.Privileged!"") + 
                 attributeIfContent("WorkingDirectory", container.WorkingDirectory!"") + 
-                attributeIfContent("Links", removeValueFromArray(networkLinks, container.Name) )
+                attributeIfContent("Links", container.ContainerNetworkLinks![] )
             ]
         ]
     [/#list]


### PR DESCRIPTION
Container links are actually only available in a unidirectional setup because the container needs to be available on the start up of the linking container. 

This change makes the ContainerNetworkLinks a container property, you can set a list of container names that are part of your service/task definition and they will be added as host file entries on the container that has ContainerNetworkLinks configured