### PR TITLE
Add System user support

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -926,6 +926,10 @@
                 [#local result = getTaskState(occurrence, parentOccurrence)]
                 [#break]
 
+            [#case USER_COMPONENT_TYPE ]
+                [#local result = getUserState(occurrence) ]
+                [#break]
+
             [#case "userpool"]
                 [#local result = getUserPoolState(occurrence)]
                 [#break]

--- a/aws/templates/id/id_iam.ftl
+++ b/aws/templates/id/id_iam.ftl
@@ -3,6 +3,7 @@
 [#-- Resources --]
 [#assign AWS_IAM_POLICY_RESOURCE_TYPE="policy" ]
 [#assign AWS_IAM_ROLE_RESOURCE_TYPE="role" ]
+[#assign AWS_IAM_USER_RESOURCE_TYPE="user"]
 
 [#function formatPolicyId ids...]
     [#return formatResourceId(

--- a/aws/templates/id/id_user.ftl
+++ b/aws/templates/id/id_user.ftl
@@ -1,4 +1,4 @@
-[#-- MOBILENOTIFIER --]
+[#-- USER --]
 
 [#-- Components --]
 [#assign USER_COMPONENT_TYPE = "user" ]

--- a/aws/templates/id/id_user.ftl
+++ b/aws/templates/id/id_user.ftl
@@ -1,0 +1,67 @@
+[#-- MOBILENOTIFIER --]
+
+[#-- Components --]
+[#assign USER_COMPONENT_TYPE = "user" ]
+
+[#assign componentConfiguration +=
+    {
+        USER_COMPONENT_TYPE : {
+            "Attributes" : [
+                { 
+                    "Name" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                },
+                {
+                    "Name" : "Type",
+                    "Default" : "system"
+                },
+                {
+                    "Name" : "GenerateCredentials",
+                    "Children" : [
+                        {
+                            "Name" : "EncryptionScheme",
+                            "Default" : "base64"
+                        },
+                        {
+                            "Name" : "CharacterLength",
+                            "Default" : 20
+                        }
+                    ]
+                }
+            ]
+        }
+    }]
+
+[#function getUserState occurrence]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#local userId = formatResourceId(AWS_IAM_USER_RESOURCE_TYPE, core.Id) ]
+    [#local userArn = getExistingReference(userId, ARN_ATTRIBUTE_TYPE)]
+
+    [#local result =
+        {
+            "Resources" : {
+                "user" : {
+                    "Id" : userId,
+                    "Name" : core.ShortFullName,
+                    "Type" : AWS_IAM_USER_RESOURCE_TYPE
+                }
+            },
+            "Attributes" : {
+                "USERNAME" : getExistingReference(userId),
+                "ARN" : userArn
+            },
+            "Roles" : {
+                "Inbound" : {
+                    "invoke" : {
+                        "Principal" : userArn
+                    }
+                }
+                "Outbound" : {}
+            }
+        }
+    ]
+    [#return result ]
+[/#function]

--- a/aws/templates/id/id_user.ftl
+++ b/aws/templates/id/id_user.ftl
@@ -7,6 +7,10 @@
     {
         USER_COMPONENT_TYPE : {
             "Attributes" : [
+                {
+                    "Name" : "Container",
+                    "Default" : ""
+                },
                 { 
                     "Name" : "Links",
                     "Subobjects" : true,

--- a/aws/templates/resource/resource_iam.ftl
+++ b/aws/templates/resource/resource_iam.ftl
@@ -185,3 +185,21 @@
     /]
 [/#macro]
 
+[#assign USER_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        ARN_ATTRIBUTE_TYPE : { 
+            "Attribute" : "Arn"
+        },
+        USERNAME_ATTRIBUTE_TYPE : { 
+            "UseRef" : true
+        }
+    }
+]
+[#assign outputMappings +=
+    {
+        AWS_IAM_USER_RESOURCE_TYPE : USER_OUTPUT_MAPPINGS
+    }
+]

--- a/aws/templates/solution/solution_user.ftl
+++ b/aws/templates/solution/solution_user.ftl
@@ -72,7 +72,6 @@
                         "Policies",
                         context.Policy
                     )
-                    attributeIfContent("Variables", stageVariables)
                 outputs=USER_OUTPUT_MAPPINGS
             /]
         [/#if]

--- a/aws/templates/solution/solution_user.ftl
+++ b/aws/templates/solution/solution_user.ftl
@@ -1,0 +1,111 @@
+[#if componentType == USER_COMPONENT_TYPE]
+
+    [#list requiredOccurrences(
+            getOccurrences(tier, component),
+            deploymentUnit) as occurrence]
+
+        [@cfDebug listMode occurrence false /]
+
+        [#assign core = occurrence.Core ]
+        [#assign resources = occurrence.State.Resources]
+        [#assign solution = occurrence.Configuration.Solution ]
+    
+        [#assign userId = resources["user"].Id ]
+        [#assign userName = resources["user"].Name]
+
+        [#assign userType = solution.Type]
+        [#assign userPasswordLength = solution.GenerateCredentials.CharacterLength ]
+
+        [#assign segmentKMSKey = getReference(formatSegmentCMKId(), ARN_ATTRIBUTE_TYPE)]
+
+        [#assign passwordEncryptionScheme = (solution.GenerateCredentials.EncryptionScheme?has_content)?then(
+            solution.GenerateCredentials.EncryptionScheme?ensure_ends_with(":"),
+            "" )]
+
+        [#assign encryptedPassword = (
+            getExistingReference(
+                userId, 
+                PASSWORD_ATTRIBUTE_TYPE)
+            )?remove_beginning(
+                passwordEncryptionScheme
+            )]
+
+        [#if deploymentSubsetRequired(USER_COMPONENT_TYPE, true)]
+            [@cfResource
+                mode=listMode
+                id=userId
+                type="AWS::IAM::User"
+                properties=
+                    {
+                        "UserName" : userName
+                    }
+                outputs=USER_OUTPUT_MAPPINGS
+            /]
+        [/#if]
+
+        [#if deploymentSubsetRequired("epilogue", false)]
+
+            [#assign credentialsPseudoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-credentials-pseudo-stack.json\"" ]
+            [@cfScript
+                mode=listMode
+                content=
+                [
+                    "case $\{STACK_OPERATION} in",
+                    "  create|update)"
+                ] +
+                ( userType == "System" && !(encryptedPassword?has_content))?then(
+                    [
+                        "# Generate IAM AccessKey",
+                        "function generate_iam_accesskey() {",
+                        "info \"Generating IAM AccessKey... \"",
+                        "access_key=\"$(create_iam_accesskey" +
+                        " \"" + region + "\" " +
+                        " \"" + userName + "\" )\"",
+                        "encrypted_secret_key=\"$(encrypt_kms_string" +
+                        " \"" + region + "\" " +
+                        " \"$\{access_key[1]}\" " +
+                        " \"" + segmentKMSKey + "\" || return $?)\"",
+                        "create_pseudo_stack" + " " +
+                        "\"IAM User AccessKey\"" + " " +
+                        "\"$\{password_pseudo_stack_file}\"" + " " +
+                        "\"" + userId + "Xusername\" \"$\{access_key[0]}\" " +
+                        "\"" + userId + "Xpassword\" \"$\{encrypted_secret_key}\" || return $?",
+                        "}",
+                        "password_pseudo_stack_file=" + credentialsPseudoStackFile,
+                        "generate_iam_accesskey || return $?"
+                    ],
+                    []) +
+                ( userType == "User" && !(encryptedPassword?has_content) )?then(
+                    [
+                        "# Generate User Password",
+                        "function generate_user_password() {",
+                        "info \"Generating User Password... \"",
+                        "user_password=\"$(generateComplexString" +
+                        " \"" + userPasswordLength + "\" )\"",
+                        "encrypted_user_password=\"$(encrypt_kms_string" +
+                        " \"" + region + "\" " +
+                        " \"$\{user_password}\" " +
+                        " \"" + segmentKMSKey + "\" || return $?)\"",
+                        "info \"Setting User Password... \"",
+                        "set_iam_userpassword" +
+                        " \"" + region + "\" " +
+                        " \"" + userName + "\" " +
+                        " \"$\{user_password}\" || return $?",
+                        "create_pseudo_stack" + " " +
+                        "\"IAM User Password\"" + " " +
+                        "\"$\{password_pseudo_stack_file}\"" + " " +
+                        "\"" + userId + "Xgeneratedpassword\" \"$\{encrypted_user_password}\" || return $?",
+                        "}",
+                        "password_pseudo_stack_file=" + credentialsPseudoStackFile,
+                        "generate_user_password || return $?"
+                    ],
+                []) +
+                [            
+                    "       ;;",
+                    "       esac"
+                ]
+            /]
+        [/#if]
+
+    [/#list]
+[/#if]

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -701,6 +701,36 @@ function encrypt_kms_string() {
   aws --region "${region}" kms encrypt --key-id "${kms_key_id}" --plaintext "${value}" --query CiphertextBlob --output text
 }
 
+# -- IAM --
+function create_iam_accesskey() {
+  local region="$1"; shift
+  local username="$1"; shift 
+
+  accesskey="$(aws --region "${region}" iam create-access-key --user-name "${username}" )" || return $?
+
+  if [[ -z "${accesskey}" ]]; then  
+    access_key_id = "$( echo "${accesskey}" | jq -r '.AccessKey.AccessKeyId')"
+    secret_access_key = "$( echo "${accesskey}" | jq -r '.AccessKey.SecretAccessKey')"
+
+    encry
+
+    echo "${access_key_id} ${secret_access_key}"
+    return 0
+  
+  else
+    fatal "Could not generate accesskey for ${username}"
+    return 255
+  fi
+}
+
+
+function set_iam_userpassword() {
+  local region="$1"; shift
+  local username="$1"; shift 
+  local password="$1"; shift
+
+  aws --region "${region}" iam  update-login-profile --user-name "${username}" --password "${password}" --no-password-reset-required || return $?
+}
 # -- Cognito --
 
 function update_cognito_userpool() {


### PR DESCRIPTION
Adds the ability to create users as a solution level component. 

Users have two types:
- system - generates an IAM Access/Secret key only
- user - generates and sets a Password only 

secrets and passwords are encrypted using the segment encryption key and stored in a pseudo stack 