### PR TITLE
Update lambda attributes to remove reference lookup

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1,6 +1,7 @@
 {
   "Regions": {
     "ap-northeast-1": {
+      "Partition" : "aws",
       "Locality": "Tokyo",
       "Zones": {
         "a": {
@@ -28,6 +29,7 @@
       }
     },
     "ap-northeast-2": {
+      "Partition" : "aws",
       "Locality": "Seoul",
       "Zones": {
         "a": {
@@ -55,6 +57,7 @@
       }
     },
     "ap-south-1": {
+      "Partition" : "aws",
       "Locality": "Mumbai",
       "Zones": {
         "a": {
@@ -82,6 +85,7 @@
       }
     },
     "ap-southeast-1": {
+      "Partition" : "aws",
       "Locality": "Singapore",
       "Zones": {
         "a": {
@@ -111,6 +115,7 @@
       }
     },
     "ap-southeast-2": {
+      "Partition" : "aws",
       "Locality": "Sydney",
       "Zones": {
         "a": {
@@ -144,6 +149,7 @@
       }
     },
     "ca-central-1": {
+      "Partition" : "aws",
       "Locality": "Central",
       "Zones": {
         "a": {
@@ -171,6 +177,7 @@
       }
     },
     "cn-north-1": {
+      "Partition" : "aws",
       "Locality": "Beijing",
       "Zones": {
         "a": {
@@ -197,6 +204,7 @@
       }
     },
     "eu-central-1": {
+      "Partition" : "aws",
       "Locality": "Frankfurt",
       "Zones": {
         "a": {
@@ -224,6 +232,7 @@
       }
     },
     "eu-west-1": {
+      "Partition" : "aws",
       "Locality": "Ireland",
       "Zones": {
         "a": {
@@ -257,6 +266,7 @@
       }
     },
     "eu-west-2": {
+      "Partition" : "aws",
       "Locality": "London",
       "Zones": {
         "a": {
@@ -284,6 +294,7 @@
       }
     },
     "eu-west-3": {
+      "Partition" : "aws",
       "Locality": "Paris",
       "Zones": {
         "a": {
@@ -311,6 +322,7 @@
       }
     },
     "sa-east-1": {
+      "Partition" : "aws",
       "Locality": "Sao Paulo",
       "Zones": {
         "a": {
@@ -344,6 +356,7 @@
       }
     },
     "us-east-1": {
+      "Partition" : "aws",
       "Locality": "North Virginia",
       "Zones": {
         "b": {
@@ -383,6 +396,7 @@
       }
     },
     "us-east-2": {
+      "Partition" : "aws",
       "Locality": "Ohio",
       "Zones": {
         "a": {
@@ -416,6 +430,7 @@
       }
     },
     "us-gov-west-1": {
+      "Partition" : "aws-us-gov",
       "Locality": "US",
       "Zones": {
         "a": {
@@ -442,6 +457,7 @@
       }
     },
     "us-west-1": {
+      "Partition" : "aws",
       "Locality": "North California",
       "Zones": {
         "b": {
@@ -469,6 +485,7 @@
       }
     },
     "us-west-2": {
+      "Partition" : "aws",
       "Locality": "Oregon",
       "Zones": {
         "a": {

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -171,8 +171,14 @@
             },
             "Attributes" : {
                 "REGION" : regionId,
-                "ARN" : getExistingReference(id,ARN_ATTRIBUTE_TYPE),
-                "NAME" : getExistingReference(id)
+                "ARN" : formatArn(
+                            regionObject.Partition,
+                            "lambda", 
+                            regionId,
+                            accountObject.AWSId,
+                            "function:" + core.FullName,
+                            true),
+                "NAME" : core.FullName
             },
             "Roles" : {
                 "Inbound" : {},

--- a/aws/templates/resource/start.ftl
+++ b/aws/templates/resource/start.ftl
@@ -17,22 +17,35 @@
     [#return resourceType + resourceSeparator + resource]
 [/#function]
 
-[#function formatArn partition service region account resource]
-    [#return
-        {
-            "Fn::Join": [
-                ":",
-                [
-                    "arn",
-                    partition,
-                    service,
-                    region,
-                    account,
-                    resource
+[#function formatArn partition service region account resource asString=false]
+    [#if asString ]
+        [#return 
+            [
+                "arn",
+                partition,
+                service,
+                region,
+                account,
+                resource
+            ]?join(":")
+        ]
+    [#else]
+        [#return
+            {
+                "Fn::Join": [
+                    ":",
+                    [
+                        "arn",
+                        partition,
+                        service,
+                        region,
+                        account,
+                        resource
+                    ]
                 ]
-            ]
-        }
-    ]
+            }
+        ]
+    [/#if]
 [/#function]
 
 [#function formatRegionalArn service resource region={ "Ref" : "AWS::Region" } account={ "Ref" : "AWS::AccountId" }]


### PR DESCRIPTION
Application components currently don't save their outputs to the cmdb. As a result of this you need to run a manageEnvironment which saves the outputs to the CMDB. 

This makes linking between application components difficult when using getExistingReference or GetReference. 

Instead for lambda we can build the arn manually and provide it as an attribute. 

This adds two core features to build the ARN as a string
 - Region partition - the partition is the type of an AWS region, currently there are 3, aws, aws-us-gov, and aws-cn 
- Formatting an ARN as a string instead of a cloudformation Join function 
