### PR TITLE
Container Startup Overrides

### DIFF
--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -249,6 +249,32 @@
     [/#if]
 [/#macro]
 
+[#macro EntryPoint entrypoint ]
+    [#if ((containerListMode!"") == "model") ]
+        [#assign context += 
+            {
+                "EntryPoint" : entrypoint?is_string?then(
+                    entrypoint?split(" "),
+                    entrypoint
+                )
+            }
+        ]
+    [/#if]
+[/#macro]
+
+[#macro Command command ]
+    [#if ((containerListMode!"") == "model") ]
+        [#assign context += 
+            {
+                "Command" : command?is_string?then(
+                    command?split(" "),
+                    command
+                )
+            }
+        ]
+    [/#if]
+[/#macro]
+
 [#macro Policy statements...]
     [#if (containerListMode!"") == "model"]
         [#assign context +=
@@ -530,7 +556,7 @@
             attributeIfContent("PortMappings", containerPortMappings) +
             attributeIfContent("IngressRules", ingressRules) +
             attributeIfContent("RunCapabilities", container.RunCapabilities) +
-            attributeIfContent("ContainerNetworkLinks", container.ContainerNetworkLinks)
+            attributeIfContent("ContainerNetworkLinks", container.ContainerNetworkLinks) 
         ]
 
         [#-- Add in container specifics including override of defaults --]

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -556,7 +556,7 @@
             attributeIfContent("PortMappings", containerPortMappings) +
             attributeIfContent("IngressRules", ingressRules) +
             attributeIfContent("RunCapabilities", container.RunCapabilities) +
-            attributeIfContent("ContainerNetworkLinks", container.ContainerNetworkLinks) 
+            attributeIfContent("ContainerNetworkLinks", container.ContainerNetworkLinks)
         ]
 
         [#-- Add in container specifics including override of defaults --]

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -97,7 +97,9 @@
                                     ) +
                 attributeIfTrue("Privileged", container.Privileged, container.Privileged!"") + 
                 attributeIfContent("WorkingDirectory", container.WorkingDirectory!"") + 
-                attributeIfContent("Links", container.ContainerNetworkLinks![] )
+                attributeIfContent("Links", container.ContainerNetworkLinks![] ) + 
+                attributeIfContent("EntryPoint", container.EntryPoint![]) + 
+                attributeIfContent("Command", container.Command![])
             ]
         ]
     [/#list]


### PR DESCRIPTION
Adds the ability to define startup overrides on containers using a container fragment macro. 

Both the entrypoint and command are available as separate macros as they map to different properties