### PR TITLE
Add endpoint configuration to api domain name

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -380,7 +380,10 @@
                                         domainCertificateId,
                                         ARN_ATTRIBUTE_TYPE,
                                         regionId
-                                    )
+                                    ),
+                                "EndpointConfiguration" : {
+                                    "Types" : [endpointType]
+                                }
                             }
                         )
                     outputs={}


### PR DESCRIPTION
This is needed to match the apiId endpoint configuration.