### PR TITLE
Add External link logout urls for Cognito

### DIFF
--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -5,7 +5,7 @@
 [#assign AWS_COGNITO_USERPOOL_CLIENT_RESOURCE_TYPE = "userpoolclient"]
 [#assign AWS_COGNITO_IDENTITYPOOL_RESOURCE_TYPE = "identitypool"]
 [#assign AWS_COGNITO_IDENTITYPOOL_ROLEMAPPING_RESOURCE_TYPE = "rolemapping"]
-[#assign AWS_COGNITO_USERPOOL_DOMAIN_RESOURCE_TYPE = "userpoolDomain" ]
+[#assign AWS_COGNITO_USERPOOL_DOMAIN_RESOURCE_TYPE = "userpooldomain" ]
 
 [#-- Components --]
 [#assign USERPOOL_COMPONENT_TYPE = "userpool"]

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -5,6 +5,7 @@
 [#assign AWS_COGNITO_USERPOOL_CLIENT_RESOURCE_TYPE = "userpoolclient"]
 [#assign AWS_COGNITO_IDENTITYPOOL_RESOURCE_TYPE = "identitypool"]
 [#assign AWS_COGNITO_IDENTITYPOOL_ROLEMAPPING_RESOURCE_TYPE = "rolemapping"]
+[#assign AWS_COGNITO_USERPOOL_DOMAIN_RESOURCE_TYPE = "userpoolDomain" ]
 
 [#-- Components --]
 [#assign USERPOOL_COMPONENT_TYPE = "userpool"]
@@ -104,6 +105,9 @@
     [#assign userPoolId = formatResourceId(AWS_COGNITO_USERPOOL_RESOURCE_TYPE, core.Id)]
     [#assign userPoolName = formatSegmentFullName(core.Name)]
 
+    [#assign userPoolDomainId = formatResourceId(AWS_COGNITO_USERPOOL_DOMAIN_RESOURCE_TYPE, core.Id)]
+    [#assign userPoolDomainName = formatName("auth", core.ShortFullName, vpc?remove_beginning("vpc-"))]
+
     [#assign userPoolClientId = formatResourceId(AWS_COGNITO_USERPOOL_CLIENT_RESOURCE_TYPE, core.Id)]
     [#assign userPoolClientName = formatSegmentFullName(core.Name)]
 
@@ -123,11 +127,12 @@
                 "userpool" : {
                     "Id" : userPoolId,
                     "Name" : userPoolName,
-                    "HostName" : formatName(
-                        "auth",
-                        core.ShortFullName,
-                        vpc?remove_beginning("vpc-")),
                     "Type" : AWS_COGNITO_USERPOOL_RESOURCE_TYPE
+                },
+                "domain" : {
+                    "Id" : userPoolDomainId,
+                    "Name" : userPoolDomainName,
+                    "Type" : AWS_COGNITO_USERPOOL_DOMAIN_RESOURCE_TYPE
                 },
                 "client" : {
                     "Id" : userPoolClientId,

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -165,7 +165,6 @@
                 "USER_POOL" : getReference(userPoolId),
                 "IDENTITY_POOL" : getReference(identityPoolId),
                 "CLIENT" : getReference(userPoolClientId),
-                "CLIENTSECRET" : getReference(userPoolClientId, PASSWORD_ATTRIBUTE_TYPE),
                 "REGION" : regionId
             },
             "Roles" : {

--- a/aws/templates/resource/resource_cognito.ftl
+++ b/aws/templates/resource/resource_cognito.ftl
@@ -21,12 +21,6 @@
     { 
         REFERENCE_ATTRIBUTE_TYPE : { 
             "UserRef" : true
-        },
-        NAME_ATTRIBUTE_TYPE : { 
-            "Attribute" : "Name" 
-        },
-        PASSWORD_ATTRIBUTE_TYPE : {
-            "Attribute" : "ClientSecret"
         }
     }
 ]

--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -103,7 +103,9 @@
                     [#if linkTargetAttributes["AUTH_CALLBACK_URL"]?has_content ]
                         [#assign callbackUrls += linkTargetAttributes["AUTH_CALLBACK_URL"]?split(",") ]
                     [/#if]
-
+                    [#if linkTargetAttributes["AUTH_SIGNOUT_URL"]?has_content ]
+                        [#assign logoutUrls += linkTargetAttributes["AUTH_SIGNOUT_URL"]?split(",") ]
+                    [/#if]
                     [#break]
                     
                 [#case LAMBDA_FUNCTION_COMPONENT_TYPE]


### PR DESCRIPTION
Minor updates to cognito user pools. 
 - Lets you set a LogOutURL via an external link 
 - Moves the userpool domain to its own resource to prevent overlap in cli command json outputs
 - Remove outputs that are supported in cloudformation but not in cognito (??)