### PR TITLE
S3 Datasets

### DIFF
--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -671,6 +671,7 @@ function isValidUnit() {
   # Known levels
   declare -gA unit_required=( \
     ["blueprint"]="false" \
+    ["buildblueprint"]="true" \
     ["account"]="true" \
     ["product"]="true" \
     ["application"]="true" \
@@ -686,6 +687,7 @@ function isValidUnit() {
     # Default deployment units for each level
     declare -ga ACCOUNT_UNITS_ARRAY=("audit" "s3" "cert" "roles" "apigateway" "waf")
     declare -ga PRODUCT_UNITS_ARRAY=("s3" "sns" "cert" "cmk")
+    declare -ga BUILDBLUEPRINT_UNITS_ARRAY=(${unit})
     declare -ga APPLICATION_UNITS_ARRAY=(${unit})
     declare -ga SOLUTION_UNITS_ARRAY=(${unit})
     declare -ga SEGMENT_UNITS_ARRAY=("iam" "lg" "eip" "s3" "cmk" "cert" "vpc" "nat" "ssh" "dns" "eipvpc" "eips3vpc")

--- a/aws/createBuildBlueprint.sh
+++ b/aws/createBuildBlueprint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+[[ -n "${GENERATION_DEBUG}" ]] && set ${GENERATION_DEBUG}
+trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
+
+${GENERATION_DIR}/createTemplate.sh -l buildblueprint "$@"
+RESULT=$?
+

--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -185,6 +185,24 @@ function process_template() {
       pass_description["template"]="blueprint"
       pass_suffix["template"]=".json"
       ;;
+    
+    buildblueprint)
+      # this is expected to run from an automation context
+      cf_dir="${AUTOMATION_DATA_DIR:-${PRODUCT_INFRASTRUCTURE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}}/"
+      pass_list=("template")
+      passes=("template")
+      template_composites+=("APPLICATION" "FRAGMENT" )
+
+      # Blueprint applies across accounts and regions
+      for pass in "${pass_list[@]}"; do
+        pass_account_prefix["${pass}"]=""
+        pass_region_prefix["${pass}"]=""
+      done
+
+      pass_level_prefix["template"]="build_blueprint-"
+      pass_description["template"]="buildblueprint"
+      pass_suffix["template"]=".json"
+      ;;
 
     account)
       cf_dir="${ACCOUNT_INFRASTRUCTURE_DIR}/cf/shared"

--- a/aws/templates/account/account_s3.ftl
+++ b/aws/templates/account/account_s3.ftl
@@ -67,7 +67,7 @@
                         "case $\{STACK_OPERATION} in",
                         "  create|update)",
                         "    sync_code_bucket || return $?",
-                        "    initialise_registries \"contentnode\" \"lambda\" \"pipeline\" \"scripts\" \"spa\" \"swagger\" || return $?",
+                        "    initialise_registries \"dataset\" \"contentnode\" \"lambda\" \"pipeline\" \"scripts\" \"spa\" \"swagger\" || return $?",
                         "    ;;",
                         " esac"
                     ]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -788,6 +788,10 @@ behaviour.
                 [#local result = getContentNodeState(occurrence)]
                 [#break]
 
+            [#case DATASET_COMPONENT_TYPE ]
+                [#local result = getDataSetState(occurrence)]
+                [#break]
+            
             [#case DATAPIPELINE_COMPONENT_TYPE ]
                 [#local result = getDataPipelineState(occurrence)]
                 [#break]

--- a/aws/templates/createBuildBlueprint.ftl
+++ b/aws/templates/createBuildBlueprint.ftl
@@ -1,0 +1,55 @@
+[#ftl]
+[#include "setContext.ftl" ]
+
+[#assign listMode = "blueprint"]
+[#assign exceptionResources = []]
+[#assign debugResources = []]
+
+[#function getComponentBlueprint ]
+  [#local result={} ]
+
+  [#list tiers as tier]
+
+    [#list tier.Components!{} as id,component]
+               
+        [#if component?is_hash]
+            [#list requiredOccurrences(
+                getOccurrences(tier, component),
+                deploymentUnit) as occurrence]
+        
+                [#local componentType = getComponentType(component)]
+
+                [#local result += {
+                    "Id" : id,
+                    "Type" : componentType,
+                    "Metadata" :
+                        {
+                            "Prepared" : .now?iso_utc,
+                            "RequestReference" : requestReference,
+                            "ConfigurationReference" : configurationReference,
+                            "RunId" : runId
+                        } +
+                        attributeIfContent("CostCentre", accountObject.CostCentre!""),
+                    "Occurrence" : occurrence
+                    } +
+                    valueIfContent(
+                        {
+                            "Debug" : debugResources
+                        },
+                        debugResources
+                    ) +
+                    valueIfContent(
+                        {
+                            "Exceptions" : exceptionResources
+                        },
+                        exceptionResources
+                    )
+                ]
+            [/#list]
+        [/#if]
+    [/#list]
+  [/#list]
+  [#return result ]
+[/#function]
+
+[@toJSON getComponentBlueprint() /]

--- a/aws/templates/id/id_dataset.ftl
+++ b/aws/templates/id/id_dataset.ftl
@@ -52,7 +52,7 @@
                                                     formatAbsolutePath(
                                                         getRegistryPrefix("dataset", occurrence),
                                                         productName,
-                                                        getOccurrenceBuildUnit(occurrence),
+                                                        getOccurrenceBuildUnit(occurrence)
                                                     ),
                         "DATASET_LOCATION" : "s3://" + getRegistryEndPoint("swagger", occurrence) + 
                                                     formatAbsolutePath(
@@ -67,7 +67,7 @@
                     [#local masterDataLocation = formatName( core.FullName, solution.Prefix )]
                     [#local attributes += { 
                         "DATASET_ENGINE" : "rdsSnapshot",
-                        "DATASET_PREFIX" : formatAbsolutePath(solution.Prefix)
+                        "DATASET_PREFIX" : formatAbsolutePath(solution.Prefix),
                         "DATASET_MASTER_LOCATION" : formatName( "dataset", core.FullName, solution.Prefix),
                         "DATASET_REGISTRY" : formatName( "dataset",  core.FullName ),
                         "DATASET_LOCATION" : formatName( "dataset",  core.FullName, getOccurrenceBuildReference(occurrence) )

--- a/aws/templates/id/id_dataset.ftl
+++ b/aws/templates/id/id_dataset.ftl
@@ -1,0 +1,75 @@
+[#-- DATA SET --]
+
+[#-- Components --]
+[#assign DATASET_COMPONENT_TYPE = "dataset"]
+
+[#assign componentConfiguration +=
+    {
+        DATASET_COMPONENT_TYPE : [
+            {
+                "Name" : "DataSource",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Name" : "Prefix",
+                "Default" : ""
+            }
+        ]
+    }]
+
+[#function getDataSetState occurrence]
+    
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution ]
+    [#local buildReference = getOccurrenceBuildReference(occurrence) ]
+
+    [#local dataSource = getLinkTarget(occurrence, solution.DataSource)]
+    [#local dataSourceType = dataSource.Core.Type ]
+    [#local dataSourceAttributes = dataSource.State.Attributes]
+
+    [#local attributes = {
+    } + 
+        dataSourceAttributes]
+
+    [#switch dataSourceType ]
+        [#case S3_COMPONENT_TYPE ]
+            [#local attributes += { 
+                "DATASET_ENGINE" : "s3",
+                "DATASET_MASTER_LOCATION" :  "s3://" + dataSourceAttributes.NAME + formatAbsolutePath(solution.Prefix),
+                "DATASET_LOCATION" : "s3://" + getRegistryEndPoint("swagger", occurrence) + 
+                                            formatAbsolutePath(
+                                                getRegistryPrefix("dataset", occurrence),
+                                                productName,
+                                                getOccurrenceBuildUnit(occurrence),
+                                                getOccurrenceBuildReference(occurrence)
+                                            )
+            }]
+            [#break]
+        [#case RDS_COMPONENT_TYPE ]
+            [#local masterDataLocation = formatName( core.FullName, solution.Prefix )]
+            [#local attributes += { 
+                "DATASET_ENGINE" : "rdsSnapshot",
+                "DATASET_MASTER_LOCATION" : formatName( "dataset", core.FullName, solution.Prefix),
+                "DATASET_LOCATION" : formatName( "dataset",  core.FullName, getOccurrenceBuildReference(occurrence) )
+            }]
+            [#break]
+        
+        [#default]
+            [#local attributes += {
+                "DATASET_ENGINE" : "COTException: DataSet Support not available for " + dataSourceType
+            }]
+    [/#switch]
+
+    [#return
+        {
+            "Resources" : {
+            },
+            "Attributes" : attributes,
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#function]

--- a/aws/templates/id/id_dataset.ftl
+++ b/aws/templates/id/id_dataset.ftl
@@ -7,7 +7,7 @@
     {
         DATASET_COMPONENT_TYPE : [
             {
-                "Name" : "DataSource",
+                "Name" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration
             },
@@ -23,43 +23,64 @@
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution ]
     [#local buildReference = getOccurrenceBuildReference(occurrence) ]
+    [#local attributes = {}]
 
-    [#local dataSource = getLinkTarget(occurrence, solution.DataSource)]
-    [#local dataSourceType = dataSource.Core.Type ]
-    [#local dataSourceAttributes = dataSource.State.Attributes]
+    [#list solution.Links["DATASOURCE"]?values as link]
+        [#if link?is_hash]
+            [#assign linkTarget = getLinkTarget(occurrence, link) ]
 
-    [#local attributes = {
-    } + 
-        dataSourceAttributes]
+            [@cfDebug listMode linkTarget false /]
 
-    [#switch dataSourceType ]
-        [#case S3_COMPONENT_TYPE ]
-            [#local attributes += { 
-                "DATASET_ENGINE" : "s3",
-                "DATASET_MASTER_LOCATION" :  "s3://" + dataSourceAttributes.NAME + formatAbsolutePath(solution.Prefix),
-                "DATASET_LOCATION" : "s3://" + getRegistryEndPoint("swagger", occurrence) + 
-                                            formatAbsolutePath(
-                                                getRegistryPrefix("dataset", occurrence),
-                                                productName,
-                                                getOccurrenceBuildUnit(occurrence),
-                                                getOccurrenceBuildReference(occurrence)
-                                            )
-            }]
-            [#break]
-        [#case RDS_COMPONENT_TYPE ]
-            [#local masterDataLocation = formatName( core.FullName, solution.Prefix )]
-            [#local attributes += { 
-                "DATASET_ENGINE" : "rdsSnapshot",
-                "DATASET_MASTER_LOCATION" : formatName( "dataset", core.FullName, solution.Prefix),
-                "DATASET_LOCATION" : formatName( "dataset",  core.FullName, getOccurrenceBuildReference(occurrence) )
-            }]
-            [#break]
-        
-        [#default]
-            [#local attributes += {
-                "DATASET_ENGINE" : "COTException: DataSet Support not available for " + dataSourceType
-            }]
-    [/#switch]
+            [#if !linkTarget?has_content]
+                [#continue]
+            [/#if]
+
+            [#assign linkTargetCore = linkTarget.Core ]
+            [#assign linkTargetConfiguration = linkTarget.Configuration ]
+            [#assign linkTargetResources = linkTarget.State.Resources ]
+            [#assign linkTargetAttributes = linkTarget.State.Attributes ]
+            
+            [#local attributes += linkTargetAttributes]
+
+            [#switch linkTargetCore.Type]
+                [#case S3_COMPONENT_TYPE ]
+                    [#local attributes += { 
+                        "DATASET_ENGINE" : "s3",
+                        "DATASET_PREFIX" : formatAbsolutePath(solution.Prefix),
+                        "DATASET_MASTER_LOCATION" :  "s3://" + linkTargetAttributes.NAME + formatAbsolutePath(solution.Prefix),
+                        "DATASET_REGISTRY" : "s3://" + getRegistryEndPoint("swagger", occurrence) + 
+                                                    formatAbsolutePath(
+                                                        getRegistryPrefix("dataset", occurrence),
+                                                        productName,
+                                                        getOccurrenceBuildUnit(occurrence),
+                                                    ),
+                        "DATASET_LOCATION" : "s3://" + getRegistryEndPoint("swagger", occurrence) + 
+                                                    formatAbsolutePath(
+                                                        getRegistryPrefix("dataset", occurrence),
+                                                        productName,
+                                                        getOccurrenceBuildUnit(occurrence),
+                                                        getOccurrenceBuildReference(occurrence)
+                                                    )
+                    }]
+                    [#break]
+                [#case RDS_COMPONENT_TYPE ]
+                    [#local masterDataLocation = formatName( core.FullName, solution.Prefix )]
+                    [#local attributes += { 
+                        "DATASET_ENGINE" : "rdsSnapshot",
+                        "DATASET_PREFIX" : formatAbsolutePath(solution.Prefix)
+                        "DATASET_MASTER_LOCATION" : formatName( "dataset", core.FullName, solution.Prefix),
+                        "DATASET_REGISTRY" : formatName( "dataset",  core.FullName ),
+                        "DATASET_LOCATION" : formatName( "dataset",  core.FullName, getOccurrenceBuildReference(occurrence) )
+                    }]
+                    [#break]
+                
+                [#default]
+                    [#local attributes += {
+                        "DATASET_ENGINE" : "COTException: DataSet Support not available for " + linkTargetCore.Type
+                    }]
+            [/#switch]
+        [/#if]
+    [/#list]
 
     [#return
         {


### PR DESCRIPTION
Ref: #425

Adds support for an S3 buckets contents to be treated in a similar way to a code artefact. 
A dataset does not provision any resources directly instead it adds an application level layer to a solution component, in this case an S3 bucket.

A dataset adds extra attributes to the existing solution component level attribute which tell other components 2 main pieces of information
 - Where data can be uploaded to if the data set needs to be updated - the master data location 
 - Where the latest built version of the data is available - this location of the data in the S3 based account-registry 

This component also allows for application builds to be processed using the deployment unit 