### PR TITLE
Mobile Notification Proxy

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -893,6 +893,14 @@
             [#case "lambda"]
                 [#local result = getLambdaState(occurrence)]
                 [#break]
+            
+            [#case MOBILENOTIFIER_COMPONENT_TYPE ]
+                [#local result = getMobileNotifierState(occurrence)]
+                [#break]
+
+            [#case MOBILENOTIFIER_PLATFORM_COMPONENT_TYPE ]
+                [#local result = getMobileNotifierPlatformState(occurrence)]
+                [#break]
 
             [#case "rds"]
                 [#local result = getRDSState(occurrence)]

--- a/aws/templates/id/id_cw.ftl
+++ b/aws/templates/id/id_cw.ftl
@@ -2,8 +2,10 @@
 
 [#-- Resources --]
 [#assign AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE = "lg" ]
-[#assign AWS_CLOUDWATCH_DASHBOARD_RESOURCE_TYPE = "dashboard" ]
+[#assign AWS_CLOUDWATCH_LOG_SUBSCRIPTION_RESOURCE_TYPE = "lsubscription" ]
 [#assign AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE = "lmetric" ]
+
+[#assign AWS_CLOUDWATCH_DASHBOARD_RESOURCE_TYPE = "dashboard" ]
 [#assign AWS_CLOUDWATCH_ALARM_RESOURCE_TYPE = "alarm" ]
 
 [#function formatLogGroupId ids...]

--- a/aws/templates/id/id_cw.ftl
+++ b/aws/templates/id/id_cw.ftl
@@ -2,9 +2,7 @@
 
 [#-- Resources --]
 [#assign AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE = "lg" ]
-[#assign AWS_CLOUDWATCH_LOG_SUBSCRIPTION_RESOURCE_TYPE = "lsubscription" ]
 [#assign AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE = "lmetric" ]
-
 [#assign AWS_CLOUDWATCH_DASHBOARD_RESOURCE_TYPE = "dashboard" ]
 [#assign AWS_CLOUDWATCH_ALARM_RESOURCE_TYPE = "alarm" ]
 

--- a/aws/templates/id/id_cw.ftl
+++ b/aws/templates/id/id_cw.ftl
@@ -2,8 +2,8 @@
 
 [#-- Resources --]
 [#assign AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE = "lg" ]
-[#assign AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE = "lmetric" ]
 [#assign AWS_CLOUDWATCH_DASHBOARD_RESOURCE_TYPE = "dashboard" ]
+[#assign AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE = "lmetric" ]
 [#assign AWS_CLOUDWATCH_ALARM_RESOURCE_TYPE = "alarm" ]
 
 [#function formatLogGroupId ids...]

--- a/aws/templates/id/id_mobilenotifier.ftl
+++ b/aws/templates/id/id_mobilenotifier.ftl
@@ -1,0 +1,91 @@
+[#-- MOBILENOTIFIER --]
+
+[#-- Components --]
+[#assign MOBILENOTIFIER_COMPONENT_TYPE = "mobilenotifier" ]
+[#assign MOBILENOTIFIER_PLATFORM_COMPONENT_TYPE = "mobilenotiferplatform" ]
+
+[#assign componentConfiguration +=
+    {
+        MOBILENOTIFIER_COMPONENT_TYPE : {
+            "Attributes" : [
+                { 
+                    "Name" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                },
+                {
+                    "Name" : "SuccessSampleRate",
+                    "Default" : 100
+                }
+            ],
+            "Components" : [
+                {
+                    "Type" : MOBILENOTIFIER_PLATFORM_COMPONENT_TYPE,
+                    "Component" : "Platforms",
+                    "Link" : [ "Platform" ]
+                }
+            ]
+        },
+        MOBILENOTIFIER_PLATFORM_COMPONENT_TYPE : [
+            {
+                "Name" : "Engine"
+            },
+            {
+                "Name" : "SuccessSampleRate"
+            },
+            { 
+                "Name" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            }
+        ]
+    }]
+
+[#function getMobileNotifierState occurrence]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#local result =
+        {
+            "Resources" : {
+                "role" : {
+                    "Id" : formatDependentRoleId( core.Id ),
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                }
+            },
+            "Attributes" : {
+            },
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+    [#return result ]
+[/#function]
+
+[#function getMobileNotifierPlatformState occurrence]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#local id = formatResourceId(AWS_SNS_PLATFORMAPPLICATION_RESOURCE_TYPE, core.Id) ]
+
+    [#local result =
+        {
+            "Resources" : {
+                "platformapplication" : {
+                    "Id" : id,
+                    "Name" : core.FullName,
+                    "Type" : AWS_SNS_PLATFORMAPPLICATION_RESOURCE_TYPE 
+                }
+            },
+            "Attributes" : {
+            },
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+    [#return result ]
+[/#function]

--- a/aws/templates/id/id_mobilenotifier.ftl
+++ b/aws/templates/id/id_mobilenotifier.ftl
@@ -101,7 +101,7 @@
             "Attributes" : {
                 "ARN" : getExistingReference(id, ARN_ATTRIBUTE_TYPE),
                 "ENGINE" : engine,
-                "TOPIC_PREFIX" : id
+                "TOPIC_PREFIX" : core.ShortFullName
             },
             "Roles" : {
                 "Inbound" : {},

--- a/aws/templates/id/id_mobilenotifier.ftl
+++ b/aws/templates/id/id_mobilenotifier.ftl
@@ -16,6 +16,15 @@
                 {
                     "Name" : "SuccessSampleRate",
                     "Default" : 100
+                },
+                {
+                    "Name" : "Credentials",
+                    "Children" : [
+                        {
+                            "Name" : "EncryptionScheme",
+                            "Default" : "base64"
+                        }
+                    ]
                 }
             ],
             "Components" : [
@@ -33,6 +42,14 @@
             {
                 "Name" : "SuccessSampleRate"
             },
+            {
+                    "Name" : "Credentials",
+                    "Children" : [
+                        {
+                            "Name" : "EncryptionScheme"
+                        }
+                    ]
+                }
             { 
                 "Name" : "Links",
                 "Subobjects" : true,

--- a/aws/templates/id/id_mobilenotifier.ftl
+++ b/aws/templates/id/id_mobilenotifier.ftl
@@ -86,6 +86,7 @@
     [#local solution = occurrence.Configuration.Solution]
 
     [#local id = formatResourceId(AWS_SNS_PLATFORMAPPLICATION_RESOURCE_TYPE, core.Id) ]
+    [#local engine = solution.Engine!core.SubComponent.Name  ]
 
     [#local result =
         {
@@ -93,14 +94,20 @@
                 "platformapplication" : {
                     "Id" : id,
                     "Name" : core.FullName,
+                    "Engine" : engine,
                     "Type" : AWS_SNS_PLATFORMAPPLICATION_RESOURCE_TYPE 
                 }
             },
             "Attributes" : {
+                "ARN" : getExistingReference(id, ARN_ATTRIBUTE_TYPE),
+                "ENGINE" : engine,
+                "TOPIC_PREFIX" : id
             },
             "Roles" : {
                 "Inbound" : {},
-                "Outbound" : {}
+                "Outbound" : {
+                    "invoke" : snsPublishPlatformApplication(id)
+                }
             }
         }
     ]

--- a/aws/templates/id/id_mobilenotifier.ftl
+++ b/aws/templates/id/id_mobilenotifier.ftl
@@ -86,7 +86,7 @@
     [#local solution = occurrence.Configuration.Solution]
 
     [#local id = formatResourceId(AWS_SNS_PLATFORMAPPLICATION_RESOURCE_TYPE, core.Id) ]
-    [#local engine = solution.Engine!core.SubComponent.Name  ]
+    [#local engine = solution.Engine!core.SubComponent.Name?upper_case  ]
 
     [#local result =
         {
@@ -106,7 +106,8 @@
             "Roles" : {
                 "Inbound" : {},
                 "Outbound" : {
-                    "invoke" : snsPublishPlatformApplication(id)
+                    "default" : "publish",
+                    "publish" : snsPublishPlatformApplication(id)
                 }
             }
         }

--- a/aws/templates/id/id_mobilenotifier.ftl
+++ b/aws/templates/id/id_mobilenotifier.ftl
@@ -15,7 +15,7 @@
                 },
                 {
                     "Name" : "SuccessSampleRate",
-                    "Default" : 100
+                    "Default" : "100"
                 },
                 {
                     "Name" : "Credentials",

--- a/aws/templates/id/id_sns.ftl
+++ b/aws/templates/id/id_sns.ftl
@@ -3,6 +3,7 @@
 [#-- Resources --]
 [#assign AWS_SNS_TOPIC_RESOURCE_TYPE = "snstopic"]
 [#assign AWS_SNS_SUBSCRIPTION_RESOURCE_TYPE = "snssub"]
+[#assign AWS_SNS_PLATFORMAPPLICATION_RESOURCE_TYPE = "snsplatformapp" ]
 
 [#function formatSNSTopicId ids...]
     [#return formatResourceId(

--- a/aws/templates/policy/policy_cw.ftl
+++ b/aws/templates/policy/policy_cw.ftl
@@ -15,3 +15,15 @@
     ]
 [/#function]
 
+[#function cwLogsConfigurePermission ]
+    [#return
+        [
+            getPolicyStatement(
+                [
+                    "logs:PutMetricFilter",
+                    "logs:PutRetentionPolicy"
+                ]
+            )
+        ]
+    ]
+[/#function]

--- a/aws/templates/policy/policy_sns.ftl
+++ b/aws/templates/policy/policy_sns.ftl
@@ -44,24 +44,26 @@
 
 [#function snsPublishPlatformApplication topic_prefix="" ]
     [#return 
-        getPolicyStatement(
-            [
-                "sns:GetPlatformApplicationAttributes",
-                "sns:CreatePlatformEndpoint",
-                "sns:GetEndpointAttributes",
-                "sns:ListEndpointsByPlatformApplication",
-                "sns:SetEndpointAttributes"   
-            ]
-        ) + 
-        getPolicyStatement(
-            [
-                "sns:CreateTopic",
-                "sns:Publish"
-            ],
-            formatRegionalArn(
-                "sns", 
-                topic_prefix + "*"
+        [
+            getPolicyStatement(
+                [
+                    "sns:GetPlatformApplicationAttributes",
+                    "sns:CreatePlatformEndpoint",
+                    "sns:GetEndpointAttributes",
+                    "sns:ListEndpointsByPlatformApplication",
+                    "sns:SetEndpointAttributes"   
+                ]
+            ),
+            getPolicyStatement(
+                [
+                    "sns:CreateTopic",
+                    "sns:Publish"
+                ],
+                formatRegionalArn(
+                    "sns", 
+                    topic_prefix + "*"
+                )
             )
-        )
+        ]
     ]
 [/#function]

--- a/aws/templates/policy/policy_sns.ftl
+++ b/aws/templates/policy/policy_sns.ftl
@@ -41,3 +41,27 @@
             "sns:publish",
             id)]
 [/#function]
+
+[#function snsPublishPlatformApplication topic_prefix="" ]
+    [#return 
+        getPolicyStatement(
+            [
+                "sns:GetPlatformApplicationAttributes",
+                "sns:CreatePlatformEndpoint",
+                "sns:GetEndpointAttributes",
+                "sns:ListEndpointsByPlatformApplication",
+                "sns:SetEndpointAttributes"   
+            ]
+        ) + 
+        getPolicyStatement(
+            [
+                "sns:CreateTopic",
+                "sns:Publish"
+            ],
+            formatRegionalArn(
+                "sns", 
+                topic_prefix + "*"
+            )
+        )
+    ]
+[/#function]

--- a/aws/templates/resource/resource_sns.ftl
+++ b/aws/templates/resource/resource_sns.ftl
@@ -64,8 +64,8 @@
 [#function getSNSPlatformAppAttributes roleId="" successSample="" credential="" principal="" ]
     [#return 
             {
-                "SuccessFeedbackRoleArn"    : getReference(roleId),
-                "FailureFeedbackRoleArn"    : getReference(roleId),
+                "SuccessFeedbackRoleArn"    : getReference(roleId, ARN_ATTRIBUTE_TYPE),
+                "FailureFeedbackRoleArn"    : getReference(roleId, ARN_ATTRIBUTE_TYPE),
                 "SuccessFeedbackSampleRate" : successSample
             } + 
             attributeIfContent(

--- a/aws/templates/resource/resource_sns.ftl
+++ b/aws/templates/resource/resource_sns.ftl
@@ -63,7 +63,8 @@
 
 [#function getSNSPlatformAppAttributes roleId="" successSample="" credential="" principal="" ]
     [#return 
-            {
+        {  
+            "Attributes" : {
                 "SuccessFeedbackRoleArn"    : getReference(roleId, ARN_ATTRIBUTE_TYPE),
                 "FailureFeedbackRoleArn"    : getReference(roleId, ARN_ATTRIBUTE_TYPE),
                 "SuccessFeedbackSampleRate" : successSample
@@ -77,18 +78,6 @@
                 "PlatformPrincipal",
                 principal,
                 principal
-            )]
-[/#function]
-
-[#function getSNSPlatformAppCreateCli name platform roleId successSample credential="" principal="" ]
-    [#return 
-        {
-            "Name" : name,
-            "Platform" : platform,
-            "Attributes" : getSNSPlatformAppAttributes(
-                                roleId,
-                                successSample,
-                                credential,
-                                principal)
-        }]
+            )
+            }]
 [/#function]

--- a/aws/templates/resource/resource_sns.ftl
+++ b/aws/templates/resource/resource_sns.ftl
@@ -60,3 +60,35 @@
     [@createSNSTopic mode, id, formatName(productName, extensions) /]
 [/#macro]
 
+
+[#function getSNSPlatformAppAttributes roleId="" successSample="" credential="" principal="" ]
+    [#return 
+            {
+                "SuccessFeedbackRoleArn"    : getReference(roleId),
+                "FailureFeedbackRoleArn"    : getReference(roleId),
+                "SuccessFeedbackSampleRate" : successSample
+            } + 
+            attributeIfContent(
+                "PlatformCredential",
+                credential,
+                credential
+            ) + 
+            attributeIfContent(
+                "PlatformPrincipal",
+                principal,
+                principal
+            )]
+[/#function]
+
+[#function getSNSPlatformAppCreateCli name platform roleId successSample credential="" principal="" ]
+    [#return 
+        {
+            "Name" : name,
+            "Platform" : platform,
+            "Attributes" : getSNSPlatformAppAttributes(
+                                roleId,
+                                successSample,
+                                credential,
+                                principal)
+        }]
+[/#function]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -28,7 +28,10 @@
         },
         {
             "Name" : ["Mount", "Subcomponent"]
-        }
+        },
+        {
+            "Name" : ["Platform"]
+        },
         "Instance",
         "Version"
     ]

--- a/aws/templates/solution/solution_mobilenotifier.ftl
+++ b/aws/templates/solution/solution_mobilenotifier.ftl
@@ -160,11 +160,12 @@
                                 "       \"" + engine + "\" " + 
                                 "       \"$\{tmpdir}/cli-" + 
                                         platformAppAttributesCliId + "-" + platformAppAttributesCommand + ".json\")\"",
-                                "       pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")" + core.SubComponent.Id + "-pseudo-stack.json\" ",
+                                "       pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-" + core.SubComponent.Id + "-pseudo-stack.json\" ",
                                 "       create_pseudo_stack" + " " +
                                 "       \"SNS Platform App\"" + " " +
                                 "       \"$\{pseudo_stack_file}\"" + " " +
-                                "       \"" + platformAppId + "Xarn\" \"$\{platform_app_arn}\" || return $?",
+                                "       \"" + platformAppId + "Xarn\" \"$\{platform_app_arn}\"" +
+                                "       \"" + platformAppId + "\" \"" + core.Name + "\" || return $?",
                                 "       ;;",
                                 "  delete)",
                                 "       # Delete SNS Platform Application",
@@ -189,7 +190,7 @@
                         "# Mobile Notifier Cleanup",
                         "case $\{STACK_OPERATION} in",
                         "  create|update)",
-                        "       info \"Cleanig up platforms that have been removed from config\"",
+                        "       info \"Cleaning up platforms that have been removed from config\"",
                         "       cleanup_sns_platformapps " + 
                         "       \"" + region + "\" " + 
                         "       \"" + platformAppName + "\" " + 

--- a/aws/templates/solution/solution_mobilenotifier.ftl
+++ b/aws/templates/solution/solution_mobilenotifier.ftl
@@ -27,7 +27,8 @@
                 policies=
                     [
                         getPolicyDocument(
-                            cwLogsProducePermission(),
+                                cwLogsProducePermission() +
+                                cwLogsConfigurePermission(),
                             "logging")
                     ]
             /]
@@ -59,16 +60,16 @@
             
             [#assign isPlatformApp = false]
 
-            [#assign engine = solution.Engine!core.SubComponent.Id ]
+            [#assign engine = solution.Engine!core.SubComponent.Name ]
 
             [#assign platformAppCreateCli = {} ]
             [#assign platformAppUpdateCli = {} ]
 
             [#assign platformAppPrincipal =
-                getOccurrenceSettingValue(occurrence, ["MobileNotifier", core.SubComponent.Id + "_Principal"], true) ]
+                getOccurrenceSettingValue(occurrence, ["MobileNotifier", core.SubComponent.Name + "_Principal"], true) ]
             
-            [#assign platformAppCertificate =
-                getOccurrenceSettingValue(occurrence, ["MobileNotifier", core.SubComponent.Id + "_Certificate"], true) ]
+            [#assign platformAppCredential =
+                getOccurrenceSettingValue(occurrence, ["MobileNotifier", core.SubComponent.Name + "_Credential"], true) ]
 
             [#assign engineFamily = "" ]
             
@@ -97,13 +98,13 @@
             [#switch engineFamily ]
                 [#case "APPLE" ]
                     [#assign isPlatformApp = true]
-                    [#if !platformAppCertificate?has_content || !platformAppPrincipal?has_content ]
+                    [#if !platformAppCredential?has_content || !platformAppPrincipal?has_content ]
                         [@cfException 
                             mode=listMode 
-                            description="Missing Credentials - Requires both Certificate and Principal" 
+                            description="Missing Credentials - Requires both Credential and Principal" 
                             context=component 
                             detail={
-                                "Certificate" : platformAppCertificate!"",
+                                "Credential" : platformAppCredential!"",
                                 "Principal" : platformAppPrincipal!""
                             } /]
                     [/#if]
@@ -132,14 +133,14 @@
                             engine, 
                             roleId,
                             successSampleRate, 
-                            platformAppCertificate,
+                            platformAppCredential,
                             platformAppPrincipal )]
 
                     [#assign platformAppUpdateCli = 
                         getSNSPlatformAppAttributes(
                             roleId, 
                             successSampleRate 
-                            platformAppCertificate,
+                            platformAppCredential,
                             platformAppPrincipal )]
 
                     [@cfCli 
@@ -196,6 +197,7 @@
                                     "       \"" + encryptionScheme + "\" " +
                                     "       \"$\{tmpdir}/cli-" + 
                                             platformAppCreateCliId + "-" + platformAppCreateCommand + ".json\")",
+                                    "       info \"Created $\{platform_app_arn}\" ",
                                     "       pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-" + core.SubComponent.Id + "-pseudo-stack.json\" ",
                                     "       create_pseudo_stack" + " " +
                                     "       \"SNS Platform Application\" " +

--- a/aws/templates/solution/solution_mobilenotifier.ftl
+++ b/aws/templates/solution/solution_mobilenotifier.ftl
@@ -1,0 +1,211 @@
+[#-- Mobile Notifier --]
+
+[#if componentType == MOBILENOTIFIER_COMPONENT_TYPE  ]
+
+    [#list requiredOccurrences(
+            getOccurrences(tier, component),
+            deploymentUnit) as occurrence]
+
+        [@cfDebug listMode occurrence false /]
+
+        [#assign core = occurrence.Core]
+        [#assign solution = occurrence.Configuration.Solution]
+        [#assign resources = occurrence.State.Resources]
+
+        [#assign successSampleRate = solution.SuccessSampleRate ]
+
+        [#assign platformAppNames = []]
+
+        [#assign roleId = resources["role"].Id]
+
+        [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(roleId)]
+            [@createRole
+                mode=listMode
+                id=roleId
+                trustedServices=["sns.amazonaws.com" ]
+                policies=
+                    [
+                        getPolicyDocument(
+                            cwLogsProducePermission(),
+                            "logging")
+                    ]
+            /]
+        [/#if]
+
+        [#assign platformAppCreateCommand = "createPlatformApp" ]
+        [#assign platformAppUpdateCommand = "updatePlatformApp" ]
+        [#assign platformAppDeleteCommand = "deletePlatformApp" ]
+
+        [#list occurrence.Occurrences![] as subOccurrence]
+
+            [#assign core = subOccurrence.Core ]
+            [#assign solution = subOccurrence.Configuration.Solution ]
+            [#assign resources = subOccurrence.State.Resources ]
+
+            [#assign successSampleRate = solution.SuccessSampleRate!successSampleRate ] 
+
+            [#assign platformAppId = resources["platformapplication"].Id]
+            [#assign platformAppName = resources["platformapplication"].Name ]
+            [#assign platformAppCreateCliId = formatId( platformAppId, "create" )]
+            [#assign platformAppUpdateCliId = formatId( platformAppId, "update" )]
+
+            [#assign platformAppNames += [ platformAppName ] ]
+
+            [#assign isPlatformApp = false]
+
+            [#assign engine = solution.Engine!core.SubComponent.Id ]
+
+            [#assign platformAppCreateCli = {} ]
+            [#assign platformAppUpdateCli = {} ]
+
+            [#assign platformAppPrincipal =
+                getOccurrenceSettingValue(occurrence, ["MobileNotifier", core.SubComponent.Id + "_Principal"], true) ]
+            
+            [#assign platformAppCertificate =
+                getOccurrenceSettingValue(occurrence, ["MobileNotifier", core.SubComponent.Id + "_Certificate"], true) ]
+
+            [#assign engineFamily = "" ]
+            
+            [#switch engine ]
+                [#case "APNS" ]
+                [#case "APNS_SANDBOX" ]
+                    [#assign engineFamily = "APPLE" ]
+                    [#break]
+                
+                [#case "GCM" ]
+                    [#assign engineFamily = "GOOGLE" ]
+                    [#break]
+                
+                [#case "SMS" ]
+                    [#assign engineFamily = "SMS" ]
+                    [#break]
+
+                [#default]
+                    [@cfException 
+                        mode=listMode 
+                        description="Unkown Engine" 
+                        context=component 
+                        detail=engine /]
+            [/#switch]
+
+            [#switch engineFamily ]
+                [#case "APPLE" ]
+                    [#assign isPlatformApp = true]
+                    [#if !platformAppCertificate?has_content || !platformAppPrincipal?has_content ]
+                        [@cfException 
+                            mode=listMode 
+                            description="Missing Credentials - Requires both Certificate and Principal" 
+                            context=component 
+                            detail={
+                                "Certificate" : platformAppCertificate!"",
+                                "Principal" : platformAppPrincipal!""
+                            } /]
+                    [/#if]
+                    [#break]
+
+                [#case "GOOGLE" ]
+                    [#assign isPlatformApp = true]
+                    [#if !platformAppPrincipal?has_content ]
+                        [@cfException 
+                            mode=listMode 
+                            description="Missing Credential - Requires Principal" 
+                            context=component 
+                            detail={
+                                "Principal" : platformAppPrincipal!""
+                            } /]
+                    [/#if]
+                    [#break]
+            [/#switch]
+            
+            [#if isPlatformApp ]
+                [#if deploymentSubsetRequired("cli", false ) ]
+
+                    [#assign platformAppCreateCli = 
+                        getSNSPlatformAppCreateCli( 
+                            platformAppName, 
+                            engine, 
+                            roleId,
+                            successSampleRate, 
+                            platformAppCertificate,
+                            platformAppPrincipal )]
+
+                    [#assign platformAppUpdateCli = 
+                        getSNSPlatformAppAttributes(
+                            roleId, 
+                            successSampleRate 
+                            platformAppCertificate,
+                            platformAppPrincipal )]
+
+                    [@cfCli 
+                        mode=listMode
+                        id=platformAppCreateCliId
+                        command=platformAppCreateCommand
+                        content=platformAppCreateCli
+                    /]
+
+
+                    [@cfCli 
+                        mode=listMode
+                        id=platformAppUpdateCliId
+                        command=platformAppUpdateCommand
+                        content=platformAppUpdateCli
+                    /]
+                [/#if]
+
+                [#if deploymentSubsetRequired("prologue", false) ]
+                    [@cfScript
+                        mode=listMode
+                        content= 
+                            [
+                                "# Platform: " + core.SubComponent.Id 
+                                "case $\{STACK_OPERATION} in",
+                                "  create|update)",
+                                "       # Get cli config file",
+                                "       split_cli_file \"$\{CLI}\" \"$\{tmpdir}\" || return $?", 
+                                "       # Apply CLI level updates to Application Platform",
+                                "       info \"Applying cli level configurtion\""
+                            ] +
+                            (getExistingReference(platformAppId)?has_content)?then(
+                                [
+                                    "       update_sns_platformapp" +
+                                    "       \"" + region + "\" " + 
+                                    "       \"" + getExistingReference(platformAppId) + "\" " + 
+                                    "       \"$\{tmpdir}/cli-" + 
+                                            platformAppUpdateCliId + "-" + platformAppUpdateCommand + ".json\"",
+                                    "    ;;",
+                                    "  delete)",
+                                    "       # Delete SNS Platform Application",
+                                    "       info \"Deleting SNS Platform App " + getExistingReference(platformAppId) + "\" ",
+                                    "       delete_sns_platformapp" +
+                                    "       \"" + region + "\" " + 
+                                    "       \"" + getExistingReference(platformAppId) + "\" "
+                                ],
+                                [
+                                    "       platform_app_arn=$( create_sns_platformapp" +
+                                    "       \"" + region + "\" " + 
+                                    "       \"" + platformAppName + "\" " + 
+                                    "       \"$\{tmpdir}/cli-" + 
+                                            platformAppCreateCliId + "-" + platformAppCreateCommand + ".json\")",
+                                    "       pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-" + core.SubComponent.Id + "-pseudo-stack.json\" ",
+                                    "       create_pseudo_stack" + " " +
+                                    "       \"SNS Platform Application\" " +
+                                    "       \"$\{pseudo_stack_file}\"" + " " +
+                                    "       \"" + platformAppId + "Xarn\" \"$\{platform_app_arn}\" || return $?"
+                                ]
+                            ) +
+                            [
+                                "   ;;",
+                                "   esac"
+                            ]
+                    /]
+                [/#if]
+            [/#if]
+        [/#list]
+
+        
+        [#if deploymentSubsetRequired("epilogue", false) ]
+            
+        [/#if]
+
+    [/#list]
+[/#if]

--- a/aws/templates/solution/solution_mobilenotifier.ftl
+++ b/aws/templates/solution/solution_mobilenotifier.ftl
@@ -48,6 +48,8 @@
 
             [#assign platformAppId = resources["platformapplication"].Id]
             [#assign platformAppName = resources["platformapplication"].Name ]
+            [#assign engine = resources["platformapplication"].Engine ]
+
             [#assign platformAppAttributesCliId = formatId( platformAppId, "attributes" )]
 
             [#assign platformArn = getExistingReference( platformAppId, ARN_ATTRIBUTE_TYPE) ] 
@@ -57,8 +59,6 @@
             [/#if]
             
             [#assign isPlatformApp = false]
-
-            [#assign engine = solution.Engine!core.SubComponent.Name ]
 
             [#assign platformAppCreateCli = {} ]
             [#assign platformAppUpdateCli = {} ]

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -921,14 +921,6 @@ function deploy_sns_platformapp() {
   esac
 }
 
-function update_sns_platformapp() {
-  local region="$1"; shift
-  local arn="$1"; shift
-  local configfile="$1"; shift 
-  
-  
-}
-
 function delete_sns_platformapp() {
   local region="$1"; shift
   local arn="$1"; shift

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -937,9 +937,10 @@ function cleanup_sns_platformapps() {
     unexpected_platform_arns="$(echo "${expected_platform_arns}" | jq --argjson currentarns "${current_platform_arns}" '. - $currentarns')"
     info "Found the following unexpected Platforms: ${unexpected_platform_arns}"
     echo "${unexpected_platform_arns}" | jq --arg region "${region}" -r '.[] | "delete_sns_platform \($region) \(.)"' > "${tmp_file}"
-
+    
     if [[ -f "${tmp_file}" ]]; then 
-      ./"${tmp_file}"
+      chmod u+x "${tmp_file}"
+      "${tmp_file}"
     fi
   fi
 


### PR DESCRIPTION
Adds initial support for mobile notifiers which are used to send push notifications to multiple mobile platforms 

## Configuration

A mobilenotifier resource containers a list of platforms, each of these platforms send notifications to a specific mobile platform, APNS (Apple), Google etc. 

Each platform is configured with an engine, we currently support: 
- APNS
- APNS_SANDBOX
- GCM
- SMS 

With the exception of SMS each of them require credentials provided by the mobile platform. For apple this is a certificate and private key and for GCM this is a shared secret. These need to be encrypted using KMS and stored as credentials, with the name format 
```
<platformId>_Principal - APNS only - this is the certificate provided by apple  - not required for GCM
<platformId_Credential - APNS - private certificate - GCM - shared secret 
```

## Attributes

Linking to a mobile notifier platform returns 3 attributes
- ARN - the arn of the platform application in SNS
- TOPIC_PREFIX - when creating a topic to send notifications the topic name must be prefixed with this prefix to ensure that topics don't overlap between platforms 
- ENGINE - the platform that this platform uses 

## Deployment
For AWS SNS platform applications are only available via the CLI. However the logging role must be created before deploying the component. 