### PR TITLE
Add RDS Snapshot MasterUsername check

### DIFF
--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -119,6 +119,16 @@
                 ] +
                 [#-- If a manual snapshot has been added the pseudo stack output should be replaced with an automated one --]
                 (getExistingReference(rdsId)?has_content)?then(
+                    (rdsManualSnapshot?has_content)?then(
+                        [
+                            "# Check Snapshot MasterUserName",
+                            "check_rds_snapshot_username" +
+                            " \"" + region + "\" " +
+                            " \"" + rdsManualSnapshot + "\" " +
+                            " \"" + rdsUsername + "\" || return $?" 
+                        ],
+                        []
+                    ) +
                     (solution.Backup.SnapshotOnDeploy || rdsManualSnapshot?has_content)?then(
                         [
                             "# Create RDS snapshot",

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -1097,9 +1097,9 @@ function check_rds_snapshot_username() {
     snapshot_username="$( echo "${snapshot_info}" | jq -r '.DBSnapshots[0].MasterUsername' )"
 
     if [[ "${snapshot_username}" != "${expected_username}" ]]; then
-    
+
       error "Snapshot Username does not match the expected username"
-      error "Update the GenerateCredentials.MasterUserName property to match the snapshot username"
+      error "Update the RDS username configuration to match the snapshot username"
       error "    Snapshot username: ${snapshot_username}"
       error "    Configured username: ${expected_username}"
       return 128


### PR DESCRIPTION
The MasterUsername of an rds instance can not be changed once it has been deployed, this also includes snapshots. 

Since we can't change the username we need to make sure that the solution configuration matches the snapshot username.

This adds a check on the username of a manual snapshot to make sure that the solution configuration matches it. This will raise an exception and you need to fix the config. 