### PR TITLE
Make link variables available in default environment

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -40,15 +40,16 @@
                 getComponentId(component)
             ) ]
 
+        [#assign contextLinks = getLinkTargets(occurrence) ]
         [#assign context =
             {
                 "Id" : containerId,
                 "Name" : containerId,
                 "Instance" : core.Instance.Id,
                 "Version" : core.Version.Id,
-                "DefaultEnvironment" : defaultEnvironment(occurrence),
+                "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks),
                 "Environment" : {},
-                "Links" : getLinkTargets(occurrence),
+                "Links" : contextLinks,
                 "DefaultCoreVariables" : false,
                 "DefaultEnvironmentVariables" : false,
                 "DefaultLinkVariables" : false

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -81,15 +81,16 @@
                 getComponentId(component)
             ) ]
 
+        [#assign contextLinks = getLinkTargets(occurrence, links) ]
         [#assign context =
             {
                 "Id" : containerId,
                 "Name" : containerId,
                 "Instance" : core.Instance.Id,
                 "Version" : core.Version.Id,
-                "DefaultEnvironment" : defaultEnvironment(occurrence),
+                "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks),
                 "Environment" : {},
-                "Links" : getLinkTargets(occurrence, links),
+                "Links" : contextLinks,
                 "DefaultCoreVariables" : true,
                 "DefaultEnvironmentVariables" : true,
                 "DefaultLinkVariables" : true

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -24,13 +24,14 @@
                     solution.Container,
                     getComponentId(core.Component)
                 ) ]
+            [#assign contextLinks = getLinkTargets(fn) ]
             [#assign context =
                 {
                     "Id" : containerId,
                     "Name" : containerId,
                     "Instance" : core.Instance.Id,
                     "Version" : core.Version.Id,
-                    "DefaultEnvironment" : defaultEnvironment(fn),
+                    "DefaultEnvironment" : defaultEnvironment(fn, contextLinks),
                     "Environment" : {},
                     "S3Bucket" : getRegistryEndPoint("lambda", occurrence),
                     "S3Key" :
@@ -40,7 +41,7 @@
                             getOccurrenceBuildReference(occurrence),
                             "lambda.zip"
                         ),
-                    "Links" : getLinkTargets(fn),
+                    "Links" : contextLinks,
                     "DefaultCoreVariables" : true,
                     "DefaultEnvironmentVariables" : true,
                     "DefaultLinkVariables" : true,

--- a/aws/templates/application/application_spa.ftl
+++ b/aws/templates/application/application_spa.ftl
@@ -18,15 +18,16 @@
                 solution.Container,
                 getComponentId(component)
             ) ]
+        [#assign contextLinks = getLinkTargets(occurrence) ]
         [#assign context =
             {
                 "Id" : containerId,
                 "Name" : containerId,
                 "Instance" : core.Instance.Id,
                 "Version" : core.Version.Id,
-                "DefaultEnvironment" : defaultEnvironment(occurrence),
+                "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks),
                 "Environment" : {},
-                "Links" : getLinkTargets(occurrence),
+                "Links" : contextLinks,
                 "DefaultCoreVariables" : false,
                 "DefaultEnvironmentVariables" : false,
                 "DefaultLinkVariables" : false


### PR DESCRIPTION
This allows easy renaming of link attributes if required, and means they
are all available in the environment if required for more complex logic.