### PR TITLE
Ensure all product settings included by default

### DIFF
--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -349,7 +349,8 @@
                         context.DefaultCoreVariables
                     ) +
                     valueIfTrue(
-                        getSettingsAsEnvironment(occurrence.Configuration.Settings.Product, true),
+                        occurrence.Configuration.Environment.General +
+                            occurrence.Configuration.Environment.Sensitive,
                         context.DefaultEnvironmentVariables
                     ) +
                     valueIfTrue(


### PR DESCRIPTION
A recent change initially saw only general settings included. This was
then changed so that only sensitive settings were included.

Revert it back to the way it was so they are all included.