### PR TITLE
Container Fragement - Jenkins - Remove JAVA_OPTS Setting

### DIFF
--- a/aws/templates/container/container_jenkins.ftl
+++ b/aws/templates/container/container_jenkins.ftl
@@ -5,8 +5,7 @@
 
     [@Settings {
             "ECS_ARN" :  getExistingReference(ecsId),
-            "MAXMEMORY" : container.MemoryReservation,
-            "JAVA_OPTS" : "-Dhudson.slaves.ChannelPinger.pingIntervalSeconds=1200 -Dhudson.slaves.ChannelPinger.pingTimeoutSeconds=30" 
+            "MAXMEMORY" : container.MemoryReservation
         }
     /]
 


### PR DESCRIPTION
The JAVA_OPTS config is controlled by the container to make sure that the container always has the right settings.

Setting it in the container fragment overrides this and removes the other JAVA_OPTS in the container. 