### PR TITLE
Allow treating of runId as significant

### DIFF
--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -391,6 +391,12 @@ function process_template() {
           existing_configuration_reference="$( jq -r ".Metadata.ConfigurationReference | select(.!=null)" < "${output_file}" )"
           [[ -n "${existing_configuration_reference}" ]] && sed_patterns+=("-e" "s/${existing_configuration_reference}//g")
 
+          if [[ -z "${TREAT_RUN_ID_DIFFERENCES_AS_SIGNIFICANT}" ]]; then
+            sed_patterns+=("-e" "s/${run_id}//g")
+            existing_run_id="$( jq -r ".Metadata.RunId | select(.!=null)" < "${output_file}" )"
+            [[ -n "${existing_run_id}" ]] && sed_patterns+=("-e" "s/${existing_run_id}//g")
+          fi
+
           cat "${template_result_file}" | jq --indent 1 "${jq_pattern}" | sed "${sed_patterns[@]}" > "${template_result_file}-new"
           cat "${output_file}" | jq --indent 1 "${jq_pattern}" | sed "${sed_patterns[@]}" > "${template_result_file}-existing"
 

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -296,7 +296,7 @@
                             getLocalFileScript(
                                 "configFiles",
                                 "$\{CONFIG}",
-                                "config.json"
+                                "config_" + runId + ".json"
                             ) +
                             syncFilesToBucketScript(
                                 "configFiles",

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -342,10 +342,11 @@
                     context.DefaultCoreVariables || asFile
                 ) +
                 valueIfTrue(
-                    { "SETTINGS_FILE" : "config/config.json"},
+                    { "SETTINGS_FILE" : "config/config" + runId + ".json"},
                     asFile,
                     valueIfTrue(
-                        getSettingsAsEnvironment(occurrence.Configuration.Settings.Build),
+                        getSettingsAsEnvironment(occurrence.Configuration.Settings.Build) +
+                        { "RUN_ID" : runId },
                         context.DefaultCoreVariables
                     ) +
                     valueIfTrue(

--- a/aws/templates/resource/start.ftl
+++ b/aws/templates/resource/start.ftl
@@ -644,7 +644,8 @@
                   {
                       "Prepared" : .now?iso_utc,
                       "RequestReference" : requestReference,
-                      "ConfigurationReference" : configurationReference
+                      "ConfigurationReference" : configurationReference,
+                      "RunId" : runId
                   } +
                   attributeIfContent("CostCentre", accountObject.CostCentre!""),
               "Resources" : templateResources,


### PR DESCRIPTION
Include the runId as metadata in every template

Treate runId differences as not significant unless specifically
requested.

Update "config as file" support to include runId in the S3 object to
trigger code updates when the config file contents change (assuming the
request asks for them to be treated as significant).

Align lambda code with the config as file changes.

NOTE: the api-gateway template already uses the runId to trigger redeploys
so will automatically be affected by the same switch flagging runId
differences as significant.