### PR TITLE
Add List Bucket permissions to standard policy

### DIFF
--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -295,14 +295,12 @@
             []
         ) +
         valueIfTrue(
-            s3AllPermission(dataBucket, getAppDataFilePrefix(occurrence))+
-            s3ListPermission(dataBucket, getAppDataFilePrefix(occurrence)),
+            s3AllPermission(dataBucket, getAppDataFilePrefix(occurrence)),
             permissions.AppData,
             []
         ) +
         valueIfTrue(
-            s3AllPermission(dataBucket, getAppDataPublicFilePrefix(occurrence))+ 
-            s3ListPermission(dataBucket, getAppDataPublicFilePrefix(occurrence)),
+            s3AllPermission(dataBucket, getAppDataPublicFilePrefix(occurrence)),
             permissions.AppPublic && getAppDataPublicFilePrefix(occurrence)?has_content,
             []
         )

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -289,17 +289,20 @@
             []
         ) +
         valueIfTrue(
-            s3ReadPermission(operationsBucket, getSettingsFilePrefix(occurrence)),
+            s3ReadPermission(operationsBucket, getSettingsFilePrefix(occurrence)) + 
+            s3ListPermission(operationsBucket, getSettingsFilePrefix(occurrence)),
             permissions.AsFile,
             []
         ) +
         valueIfTrue(
-            s3AllPermission(dataBucket, getAppDataFilePrefix(occurrence)),
+            s3AllPermission(dataBucket, getAppDataFilePrefix(occurrence))+
+            s3ListPermission(dataBucket, getAppDataFilePrefix(occurrence)),
             permissions.AppData,
             []
         ) +
         valueIfTrue(
-            s3AllPermission(dataBucket, getAppDataPublicFilePrefix(occurrence)),
+            s3AllPermission(dataBucket, getAppDataPublicFilePrefix(occurrence))+ 
+            s3ListPermission(dataBucket, getAppDataPublicFilePrefix(occurrence)),
             permissions.AppPublic && getAppDataPublicFilePrefix(occurrence)?has_content,
             []
         )
@@ -322,7 +325,7 @@
                         context.DefaultCoreVariables
                     ) +
                     valueIfTrue(
-                        getSettingsAsEnvironment(occurrence.Configuration.Settings.Product),
+                        getSettingsAsEnvironment(occurrence.Configuration.Settings.Product, true),
                         context.DefaultEnvironmentVariables
                     ) +
                     valueIfTrue(


### PR DESCRIPTION
When working with appsettings as files you might not know exactly how many files you are being given. 

This permission allows you to list the objects in the components settings prefix only in order to run a listObjects command from within an app. 

Also adds a minor fix to include sensitive settings as environment variables 