### PR TITLE
Shared container fragments

### DIFF
--- a/aws/templates/container/container_cleanup.ftl
+++ b/aws/templates/container/container_cleanup.ftl
@@ -1,4 +1,6 @@
 [#case "cleanup"]
+[#case "_cleanup" ]
+
     [@Attributes image="cleanup" /]
 
     [@Variables

--- a/aws/templates/container/container_codeontap.ftl
+++ b/aws/templates/container/container_codeontap.ftl
@@ -1,4 +1,6 @@
 [#case "codeontap"]
+[#case "_codeontap"]
+
     [#assign settings = context.DefaultEnvironment]
 
     [#assign dockerStageDir = settings["DOCKER_STAGE_DIR"]!"/tmp" ]

--- a/aws/templates/container/container_couchdb.ftl
+++ b/aws/templates/container/container_couchdb.ftl
@@ -1,6 +1,7 @@
 [#case "couchdb"]
-    [#-- COUCHDB credentials (USER, PASSWORD) expected in env --]
+[#case "_couchdb"]
 
+    [#-- COUCHDB credentials (USER, PASSWORD) expected in env --]
     [@Attributes image="couchdb" /]
 
     [@Volume "couchdb" "/usr/local/var/lib/couchdb" "/codeontap/couchdb" /]

--- a/aws/templates/container/container_filter.ftl
+++ b/aws/templates/container/container_filter.ftl
@@ -1,4 +1,6 @@
 [#case "filter"]
+[#case "_filter"]
+
     [#-- DATA and QUERY credentials (USERNAME, PASSWORD) expected in env --]
     [#-- TODO(mfl): change container to use standard ES atributes --]
     [#assign es = component.Links["es"]]

--- a/aws/templates/container/container_jenkins.ftl
+++ b/aws/templates/container/container_jenkins.ftl
@@ -1,4 +1,6 @@
 [#case "jenkins"]
+[#case "_jenkins"]
+
     [@Attributes image="jenkins-master" /]
    
     [#assign settings = context.DefaultEnvironment]

--- a/aws/templates/container/container_logstash.ftl
+++ b/aws/templates/container/container_logstash.ftl
@@ -1,4 +1,6 @@
 [#case "logstash"]
+[#case "_logstash"]
+
     [#assign esConfiguration = configurationObject.ElasticSearch]
 
     [@Attributes name="logstash" /]

--- a/aws/templates/container/container_mongodb.ftl
+++ b/aws/templates/container/container_mongodb.ftl
@@ -1,4 +1,6 @@
 [#case "mongodb"]
+[#case "_mongodb"]
+
     [@Attributes image="mongodb" /]
     
     [@Volume "mongodb" "/data/db" "/codeontap/mongodb/db" /]

--- a/aws/templates/container/container_rabbit.ftl
+++ b/aws/templates/container/container_rabbit.ftl
@@ -1,5 +1,7 @@
 [#case "rabbit"]
+[#case "_rabbit"]
 [#case "rabbittask"]
+[#case "_rabbittask"]
 
     [@Attributes image="rabbitmq-autocluster" /]
 

--- a/aws/templates/container/container_redirector.ftl
+++ b/aws/templates/container/container_redirector.ftl
@@ -1,4 +1,5 @@
 [#case "redirector"]
+[#case "_redirector"]
 
     [@DefaultLinkVariables enabled=false /]
     [@DefaultCoreVariables enabled=false /]

--- a/aws/templates/container/start.ftl
+++ b/aws/templates/container/start.ftl
@@ -1,2 +1,3 @@
 [#ftl]
+[@cfDebug listMode containerId false /]
 [#switch containerId]

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -406,10 +406,16 @@
 [#-- Container --]
 
 [#function formatContainerFragmentId occurrence container]
-    [#return formatName(
-                getContainerId(container),
-                occurrence.Core.Instance.Id,
-                occurrence.Core.Version.Id)]
+    [#local containerId = getContainerId(container) ]
+    [#if containerId?starts_with("_") ]
+        [#return containerId ]
+    [#else]
+        [#return 
+                formatName(
+                    getContainerId(container),
+                    occurrence.Core.Instance.Id,
+                    occurrence.Core.Version.Id)]
+    [/#if]
 [/#function]
 
 [#function formatContainerSecurityGroupIngressId resourceId container portRange source=""]

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -412,7 +412,7 @@
     [#else]
         [#return 
                 formatName(
-                    getContainerId(container),
+                    containerId,
                     occurrence.Core.Instance.Id,
                     occurrence.Core.Version.Id)]
     [/#if]

--- a/aws/templates/resource/resource_ec2.ftl
+++ b/aws/templates/resource/resource_ec2.ftl
@@ -265,7 +265,7 @@
 
     [#if dockerUsers?has_content ] 
         [#list dockerUsers as userName,details ]
-            [#local dockerUsersEnv += details.UserName?has_content?then(details.UserName,userName) + ":" + details.UID + "," ]
+            [#local dockerUsersEnv += details.UserName?has_content?then(details.UserName,userName) + ":" + details.UID?c + "," ]
         [/#list] 
     [/#if]
     [#local dockerUsersEnv = dockerUsersEnv?remove_ending(",")]


### PR DESCRIPTION
Adds the ability to have shared container fragments. When a container Id starts with an underscore its instance and version details are ignored when processing container fragments. 

This allows for container fragments that can be shared between all instances and versions of a container. 