### PR TITLE
remove underscore from config filename

### DIFF
--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -342,7 +342,7 @@
                     context.DefaultCoreVariables || asFile
                 ) +
                 valueIfTrue(
-                    { "SETTINGS_FILE" : "config/config" + runId + ".json"},
+                    { "SETTINGS_FILE" : "config/config_" + runId + ".json"},
                     asFile,
                     valueIfTrue(
                         getSettingsAsEnvironment(occurrence.Configuration.Settings.Build) +


### PR DESCRIPTION
Underscore symbol is escaped in the environment variable `SETTINGS_FILE` value, so a filename shall not contain it. 