### PR TITLE
Add awslogs agent support for Cloudwatch Ec2 Logging

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1360,5 +1360,106 @@
         }
       }
     }
+  },
+  "LogFiles" : {
+    "/var/log/dmesg" : {
+      "FilePath" : "/var/log/dmesg"
+    },
+    "/var/log/messages" : {
+      "FilePath" : "/var/log/messages",
+      "TimeFormat" : "%b %d %H:%M:%S"
+    },
+    "/var/log/secure" : {
+      "FilePath" : "/var/log/secure",
+      "TimeFormat" : "%b %d %H:%M:%S"
+    },
+    "/var/log/cron" : {
+      "FilePath" : "/var/log/cron",
+      "TimeFormat" : "%b %d %H:%M:%S"
+    },
+    "/var/log/cloud-init.log" : {
+      "FilePath" : "/var/log/cloud-init.log",
+      "TimeFormat" : "%b %d %H:%M:%S"
+    },
+    "/var/log/cloud-init-output.log" : {
+      "FilePath" : "/var/log/cloud-init-output.log",
+      "TimeFormat" : "%b %d %H:%M:%S"
+    },
+    "/var/log/audit/audit.log" : {
+      "FilePath" : "/var/log/audit/audit.log",
+      "MultiLinePattern" : "^type"
+    },
+    "/var/log/amazon/ssm/amazon-ssm-agent.log" : {
+      "FilePath" : "/var/log/amazon/ssm/amazon-ssm-agent.log",
+      "MultiLinePattern" : "^INFO"
+    },
+    "/var/log/aide/aide.log" : {
+      "FilePath" : "/var/log/aide/aide.log",
+      "TimeFormat" : "%b %d %H:%M:%S"
+    },
+    "/var/log/docker" : {
+      "FilePath" : "/var/log/docker",
+      "TimeFormat" : "%b %d %H:%M:%S"
+    },
+    "/var/log/ecs/ecs-init.log" : {
+      "FilePath" : "/var/log/ecs/ecs-init.log",
+      "TimeFormat" : "%b %d %H:%M:%S"
+    },
+    "/var/log/ecs/ecs-agent.log" : {
+      "FilePath" : "/var/log/ecs/ecs-agent.log",
+      "TimeFormat" : "%b %d %H:%M:%S"
+    },
+    "/var/log/ecs/audit.log" : {
+      "FilePath" : "/var/log/ecs/audit.log",
+      "TimeFormat"  : "%b %d %H:%M:%S"
+    }
+  },
+  "LogFileGroups" : {
+    "security" : {
+      "LogFiles" : [
+        "/var/log/secure",
+        "/var/log/audit/audit.log",
+        "/var/log/aide/aide.log"
+      ]
+    },
+    "system" : {
+      "LogFiles" : [
+        "/var/log/dmesg",
+        "/var/log/messages",
+        "/var/log/cron"
+      ]
+    },
+    "docker" : {
+      "LogFiles" : [
+        "/var/log/docker"
+      ]
+    },
+    "aws-ecs" : {
+      "LogFiles" : [
+        "/var/log/ecs/ecs-init.log",
+        "/var/log/ecs/ecs-agent.log",
+        "/var/log/ecs/audit.log"
+      ]
+    },
+    "aws-system" : {
+      "LogFiles" : [
+        "/var/log/cloud-init.log",
+        "/var/log/cloud-init-output.log",
+        "/var/log/amazon/ssm/amazon-ssm-agent.log" 
+      ]
+    }
+  },
+  "LogFileProfiles" : { 
+    "default" : {
+      "EC2" : {
+        "LogFileGroups" : ["system", "aws-system", "security", "docker"]
+      },
+      "ComputeCluster" : {
+        "LogFileGroups" : ["system", "aws-system", "security", "docker"]
+      },
+      "ECS" : {
+        "LogFileGroups" : ["system", "aws-system", "security", "docker", "aws-ecs"]
+      }
+    }
   }
 }

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -125,7 +125,8 @@
                             s3ReadPermission(codeBucket) +
                             s3ListPermission(operationsBucket) +
                             s3WritePermission(operationsBucket, "DOCKERLogs") +
-                            s3WritePermission(operationsBucket, "Backups"),
+                            s3WritePermission(operationsBucket, "Backups") +
+                            cwLogsProducePermission(computeClusterLogGroupName),
                             "basic")
                     ] + targetGroupPermission?then(
                         [

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -14,13 +14,17 @@
 
         [#assign dockerHost = solution.DockerHost]
 
-        [#assign computeClusterRoleId = resources["role"].Id ]
-        [#assign computeClusterInstanceProfileId = resources["instanceProfile"].Id ]
-        [#assign computeClusterAutoScaleGroupId = resources["autoScaleGroup"].Id ]
-        [#assign computeClusterAutoScaleGroupName = resources["autoScaleGroup"].Name ]
-        [#assign computeClusterLaunchConfigId = resources["launchConfig"].Id ]
-        [#assign computeClusterSecurityGroupId = resources["securityGroup"].Id ]
-        [#assign computeClusterSecurityGroupName = resources["securityGroup"].Name ]
+        [#assign computeClusterRoleId               = resources["role"].Id ]
+        [#assign computeClusterInstanceProfileId    = resources["instanceProfile"].Id ]
+        [#assign computeClusterAutoScaleGroupId     = resources["autoScaleGroup"].Id ]
+        [#assign computeClusterAutoScaleGroupName   = resources["autoScaleGroup"].Name ]
+        [#assign computeClusterLaunchConfigId       = resources["launchConfig"].Id ]
+        [#assign computeClusterSecurityGroupId      = resources["securityGroup"].Id ]
+        [#assign computeClusterSecurityGroupName    = resources["securityGroup"].Name ]
+        [#assign computeClusterLogGroupId           = resources["lg"].Id]
+        [#assign computeClusterLogGroupName        = resources["lg"].Name]
+
+        [#assign logFileProfile = getLogFileProfile(tier, component, "ComputeCluster")]
 
         [#assign targetGroupPermission = false ]
         [#assign targetGroups = [] ]
@@ -233,6 +237,25 @@
         [/#list]
 
         [#assign configSets += getInitConfigScriptsDeployment(scriptsFile, environmentVariables, solution.UseInitAsService, false)]
+
+        [#assign logProfileGroupPrefix = formatLogFileGroupName( computeClusterLogGroupName )]
+        [#list logFileProfile.LogFileGroups as logGroup ]
+            [#assign logProfileGroupId = formatLogFileGroupId( computeClusterLogGroupId, logGroup) ]
+            [#assign logProfileGroupName = formatPath(false, logProfileGroupPrefix, logGroup)]
+
+            [#if deploymentSubsetRequired("lg", true) && isPartOfCurrentDeploymentUnit(logProfileGroupId) ]
+                [@createLogGroup 
+                    mode=listMode
+                    id=logProfileGroupId
+                    name=logProfileGroupName /]
+            [/#if]
+        [/#list]
+
+        [#assign configSets +=
+            getInitConfigLogAgent(
+                logFileProfile,
+                logProfileGroupPrefix
+            )]
 
         [#if deploymentSubsetRequired(COMPUTECLUSTER_COMPONENT_TYPE, true)]
 

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1741,6 +1741,23 @@
     [/#if]
 [/#function]
 
+[#function getLogFileProfile tier component type extensions... ]
+    [#local tc = formatComponentShortName(
+                    tier,
+                    component,
+                    extensions)]
+    [#local defaultProfile = "default"]
+    [#if (component[type].LogFileProfile)??]
+        [#return component[type].LogFileProfile]
+    [/#if]
+    [#if (logFileProfiles[defaultProfile][tc])??]
+        [#return logFileProfiles[defaultProfile][tc]]
+    [/#if]
+    [#if (logFileProfiles[defaultProfile][type])??]
+        [#return logFileProfiles[defaultProfile][type]]
+    [/#if]
+[/#function]
+
 [#-- Get storage settings --]
 [#function getStorage tier component type extensions...]
     [#local tc = formatComponentShortName(

--- a/aws/templates/id/id_computecluster.ftl
+++ b/aws/templates/id/id_computecluster.ftl
@@ -81,6 +81,11 @@
                     "Name" : core.FullName,
                     "Type" : AWS_EC2_AUTO_SCALE_GROUP_RESOURCE_TYPE
                 },
+                "lg" : {             
+                    "Id" : formatLogGroupId(core.Id),
+                    "Name" : core.FullAbsolutePath,
+                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+                },
                 "launchConfig" : {
                     "Id" : formatResourceId(
                                 AWS_EC2_LAUNCH_CONFIG_RESOURCE_TYPE,

--- a/aws/templates/id/id_cw.ftl
+++ b/aws/templates/id/id_cw.ftl
@@ -12,6 +12,21 @@
                 ids)]
 [/#function]
 
+[#function formatLogFileGroupId resourceId extensions... ]
+    [#return 
+        formatLogGroupId( resourceId,
+                          "logfile",
+                          extensions)]
+[/#function]
+
+[#function formatLogFileGroupName resourceName extensions... ]
+    [#return
+        formatPath( false, 
+                    resourceName, 
+                    "logfile", 
+                    extensions)]
+[/#function]
+
 [#function formatDependentLogGroupId resourceId extensions...]
     [#return formatDependentResourceId(
                 AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,

--- a/aws/templates/id/id_ec2.ftl
+++ b/aws/templates/id/id_ec2.ftl
@@ -158,6 +158,11 @@
                     "Id" : formatComponentRoleId(core.Tier, core.Component),
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
                 },
+                "lg" : {             
+                    "Id" : formatLogGroupId(core.Id),
+                    "Name" : core.FullAbsolutePath,
+                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+                },
                 "Zones" : zoneResources
             },
             "Attributes" : {

--- a/aws/templates/policy/policy_cw.ftl
+++ b/aws/templates/policy/policy_cw.ftl
@@ -1,6 +1,11 @@
 [#-- Cloud Watch --]
 
-[#function cwLogsProducePermission ]
+[#function cwLogsProducePermission logGroupName="" ]
+    [#local logGroupArn = logGroupName?has_content?then(
+                    formatRegionalArn(
+                            "log-group",
+                            logGroupName + "*"),
+                    "")]
     [#return
         [
             getPolicyStatement(
@@ -10,7 +15,8 @@
                     "logs:PutLogEvents",
                     "logs:DescribeLogGroups",
                     "logs:DescribeLogStreams"
-                ])
+                ],
+                logGroupArn)
         ]
     ]
 [/#function]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -209,6 +209,9 @@
 [#assign processors = blueprintObject.Processors]
 [#assign ports = blueprintObject.Ports]
 [#assign portMappings = blueprintObject.PortMappings]
+[#assign logFiles = blueprintObject.LogFiles ]
+[#assign logFileGroups = blueprintObject.LogFileGroups]
+[#assign logFileProfiles = blueprintObject.LogFileProfiles ]
 
 [#-- Regions --]
 [#if region?has_content]

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -200,7 +200,8 @@
                             s3ReadPermission(codeBucket) +
                             s3ListPermission(operationsBucket) +
                             s3WritePermission(operationsBucket, "DOCKERLogs") +
-                            s3WritePermission(operationsBucket, "Backups"),
+                            s3WritePermission(operationsBucket, "Backups") + 
+                            cwLogsProducePermission(ec2LogGroupName),
                             "basic")
                     ] + targetGroupPermission?then(
                         [

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -20,6 +20,12 @@
         [#assign ec2SecurityGroupName   = resources["sg"].Name]
         [#assign ec2RoleId              = resources["ec2Role"].Id]
         [#assign ec2InstanceProfileId   = resources["instanceProfile"].Id]
+        [#assign ec2LogGroupId          = resources["lg"].Id]
+        [#assign ec2LogGroupName        = resources["lg"].Name]
+
+        [#assign processorProfile       = getProcessor(tier, component, "EC2")]
+        [#assign storageProfile         = getStorage(tier, component, "EC2")]
+        [#assign logFileProfile         = getLogFileProfile(tier, component, "EC2")]
 
         [#assign targetGroupRegistrations = {}]
         [#assign targetGroupPermission = false ]
@@ -206,6 +212,25 @@
             /]
         [/#if]
 
+        [#assign logProfileGroupPrefix = formatLogFileGroupName( ec2LogGroupName )]
+        [#list logFileProfile.LogFileGroups as logGroup ]
+            [#assign logProfileGroupId = formatLogFileGroupId( ec2LogGroupId, logGroup) ]
+            [#assign logProfileGroupName = formatPath(false, logProfileGroupPrefix, logGroup)]
+
+            [#if deploymentSubsetRequired("lg", true) && isPartOfCurrentDeploymentUnit(logProfileGroupId) ]
+                [@createLogGroup 
+                    mode=listMode
+                    id=logProfileGroupId
+                    name=logProfileGroupName /]
+            [/#if]
+        [/#list]
+
+        [#assign configSets +=
+            getInitConfigLogAgent(
+                logFileProfile,
+                logProfileGroupPrefix
+            )]
+
         [#if deploymentSubsetRequired("ec2", true)]
 
             [@createSecurityGroup
@@ -236,8 +261,6 @@
                     [#assign zoneEc2EIPId               = zoneResources[zone.Id]["ec2EIP"].Id]
                     [#assign zoneEc2EIPAssociationId    = zoneResources[zone.Id]["ec2EIPAssociation"].Id]
 
-                    [#assign processorProfile = getProcessor(tier, component, "EC2")]
-                    [#assign storageProfile = getStorage(tier, component, "EC2")]
                     [#assign updateCommand = "yum clean all && yum -y update"]
                     [#assign dailyUpdateCron = 'echo \"59 13 * * * ${updateCommand} >> /var/log/update.log 2>&1\" >crontab.txt && crontab crontab.txt']
                     [#if environmentId == "prod"]

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -25,6 +25,8 @@
         [#assign defaultLogDriver = solution.LogDriver ]
         [#assign fixedIP = solution.FixedIP ]
 
+        [#assign logFileProfile = getLogFileProfile(tier, component, "ECS")]
+
         [#assign configSetName = componentType ]
         [#assign configSets =  
                 getInitConfigDirectories() + 
@@ -74,6 +76,25 @@
                 id=ecsLogGroupId
                 name=ecsLogGroupName /]
         [/#if]
+
+        [#assign logProfileGroupPrefix = formatLogFileGroupName( ecsLogGroupName )]
+        [#list logFileProfile.LogFileGroups as logGroup ]
+            [#assign logProfileGroupId = formatLogFileGroupId( ecsLogGroupId, logGroup) ]
+            [#assign logProfileGroupName = formatPath(false, logProfileGroupPrefix, logGroup)]
+
+            [#if deploymentSubsetRequired("lg", true) && isPartOfCurrentDeploymentUnit(logProfileGroupId) ]
+                [@createLogGroup 
+                    mode=listMode
+                    id=logProfileGroupId
+                    name=logProfileGroupName /]
+            [/#if]
+        [/#list]
+
+        [#assign configSets +=
+            getInitConfigLogAgent(
+                logFileProfile,
+                logProfileGroupPrefix
+            )]
             
         [#if deploymentSubsetRequired("ecs", true)]
     

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -54,7 +54,8 @@
                                 s3ReadPermission(codeBucket) +
                                 s3ListPermission(operationsBucket) +
                                 s3WritePermission(operationsBucket, getSegmentBackupsFilePrefix()) +
-                                s3WritePermission(operationsBucket, "DOCKERLogs"),
+                                s3WritePermission(operationsBucket, "DOCKERLogs") + 
+                                cwLogsProducePermission(ecsLogGroupName),
                             "docker")
                     ]
             /]


### PR DESCRIPTION
Adds support for the provisioning of the awslogs agent to enable Ec2 based logging to Cloudwatch. 

LogFiles are grouped into LogFileGroups based on the logging content, with the defaults as system, security, docker, aws-system, aws-ecs 

Each ec2 based component has a LogProfile assigned to it which is a list of LogFileGroups. 

The awslogs agent is installed as part of the cfn-init process and the config file is deployed as part of this process. 

