### PR TITLE
consolidate instance logs into single log group

### DIFF
--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -239,22 +239,17 @@
 
         [#assign configSets += getInitConfigScriptsDeployment(scriptsFile, environmentVariables, solution.UseInitAsService, false)]
 
-        [#list logFileProfile.LogFileGroups as logGroup ]
-            [#assign logProfileGroupId = formatLogFileGroupId(computeClusterLogGroupId, logGroup) ]
-            [#assign logProfileGroupName = formatLogFileGroupName(computeClusterLogGroupName, logGroup)]
-
-            [#if deploymentSubsetRequired("lg", true) && isPartOfCurrentDeploymentUnit(logProfileGroupId) ]
-                [@createLogGroup 
-                    mode=listMode
-                    id=logProfileGroupId
-                    name=logProfileGroupName /]
-            [/#if]
-        [/#list]
+        [#if deploymentSubsetRequired("lg", true) && isPartOfCurrentDeploymentUnit(computeClusterLogGroupId) ]
+            [@createLogGroup 
+                mode=listMode
+                id=computeClusterLogGroupId
+                name=computeClusterLogGroupName /]
+        [/#if]
 
         [#assign configSets +=
             getInitConfigLogAgent(
                 logFileProfile,
-                formatLogFileGroupName(ecsLogGroupName)
+                computeClusterLogGroupName
             )]
 
         [#if deploymentSubsetRequired(COMPUTECLUSTER_COMPONENT_TYPE, true)]

--- a/aws/templates/id/id_cw.ftl
+++ b/aws/templates/id/id_cw.ftl
@@ -12,20 +12,6 @@
                 ids)]
 [/#function]
 
-[#function formatLogFileGroupId resourceId extensions... ]
-    [#return 
-        formatLogGroupId( resourceId,
-                          "logfile",
-                          extensions)]
-[/#function]
-
-[#function formatLogFileGroupName resourceName extensions... ]
-    [#return
-        formatAbsolutePath( resourceName, 
-                            "logfile", 
-                                extensions)]
-[/#function]
-
 [#function formatDependentLogGroupId resourceId extensions...]
     [#return formatDependentResourceId(
                 AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -258,6 +258,11 @@
                     "Id" : formatLogGroupId(core.Id),
                     "Name" : core.FullAbsolutePath,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+                },
+                "lgInstanceLog" : {
+                    "Id" : formatLogGroupId(core.Id, "instancelog"),
+                    "Name" : formatAbsolutePath( core.FullAbsolutePath, "instancelog"),
+                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
                 }
             },
             "Attributes" : {

--- a/aws/templates/resource/resource_ec2.ftl
+++ b/aws/templates/resource/resource_ec2.ftl
@@ -334,7 +334,7 @@
     ]
 [/#function]
 
-[#function getInitConfigLogAgent logProfile logGroupPrefix ignoreErrors=false ]
+[#function getInitConfigLogAgent logProfile logGroupName ignoreErrors=false ]
     [#local logContent = [
         "[general]\n",
         "state_file = /var/lib/awslogs/agent-state\n",
@@ -343,7 +343,6 @@
 
     [#list logProfile.LogFileGroups as logFileGroup ]
         [#local logGroup = logFileGroups[logFileGroup] ]
-        [#local logGroupName = logGroupPrefix + "/" + logGroup.Name ]
         [#list logGroup.LogFiles as logFile ]
             [#local logFileDetails = logFiles[logFile] ]
             [#local logContent +=

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -213,22 +213,17 @@
             /]
         [/#if]
 
-        [#list logFileProfile.LogFileGroups as logGroup ]
-            [#assign logProfileGroupId = formatLogFileGroupId( ec2LogGroupId, logGroup) ]
-            [#assign logProfileGroupName = formatLogFileGroupName(ec2LogGroupName, logGroup)]
-
-            [#if deploymentSubsetRequired("lg", true) && isPartOfCurrentDeploymentUnit(logProfileGroupId) ]
-                [@createLogGroup 
-                    mode=listMode
-                    id=logProfileGroupId
-                    name=logProfileGroupName /]
-            [/#if]
-        [/#list]
+        [#if deploymentSubsetRequired("lg", true) && isPartOfCurrentDeploymentUnit(ec2LogGroupId) ]
+            [@createLogGroup 
+                mode=listMode
+                id=ec2LogGroupId
+                name=ec2LogGroupName /]
+        [/#if]
 
         [#assign configSets +=
             getInitConfigLogAgent(
                 logFileProfile,
-                formatLogFileGroupName(ecsLogGroupName)
+                ec2LogGroupName
             )]
 
         [#if deploymentSubsetRequired("ec2", true)]

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -22,6 +22,8 @@
         [#assign ecsSecurityGroupId = resources["securityGroup"].Id ]
         [#assign ecsLogGroupId = resources["lg"].Id ]
         [#assign ecsLogGroupName = resources["lg"].Name ]
+        [#assign ecsInstanceLogGroupId = resources["lgInstanceLog"].Id]
+        [#assign ecsInstanceLogGroupName = resources["lgInstanceLog"].Name]
         [#assign defaultLogDriver = solution.LogDriver ]
         [#assign fixedIP = solution.FixedIP ]
 
@@ -78,22 +80,17 @@
                 name=ecsLogGroupName /]
         [/#if]
 
-        [#list logFileProfile.LogFileGroups as logGroup ]
-            [#assign logProfileGroupId = formatLogFileGroupId( ecsLogGroupId, logGroup) ]
-            [#assign logProfileGroupName = formatLogFileGroupName(ecsLogGroupName, logGroup)]
-
-            [#if deploymentSubsetRequired("lg", true) && isPartOfCurrentDeploymentUnit(logProfileGroupId) ]
-                [@createLogGroup 
-                    mode=listMode
-                    id=logProfileGroupId
-                    name=logProfileGroupName /]
-            [/#if]
-        [/#list]
+        [#if deploymentSubsetRequired("lg", true) && isPartOfCurrentDeploymentUnit(ecsInstanceLogGroupId) ]
+            [@createLogGroup 
+                mode=listMode
+                id=ecsInstanceLogGroupId
+                name=ecsInstanceLogGroupName /]
+        [/#if]
 
         [#assign configSets +=
             getInitConfigLogAgent(
                 logFileProfile,
-                formatLogFileGroupName(ecsLogGroupName)
+                ecsInstanceLogGroupName
             )]
             
         [#if deploymentSubsetRequired("ecs", true)]


### PR DESCRIPTION
After deploying the existing configuration it shows that searching logs when they are split into groups is going to be difficult. Instead the logs will be consolidated down to a single log group which allows for the logs to be searched across an entire component. 

The exception is the ecs logs which have a dedicated instancelogs log group to seperate container logs from host logs. 