### PR TITLE
Add Bucket to S3 related Policies

### DIFF
--- a/aws/templates/policy/policy_s3.ftl
+++ b/aws/templates/policy/policy_s3.ftl
@@ -1,14 +1,18 @@
 [#-- S3 --]
 
 [#function getS3Statement actions bucket key="" object="" principals="" conditions=""]
+    [#local s3BucketArn = "arn:aws:s3:::" + (getExistingReference(bucket)?has_content)?then(getExistingReference(bucket),bucket) ]
+
     [#return
         [
             getPolicyStatement(
                 actions,
-                "arn:aws:s3:::" + 
-                    (getExistingReference(bucket)?has_content)?then(getExistingReference(bucket),bucket) +
-                    key?has_content?then("/" + key, "") +
-                    object?has_content?then("/" + object, ""),
+                [
+                    s3BucketArn,
+                    s3BucketArn + 
+                        key?has_content?then("/" + key,  "") +
+                        object?has_content?then("/" + object, "")
+                ],
                 principals,
                 conditions)
         ]

--- a/aws/templates/policy/policy_s3.ftl
+++ b/aws/templates/policy/policy_s3.ftl
@@ -5,12 +5,10 @@
         [
             getPolicyStatement(
                 actions,
-                [
-                    s3BucketArn,
-                    s3BucketArn + 
+                "arn:aws:s3:::" + 
+                    (getExistingReference(bucket)?has_content)?then(getExistingReference(bucket),bucket) +
                         key?has_content?then("/" + key,  "") +
-                        object?has_content?then("/" + object, "")
-                ],
+                        object?has_content?then("/" + object, ""),
                 principals,
                 conditions)
         ]

--- a/aws/templates/policy/policy_s3.ftl
+++ b/aws/templates/policy/policy_s3.ftl
@@ -7,8 +7,8 @@
                 actions,
                 "arn:aws:s3:::" + 
                     (getExistingReference(bucket)?has_content)?then(getExistingReference(bucket),bucket) +
-                        key?has_content?then("/" + key,  "") +
-                        object?has_content?then("/" + object, ""),
+                    key?has_content?then("/" + key, "") +
+                    object?has_content?then("/" + object, ""),
                 principals,
                 conditions)
         ]


### PR DESCRIPTION
Some actions in S3 like ListObjects in the boto api are performed against the S3 bucket instead of the objects in the bucket. 

This PR adds a new function getS3BucketStatement which allows for bucket level permissions to be applied. 

It also uses the s3:prefix condition to control what can be listed within the bucket 
See: https://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html#bucket-keys-in-amazon-s3-policies 
