### PR TITLE
Pass host field through for regional apis

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -284,7 +284,15 @@
                             getOccurrenceSettingValue(
                                 occurrence,
                                 ["APIGateway","API","AccessKey"]))) ]
-                [#assign defaultCacheBehaviour = getCFAPIGatewayCacheBehaviour(origin, solution.CloudFront.CustomHeaders) ]
+                [#assign defaultCacheBehaviour =
+                    getCFAPIGatewayCacheBehaviour(
+                        origin,
+                        solution.CloudFront.CustomHeaders +
+                            valueIfTrue(
+                                ["Host"],
+                                endpointType == "REGIONAL",
+                                []
+                            ) ) ]
                 [#assign restrictions = {} ]
                 [#if solution.CloudFront.CountryGroups?has_content]
                     [#list asArray(solution.CloudFront.CountryGroups) as countryGroup]


### PR DESCRIPTION
For regional APIs, we need the host field so it can match the
custom domain name on the API.