### PR TITLE
Add SES SMTP Password Generation

### DIFF
--- a/aws/templates/application/application_user.ftl
+++ b/aws/templates/application/application_user.ftl
@@ -131,11 +131,17 @@
                         " \"" + region + "\" " +
                         " \"$\{access_key_array[1]}\" " +
                         " \"" + segmentKMSKey + "\" || return $?)\"",
+                        "smtp_password=\"$(get_iam_smtp_password \"$\{access_key_array[1]}\" )",
+                        "encrypted_smtp_password=\"$(encrypt_kms_string" +
+                        " \"" + region + "\" " +
+                        " \"$\{smtp_password}\" " +
+                        " \"" + segmentKMSKey + "\" || return $?)\"",
                         "create_pseudo_stack" + " " +
                         "\"IAM User AccessKey\"" + " " +
                         "\"$\{password_pseudo_stack_file}\"" + " " +
                         "\"" + userId + "Xusername\" \"$\{access_key_array[0]}\" " +
-                        "\"" + userId + "Xpassword\" \"$\{encrypted_secret_key}\" || return $?",
+                        "\"" + userId + "Xpassword\" \"$\{encrypted_secret_key}\" " + 
+                        "\"" + userId + "Xkey\" \"$\{encrypted_smtp_password}\" || return $?",
                         "}",
                         "password_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-creds-system-pseudo-stack.json\" ",
                         "generate_iam_accesskey || return $?"

--- a/aws/templates/id/id_user.ftl
+++ b/aws/templates/id/id_user.ftl
@@ -61,7 +61,8 @@
                 "USERNAME" : getExistingReference(userId),
                 "ARN" : userArn,
                 "ACCESS_KEY" : getExistingReference(userId, USER_ATTRIBUTE_TYPE),
-                "SECRET_KEY" : getExistingReference(userId, PASSWORD_ATTRIBUTE_TYPE)?ensure_starts_with(encryptionScheme)
+                "SECRET_KEY" : getExistingReference(userId, PASSWORD_ATTRIBUTE_TYPE)?ensure_starts_with(encryptionScheme),
+                "SES_SMTP_PASSWORD" : getExistingReference(userId, KEY_ATTRIBUTE_TYPE)?ensure_starts_with(encryptionScheme)
             },
             "Roles" : {
                 "Inbound" : {

--- a/aws/templates/id/start.ftl
+++ b/aws/templates/id/start.ftl
@@ -120,6 +120,7 @@
 [#assign ALLOCATION_ATTRIBUTE_TYPE = "id" ]
 [#assign CANONICAL_ID_ATTRIBUTE_TYPE = "canonicalid" ]
 [#assign CERTIFICATE_ATTRIBUTE_TYPE = "certificate" ]
+[#assign KEY_ATTRIBUTE_TYPE = "key" ]
 [#assign QUALIFIER_ATTRIBUTE_TYPE = "qualifier" ]
 [#assign ROOT_ATTRIBUTE_TYPE = "root" ]
 [#assign PORT_ATTRIBUTE_TYPE = "port" ]

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -721,6 +721,13 @@ function create_iam_accesskey() {
   fi
 }
 
+function get_iam_smtp_password() { 
+  local secretkey="$1"; shift
+
+  (echo -en "\x02"; echo -n 'SendRawEmail' \
+  | openssl dgst -sha256 -hmac $secretkey -binary) \
+  | openssl enc -base64
+}
 
 function set_iam_userpassword() {
   local region="$1"; shift


### PR DESCRIPTION
The SES SMTP password is made from a hash of a users IAM SECRET Access key 

This PR adds this hashed smtp password into the attributes of a user application component.

This does not apply SES permissions just creates the password that is required 