### PR TITLE
Support for redirects and fixed response on ALB

### DIFF
--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -99,15 +99,15 @@
                     },
                     {
                         "Name" : "Host",
-                        "Default" : "#{host}"
+                        "Default" : "#\{host}"
                     },
                     {
                         "Name" : "Path",
-                        "Default" : "#{path}"
+                        "Default" : "#\{path}"
                     },
                     {
                         "Name" : "Query",
-                        "Default" : "#{query}"
+                        "Default" : "#\{query}"
                     },
                     {
                         "Name" : "Permanent",

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -128,7 +128,7 @@
                     },
                     {
                         "Name" : "StatusCode",
-                        "Default" : 200
+                        "Default" : 404
                     }
                 ]
             }

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -85,6 +85,52 @@
                         "Default" : 604800
                     }
                 ]
+            },
+            {
+                "Name" : "Redirect",
+                "Children" : [
+                    {
+                        "Name" : "Protocol",
+                        "Default" : "https"
+                    },
+                    {
+                        "Name" : "Port",
+                        "Default" : "443"
+                    },
+                    {
+                        "Name" : "Host",
+                        "Default" : "#{host}"
+                    },
+                    {
+                        "Name" : "Path",
+                        "Default" : "#{path}"
+                    },
+                    {
+                        "Name" : "Query",
+                        "Default" : "#{query}"
+                    },
+                    {
+                        "Name" : "Permanent",
+                        "Default" : false
+                    }
+                ]
+            },
+            {
+                "Name" : "Fixed",
+                "Children" : [
+                    {
+                        "Name" : "Message",
+                        "Default" : "This application is currently unavailable. Please try again later."
+                    },
+                    {
+                        "Name" : "ContentType",
+                        "Default" : "text/plain"
+                    },
+                    {
+                        "Name" : "StatusCode",
+                        "Default" : 200
+                    }
+                ]
             }
         ]
     }]

--- a/aws/templates/resource/resource_lb.ftl
+++ b/aws/templates/resource/resource_lb.ftl
@@ -216,11 +216,11 @@
         {
             "Type": "redirect",
             "RedirectConfig": {
-                "Protocol": "string",
-                "Port": "string",
-                "Host": "string",
-                "Path": "string",
-                "Query": "string",
+                "Protocol": protocol,
+                "Port": port,
+                "Host": host,
+                "Path": path,
+                "Query": query,
                 "StatusCode": valueIfTrue("HTTP_301", permanent, "HTTP_302")
             }
         } +

--- a/aws/templates/resource/resource_lb.ftl
+++ b/aws/templates/resource/resource_lb.ftl
@@ -201,25 +201,53 @@
     /]
 [/#macro]
 
-[#function getListenerRuleForwardAction targetGroupId]
+[#function getListenerRuleForwardAction targetGroupId order=""]
     [#return
-        [
-            {
-                "Type": "forward",
-                "TargetGroupArn": getReference(targetGroupId)
+        {
+            "Type": "forward",
+            "TargetGroupArn": getReference(targetGroupId, ARN_ATTRIBUTE_TYPE)
+        } +
+        attributeIfContent("Order", order)
+    ]
+[/#function]
+
+[#function getListenerRuleRedirectAction protocol port host path query permanent=true order=""]
+    [#return
+        {
+            "Type": "redirect",
+            "RedirectConfig": {
+                "Protocol": "string",
+                "Port": "string",
+                "Host": "string",
+                "Path": "string",
+                "Query": "string",
+                "StatusCode": valueIfTrue("HTTP_301", permanent, "HTTP_302")
             }
-        ]
+        } +
+        attributeIfContent("Order", order)
+    ]
+[/#function]
+
+[#function getListenerRuleFixedAction message contentType statusCode order=""]
+    [#return
+        {
+            "Type": "fixed-response",
+            "FixedResponseConfig": {
+                "MessageBody": message,
+                "ContentType": contentType,
+                "StatusCode": statusCode
+            }
+        } +
+        attributeIfContent("Order", order)
     ]
 [/#function]
 
 [#function getListenerRulePathCondition paths]
     [#return
-        [
-            {
-                "Field": "path-pattern",
-                "Values": asArray(paths)
-            }
-        ]
+        {
+            "Field": "path-pattern",
+            "Values": asArray(paths)
+        }
     ]
 [/#function]
 
@@ -231,8 +259,8 @@
         properties=
             {
                 "Priority" : priority,
-                "Actions" : actions,
-                "Conditions": conditions,
+                "Actions" : asArray(actions),
+                "Conditions": asArray(conditions),
                 "ListenerArn" : getReference(listenerId, ARN_ATTRIBUTE_TYPE)
             }
         outputs=ALB_LISTENER_RULE_OUTPUT_MAPPINGS

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -102,6 +102,7 @@
                     [#else]
                         [#assign path = solution.Path ]
                         [#assign listenerRuleRequired = true ]
+                        [#-- Initially assume tg will be required for explicit path --]
                         [#assign targetGroupRequired = true ]
                     [/#if]
                     [#break]
@@ -115,6 +116,7 @@
             [#-- Redirect rule processing --]
             [#if solution.Redirect.Configured]
                 [#assign listenerRuleRequired = true ]
+                [#assign targetGroupRequired = false ]
                 [#assign listenerRuleConfig =
                     {
                         "Conditions" : listenerRuleConditions,
@@ -133,6 +135,7 @@
             [#-- Fixed rule processing --]
             [#if solution.Fixed.Configured]
                 [#assign listenerRuleRequired = true ]
+                [#assign targetGroupRequired = false ]
                 [#assign fixedMessage = getOccurrenceSettingValue(subOccurrence, ["Fixed", "Message"], true) ]
                 [#assign fixedContentType = getOccurrenceSettingValue(subOccurrence, ["Fixed", "ContentType"], true) ]
                 [#assign fixedStatusCode = getOccurrenceSettingValue(subOccurrence, ["Fixed", "StatusCode"], true) ]
@@ -241,6 +244,7 @@
 
                         [#case SPA_COMPONENT_TYPE]
                             [#assign listenerRuleRequired = true ]
+                            [#assign targetGroupRequired = false ]
                             [#assign listenerRuleConfig =
                                 {
                                     "Conditions" : listenerRuleConditions,

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -6,7 +6,7 @@
             deploymentUnit) as occurrence]
 
         [@cfDebug listMode occurrence false /]
-      
+
         [#assign solution = occurrence.Configuration.Solution ]
         [#assign resources = occurrence.State.Resources ]
 
@@ -24,13 +24,14 @@
             [#if solution.HealthCheckPort?has_content ]
                 [#assign healthCheckPort = ports[solution.HealthCheckPort]]
             [#else]
-                [@cfPreconditionFailed listMode "solution_lb" {} "No health check port provided" /]    
+                [@cfPreconditionFailed listMode "solution_lb" {} "No health check port provided" /]
             [/#if]
         [/#if]
 
         [#assign portProtocols = [] ]
         [#assign classicListeners = []]
         [#assign ingressRules = [] ]
+        [#assign listenerPortsSeen = [] ]
 
         [#list occurrence.Occurrences![] as subOccurrence]
 
@@ -38,72 +39,120 @@
             [#assign solution = subOccurrence.Configuration.Solution ]
             [#assign resources = subOccurrence.State.Resources ]
 
+            [#-- Determine if this is the first mapping for the source port --]
+            [#-- The assumption is that all mappings for a given port share --]
+            [#-- the same listenerId, so the same port number shouldn't be  --]
+            [#-- defined with different names --]
             [#assign listenerId = resources["listener"].Id ]
-            [#assign defaultListener = false]
-    
+            [#assign firstMappingForPort = !listenerPortsSeen?seq_contains(listenerId) ]
+            [#assign listenerPortsSeen =
+                        getUniqueArrayElements(listenerPortsSeen, listenerId) ]
+
+            [#-- Determine the IP whitelisting required --]
             [#assign portIpAddressGroups = solution.IPAddressGroups ]
             [#if !solution.IPAddressGroups?seq_contains("_localnet") && tier.Network.RouteTable != "external" ]
                 [#assign portIpAddressGroups += [ "_localnet"] ]
             [/#if]
-
             [#assign cidrs = getGroupCIDRs(portIpAddressGroups)]
-
             [#assign securityGroupId = resources["sg"].Id]
             [#assign securityGroupName = resources["sg"].Name]
 
-            [#assign targetGroupId = resources["targetgroup"].Id]
-            [#assign targetGroupName = resources["targetgroup"].Name]
-
+            [#-- Check source and destination ports --]
             [#assign mapping = solution.Mapping!core.SubComponent.Name ]
             [#assign source = (portMappings[mapping].Source)!"" ]
             [#assign destination = (portMappings[mapping].Destination)!"" ]
             [#assign sourcePort = (ports[source])!{} ]
             [#assign destinationPort = (ports[destination])!{} ]
 
+            [#if !(sourcePort?has_content && destinationPort?has_content)]
+                [#continue ]
+            [/#if]
+            [#assign portProtocols += [ sourcePort.Protocol ] ]
+            [#assign portProtocols += [ destinationPort.Protocol] ]
+
+            [#-- Rule setup --]
             [#assign priority = solution.Priority + subOccurrence?index ]
-            
+
+            [#assign targetGroupId = resources["targetgroup"].Id]
+            [#assign targetGroupName = resources["targetgroup"].Name]
+            [#assign targetGroupRequired = false ]
+
             [#assign listenerRuleId = resources["listenerRule"].Id ]
             [#assign listenerRuleRequired = false ]
             [#assign listenerRuleConfig = {}]
             [#assign listenerRuleCommand = "createListenerRule" ]
 
-            [#if engine == "application" ]
+            [#-- Path processing --]
+            [#switch engine ]
+                [#case "application"]
+                    [#if solution.Path == "default" ]
+                        [#assign path = "*"]
+                    [#else]
+                        [#assign path = solution.Path ]
+                        [#assign listenerRuleRequired = true ]
+                        [#assign targetGroupRequired = true ]
+                    [/#if]
+                    [#break]
 
-                [#if solution.Path == "default" ]
-                    [#assign defaultListener = true]
-                    [#assign path = "*"]
-                [#else]
-                    [#assign path = solution.Path ]
-                    [#assign listenerRuleRequired = true ]
-                [/#if]
+                [#default]
+                    [#assign path = "" ]
+                    [#break]
+            [/#switch]
+            [#assign listenerRuleConditions = asArray(getListenerRulePathCondition(path)) ]
 
-            [#else]
-                [#assign defaultListener = true]
-                [#assign path = "" ]
+            [#-- Redirect rule processing --]
+            [#if solution.Redirect.Configured && solution.Redirect.Enabled]
+                [#assign listenerRuleRequired = true ]
+                [#assign listenerRuleConfig =
+                    {
+                        "Conditions" : listenerRuleConditions,
+                        "Priority" : priority,
+                        "Actions" : asArray(
+                                        getListenerRuleRedirectAction(
+                                            solution.Redirect.Protocol,
+                                            solution.Redirect.Port,
+                                            solution.Redirect.Host,
+                                            solution.Redirect.Path,
+                                            solution.Redirect.Query,
+                                            solution.Redirect.Permanent))
+                    } ]
             [/#if]
 
-            [#assign listenerRuleConditions = getListenerRulePathCondition(path)]
-
-            [#if !(sourcePort?has_content && destinationPort?has_content)]
-                [#continue ]
+            [#-- Fixed rule processing --]
+            [#if solution.Fixed.Configured && solution.Fixed.Enabled]
+                [#assign listenerRuleRequired = true ]
+                [#assign listenerRuleConfig =
+                    {
+                        "Conditions" : listenerRuleConditions,
+                        "Priority" : priority,
+                        "Actions" : asArray(
+                                        getListenerRuleFixedAction(
+                                            solution.Fixed.Message,
+                                            solution.Fixed.ContentType,
+                                            solution.Fixed.Host))
+                    } ]
             [/#if]
 
-            [#assign portProtocols += [ sourcePort.Protocol ] ]
-            [#assign portProtocols += [ destinationPort.Protocol] ]
-
-            
+            [#-- Certificate details if required --]
             [#assign certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers, sourcePort.Id, sourcePort.Name) ]
             [#assign hostName = getHostName(certificateObject, subOccurrence) ]
             [#assign certificateId = formatDomainCertificateId(certificateObject, hostName) ]
 
-            [#assign targetType = solution.TargetType ]
-
-            [#if !(sourcePort?has_content && destinationPort?has_content)]
-                [#continue ]
-            [/#if]
-
+            [#-- Use presence of links to determine rule required --]
+            [#-- More than one link is an error --]
+            [#assign linkCount = 0 ]
             [#list solution.Links?values as link]
                 [#if link?is_hash]
+                    [#assign linkCount += 1 ]
+                    [#if linkCount > 1 ]
+                        [@cfException
+                            mode=listMode
+                            description="A port mapping can only have a maximum of one link"
+                            context=subOccurrence
+                        /]
+                        [#continue]
+                    [/#if]
+
                     [#assign linkTarget = getLinkTarget(occurrence, link) ]
 
                     [@cfDebug listMode linkTarget false /]
@@ -116,7 +165,7 @@
                     [#assign linkTargetConfiguration = linkTarget.Configuration ]
                     [#assign linkTargetResources = linkTarget.State.Resources ]
                     [#assign linkTargetAttributes = linkTarget.State.Attributes ]
-                    
+
                     [#switch linkTargetCore.Type]
 
                         [#case USERPOOL_COMPONENT_TYPE]
@@ -143,7 +192,7 @@
                             [/#if]
 
                             [#assign listenerRuleRequired = true ]
-                            [#assign listenerRuleConfig = 
+                            [#assign listenerRuleConfig =
                                 {
                                     "Conditions" : listenerRuleConditions,
                                     "Priority" : priority,
@@ -161,36 +210,55 @@
                                             },
                                             "Order" : 1
                                         },
-                                        {
-                                            "Type": "forward",
-                                            "TargetGroupArn" : getReference(targetGroupId, ARN_ATTRIBUTE_TYPE),
-                                            "Order" : 2
-                                        }
+                                        getListenerRuleForwardAction(targetGroupId, 2)
                                     ]
-                                }]  
+                                }]
+                            [#break]
+
+                        [#case SPA_COMPONENT_TYPE]
+                            [#assign listenerRuleRequired = true ]
+                            [#assign listenerRuleConfig =
+                                {
+                                    "Conditions" : listenerRuleConditions,
+                                    "Priority" : priority,
+                                    "Actions" : asArray(
+                                                    getListenerRuleRedirectAction(
+                                                        "https",
+                                                        "443",
+                                                        linkTargetAttributes.FQDN,
+                                                        "",
+                                                        "",
+                                                        false))
+                                } ]
                             [#break]
                     [/#switch]
                 [/#if]
             [/#list]
 
-            [#if engine == "application" || engine == "classic" ]
-                [#if deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
-                    [@createSecurityGroup
-                        mode=listMode
-                        id=securityGroupId
-                        name=securityGroupName
-                        tier=tier
-                        component=component
-                        ingressRules=[ {"Port" : sourcePort.Port, "CIDR" : cidrs} ]/]
+            [#-- Create the security group for the listener --]
+            [#switch engine ]
+                [#case "application"]
+                [#case "classic"]
+                    [#if firstMappingForPort &&
+                        deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
+                        [@createSecurityGroup
+                            mode=listMode
+                            id=securityGroupId
+                            name=securityGroupName
+                            tier=tier
+                            component=component
+                            ingressRules=[ {"Port" : sourcePort.Port, "CIDR" : cidrs} ]/]
 
-                [/#if]
-            [/#if]
+                    [/#if]
+                    [#break]
+            [/#switch]
 
+            [#-- Process the mapping --]
             [#switch engine ]
                 [#case "application"]
                 [#case "network"]
 
-                    [#if defaultListener ]
+                    [#if firstMappingForPort ]
                         [#assign lbSecurityGroupIds += [securityGroupId] ]
                         [#if deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
                             [@createALBListener
@@ -208,7 +276,7 @@
 
                             [#if deploymentSubsetRequired("cli", false)]
 
-                                [@cfCli 
+                                [@cfCli
                                     mode=listMode
                                     id=listenerRuleId
                                     command=listenerRuleCommand
@@ -225,13 +293,13 @@
                                             "case $\{STACK_OPERATION} in",
                                             "  delete)",
                                             "       delete_elbv2_rule" +
-                                            "       \"" + region + "\" " + 
-                                            "       \"" + getExistingReference(listenerRuleId) + "\" " 
+                                            "       \"" + region + "\" " +
+                                            "       \"" + getExistingReference(listenerRuleId) + "\" "
                                             "   ;;",
                                             "   esac"
                                         ],
                                         []
-                                    ) 
+                                    )
                                 /]
                             [/#if]
                             [#if deploymentSubsetRequired("epilogue", false) ]
@@ -242,23 +310,23 @@
                                                     "case $\{STACK_OPERATION} in",
                                                     "  create|update)",
                                                     "       # Get cli config file",
-                                                    "       split_cli_file \"$\{CLI}\" \"$\{tmpdir}\" || return $?", 
+                                                    "       split_cli_file \"$\{CLI}\" \"$\{tmpdir}\" || return $?",
                                                     "       # Apply CLI level updates to ELB listener",
                                                     "       info \"Applying cli level configurtion\""
                                                 ] +
                                                 (getExistingReference(listenerRuleId)?has_content)?then(
                                                     [
                                                         "       update_elbv2_rule" +
-                                                        "       \"" + region + "\" " + 
-                                                        "       \"" + getExistingReference(listenerRuleId) + "\" " + 
-                                                        "       \"$\{tmpdir}/cli-" + 
+                                                        "       \"" + region + "\" " +
+                                                        "       \"" + getExistingReference(listenerRuleId) + "\" " +
+                                                        "       \"$\{tmpdir}/cli-" +
                                                                 listenerRuleId + "-" + listenerRuleCommand + ".json\""
                                                     ],
                                                     [
                                                         "       listener_rule_arn=$( create_elbv2_rule" +
-                                                        "       \"" + region + "\" " + 
-                                                        "       \"" + getExistingReference(listenerId) + "\" " + 
-                                                        "       \"$\{tmpdir}/cli-" + 
+                                                        "       \"" + region + "\" " +
+                                                        "       \"" + getExistingReference(listenerId) + "\" " +
+                                                        "       \"$\{tmpdir}/cli-" +
                                                                 listenerRuleId + "-" + listenerRuleCommand + ".json\")",
                                                         "       pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-pseudo-stack.json\" ",
                                                         "       create_pseudo_stack" + " " +
@@ -292,8 +360,9 @@
                         [/#if]
 
                     [/#if]
-                    
-                    [#if deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
+
+                    [#if (targetGroupRequired || firstMappingForPort) &&
+                        deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
 
                         [@createTargetGroup
                             mode=listMode
@@ -319,10 +388,10 @@
                                 "SSLCertificateId",
                                 sourcePort.Certificate!false,
                                 getReference(certificateId, ARN_ATTRIBUTE_TYPE, regionId)
-                            ) 
+                            )
                         ]
                     ]
-                    
+
                     [#break]
             [/#switch]
         [/#list]
@@ -374,11 +443,11 @@
                         idleTimeout=idleTimeout /]
                 [/#if]
                 [#break]
-                
+
             [#case "classic"]
-                
+
                 [#assign healthCheck = {
-                    "Target" : healthCheckPort.HealthCheck.Protocol!healthCheckPort.Protocol + ":" 
+                    "Target" : healthCheckPort.HealthCheck.Protocol!healthCheckPort.Protocol + ":"
                                 + (healthCheckPort.HealthCheck.Port!healthCheckPort.Port)?c + healthCheckPort.HealthCheck.Path!"",
                     "HealthyThreshold" : healthCheckPort.HealthCheck.HealthyThreshold,
                     "UnhealthyThreshold" : healthCheckPort.HealthCheck.UnhealthyThreshold,
@@ -387,48 +456,20 @@
                 }]
 
                 [#if deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
-                    [@createClassicLB 
-                        mode=listMode 
-                        id=lbId 
-                        name=lbName 
+                    [@createClassicLB
+                        mode=listMode
+                        id=lbId
+                        name=lbName
                         shortName=lbShortName
                         tier=tier
-                        component=component 
-                        listeners=classicListeners 
-                        healthCheck=healthCheck 
-                        securityGroups=lbSecurityGroupIds 
-                        logs=lbLogs 
-                        bucket=operationsBucket 
+                        component=component
+                        listeners=classicListeners
+                        healthCheck=healthCheck
+                        securityGroups=lbSecurityGroupIds
+                        logs=lbLogs
+                        bucket=operationsBucket
                         idleTimeout=idleTimeout
                         /]
-                [/#if]
-                [#break]
-
-            [#case "classic"]
-            
-                [#if deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
-                    [#assign healthCheck = {
-                        "Target" : healthCheckPort.HealthCheck.Protocol!healthCheckPort.Protocol + ":" 
-                                    + (healthCheckPort.HealthCheck.Port!healthCheckPort.Port)?c + healthCheckPort.HealthCheck.Path!"",
-                        "HealthyThreshold" : healthCheckPort.HealthCheck.HealthyThreshold,
-                        "UnhealthyThreshold" : healthCheckPort.HealthCheck.UnhealthyThreshold,
-                        "Interval" : healthCheckPort.HealthCheck.Interval,
-                        "Timeout" : healthCheckPort.HealthCheck.Timeout
-                    }]
-
-                    [@createClassicLB 
-                        mode=listMode 
-                        id=lbId 
-                        name=lbName 
-                        shortName=lbShortName
-                        tier=tier
-                        component=component 
-                        listeners=classicListeners 
-                        healthCheck=healthCheck 
-                        securityGroups=lbSecurityGroupIds 
-                        logs=lbLogs 
-                        bucket=operationsBucket 
-                    /]
                 [/#if]
                 [#break]
         [/#switch ]


### PR DESCRIPTION
Reorganise the logic of LB processing to support addition of redirect
and fixed response rules on ALB.

Separate out determination of which is the first port mapping for a
given source port.

Add redirect and fixed response rule creation via CLI.

Fixed response values are taken from the settings if present, otherwise
from the solution.

Add explicit flag controlling creation of target group, as we don't need
one for redirects or fixed responses.

Remove redundant copy of case statement for creating the classic LB.