### PR TITLE
Refactor type support

### DIFF
--- a/aws/templates/base.ftl
+++ b/aws/templates/base.ftl
@@ -1,0 +1,430 @@
+[#ftl]
+[#-------------------
+-- Logic functions --
+---------------------]
+
+[#function valueIfTrue value condition otherwise={}]
+    [#return condition?then(value, otherwise) ]
+[/#function]
+
+[#function valueIfContent value content otherwise={}]
+    [#return valueIfTrue(value, content?has_content, otherwise) ]
+[/#function]
+
+[#function contentIfContent value otherwise={}]
+    [#return valueIfTrue(value, value?has_content, otherwise) ]
+[/#function]
+
+[#function attributeIfTrue attribute condition value]
+    [#return valueIfTrue({attribute : value}, condition) ]
+[/#function]
+
+[#function attributeIfContent attribute content value={}]
+    [#return attributeIfTrue(
+        attribute,
+        content?has_content,
+        value?has_content?then(value,content)) ]
+[/#function]
+
+[#------------------------
+-- Powers of 2 handling --
+--------------------------]
+
+[#assign powersOf2 = [1] ]
+[#list 0..31 as index]
+    [#assign powersOf2 += [2*powersOf2[index]] ]
+[/#list]
+
+[#-- Calculate the closest power of 2 --]
+[#function getPowerOf2 value]
+    [#local exponent = -1]
+    [#list powersOf2 as powerOf2]
+        [#if powerOf2 <= value]
+            [#local exponent = powerOf2?index]
+        [#else]
+            [#break]
+        [/#if]
+    [/#list]
+    [#return exponent]
+[/#function]
+
+[#-------------------
+-- String handling --
+---------------------]
+
+[#function replaceAlphaNumericOnly string delimeter=""]
+    [#return string?replace("[^a-zA-Z\\d]", delimeter, "r" )]
+[/#function]
+
+[#function asString arg attribute]
+    [#return
+        arg?is_string?then(
+            arg,
+            arg?is_hash?then(
+                arg[attribute]?has_content?then(
+                    asString(arg[attribute], attribute),
+                    ""
+                ),
+                arg[0]?has_content?then(
+                    asString(arg[0], attribute),
+                    ""
+                )
+            )
+        )
+    ]
+[/#function]
+
+[#function asSerialisableString arg]
+    [#if arg?is_hash || arg?is_sequence ]
+        [#return getJSON(arg) ]
+    [#else]
+        [#return arg ]
+    [/#if]
+[/#function]
+
+[#------------------
+-- Array handling --
+--------------------]
+
+[#-- Recursively concatenate sequence of non-empty strings with a separator --]
+[#function concatenate args separator]
+    [#local content = []]
+    [#list asFlattenedArray(args) as arg]
+        [#local argValue = arg!"COT:ERROR_INVALID_ARG_TO_CONCATENATE"]
+        [#if argValue?is_hash]
+            [#switch separator]
+                [#case "X"]
+                    [#if (argValue.Core.Internal.IdExtensions)??]
+                        [#local argValue = concatenate(
+                                            argValue.Core.Internal.IdExtensions,
+                                            separator)]
+                    [#else]
+                        [#local argValue = argValue.Id!""]
+                    [/#if]
+                    [#break]
+                [#case "-"]
+                [#case "_"]
+                [#case "/"]
+                    [#if (argValue.Core.Internal.NameExtensions)??]
+                        [#local argValue = concatenate(
+                                            argValue.Core.Internal.NameExtensions,
+                                            separator)]
+                    [#else]
+                        [#local argValue = argValue.Name!""]
+                    [/#if]
+                    [#break]
+                [#default]
+                    [#local argValue = ""]
+                    [#break]
+            [/#switch]
+        [/#if]
+        [#if argValue?is_number]
+            [#local argValue = argValue?c]
+        [/#if]
+        [#if argValue?has_content]
+            [#local content +=
+                [
+                    argValue?remove_beginning(separator)?remove_ending(separator)
+                ]
+            ]
+        [/#if]
+    [/#list]
+    [#return content?join(separator)]
+[/#function]
+
+[#function asArray arg flatten=false ignoreEmpty=false]
+    [#local result = [] ]
+    [#if arg?is_sequence]
+        [#if flatten]
+            [#list arg as element]
+                [#local result += asArray(element, flatten, ignoreEmpty) ]
+            [/#list]
+        [#else]
+            [#if ignoreEmpty]
+                [#list arg as element]
+                    [#local elementResult = asArray(element, flatten, ignoreEmpty) ]
+                    [#if elementResult?has_content]
+                        [#local result += valueIfTrue([elementResult], element?is_sequence, elementResult) ]
+                    [/#if]
+                [/#list]
+            [#else]
+                [#local result = arg]
+            [/#if]
+        [/#if]
+    [#else]
+        [#local result = valueIfTrue([arg], !ignoreEmpty || arg?has_content, []) ]
+    [/#if]
+
+    [#return result ]
+[/#function]
+
+[#function asFlattenedArray arg ignoreEmpty=false]
+    [#return asArray(arg, true, ignoreEmpty) ]
+[/#function]
+
+[#function getUniqueArrayElements args...]
+    [#local result = [] ]
+    [#list args as arg]
+        [#list asFlattenedArray(arg) as member]
+            [#if !result?seq_contains(member) ]
+                [#local result += [member] ]
+            [/#if]
+        [/#list]
+    [/#list]
+    [#return result ]
+[/#function]
+
+[#function firstContent alternatives=[] otherwise={}]
+    [#list asArray(alternatives) as alternative]
+        [#if alternative?has_content]
+            [#return alternative]
+        [/#if]
+    [/#list]
+    [#return otherwise ]
+[/#function]
+
+[#function removeValueFromArray array string ]
+    [#local result = [] ]
+    [#list array as item ]
+        [#if item != string ]
+            [#local result += [ item ] ]
+        [/#if]
+    [/#list]
+    [#return result]
+[/#function]
+
+[#-----------------
+-- Object handling --
+-------------------]
+
+[#-- Output object as JSON --]
+[#function getJSON obj escaped=false]
+    [#local result = ""]
+    [#if obj?is_hash]
+        [#local result += "{"]
+        [#list obj as key,value]
+            [#local result += "\"" + key + "\" : " + getJSON(value)]
+            [#sep][#local result += ","][/#sep]
+        [/#list]
+        [#local result += "}"]
+    [#else]
+        [#if obj?is_sequence]
+            [#local result += "["]
+            [#list obj as entry]
+                [#local result += getJSON(entry)]
+                [#sep][#local result += ","][/#sep]
+            [/#list]
+            [#local result += "]"]
+        [#else]
+            [#if obj?is_string]
+                [#local result = "\"" + obj?json_string + "\""]
+            [#else]
+                [#local result = obj?c]
+            [/#if]
+        [/#if]
+    [/#if]
+    [#return escaped?then(result?json_string, result) ]
+[/#function]
+
+[#macro toJSON obj escaped=false]
+    ${getJSON(obj, escaped)}[/#macro]
+
+[#function getDescendent object default path...]
+    [#local descendent=object]
+    [#list asFlattenedArray(path) as part]
+        [#if descendent[part]??]
+            [#local descendent=descendent[part] ]
+        [#else]
+            [#return default]
+        [/#if]
+    [/#list]
+
+    [#return descendent]
+[/#function]
+
+[#function setDescendent object descendent id path...]
+  [#local effectivePath = asFlattenedArray(path) ]
+    [#if effectivePath?has_content]
+      [#return
+        object +
+        {
+          effectivePath?first :
+            setDescendent(
+              object[effectivePath?first]!{},
+              descendent,
+              id,
+              (effectivePath?size == 1)?then([],effectivePath[1..]))
+        }
+      ]
+    [#else]
+      [#if object[id]?? && object[id]?is_hash]
+          [#return object + { id : object[id] + descendent } ]
+      [/#if]
+      [#return object + { id : descendent } ]
+    [/#if]
+[/#function]
+
+[#-----------------
+-- Type handling --
+-------------------]
+
+[#assign OBJECT_TYPE = "object" ]
+[#assign ARRAY_TYPE = "array" ]
+[#assign STRING_TYPE = "string" ]
+[#assign NUMBER_TYPE = "number" ]
+[#assign BOOLEAN_TYPE = "boolean" ]
+[#assign ANY_TYPE = "any" ]
+[#assign UNKNOWN_TYPE = "unknown" ]
+[#assign ARRAY_OF_OBJECT_TYPE  = [ARRAY_TYPE, OBJECT_TYPE] ]
+[#assign ARRAY_OF_STRING_TYPE  = [ARRAY_TYPE, STRING_TYPE] ]
+[#assign ARRAY_OF_NUMBER_TYPE  = [ARRAY_TYPE, NUMBER_TYPE] ]
+[#assign ARRAY_OF_BOOLEAN_TYPE = [ARRAY_TYPE, BOOLEAN_TYPE] ]
+[#-- Array of any if different to array in that value will be forced to an array --]
+[#assign ARRAY_OF_ANY_TYPE     = [ARRAY_TYPE, ANY_TYPE] ]
+
+[#function getBaseType arg]
+    [#if arg?is_hash]
+        [#return OBJECT_TYPE]
+    [/#if]
+    [#if arg?is_sequence]
+        [#return ARRAY_TYPE]
+    [/#if]
+    [#if arg?is_string]
+        [#return STRING_TYPE]
+    [/#if]
+    [#if arg?is_number]
+        [#return NUMBER_TYPE]
+    [/#if]
+    [#if arg?is_boolean]
+        [#return BOOLEAN_TYPE]
+    [/#if]
+    [#return UNKNOWN_TYPE]
+[/#function]
+
+[#function isOneOfTypes arg types]
+    [#local typesArray = asArray(types) ]
+    [#return
+        typesArray?seq_contains(getBaseType(arg)) ||
+        typesArray?seq_contains(ANY_TYPE) ]
+[/#function]
+
+[#function isArrayOfType types]
+    [#local typesArray = asArray(types) ]
+    [#return (typesArray?size > 1) && typesArray?seq_contains(ARRAY_TYPE) ]
+[/#function]
+
+[#function asType arg types]
+    [#return valueIfTrue(asFlattenedArray(arg), isArrayOfType(types), arg) ]
+[/#function]
+
+[#function isOfType arg types]
+    [#if isArrayOfType(types) ]
+        [#-- Expecting an array of specific types --]
+        [#list asType(arg, types) as element]
+            [#if !isOneOfTypes(element, types) ]
+                [#return false]
+            [/#if]
+        [/#list]
+    [#else]
+        [#-- Match against --]
+        [#return isOneOfTypes(arg, types) ]
+    [/#if]
+    [#return true]
+[/#function]
+
+[#-----------------
+-- CIDR handling --
+-------------------]
+
+[#function asCIDR value mask]
+    [#local remainder = value]
+    [#local result = []]
+    [#list 0..3 as index]
+        [#local result = [remainder % 256] + result]
+        [#local remainder = (remainder / 256)?int ]
+    [/#list]
+    [#return [result?join("."), mask]?join("/")]
+[/#function]
+
+[#function analyzeCIDR cidr ]
+    [#local re = cidr?matches(r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/(\d{1,2})") ]
+    [#if !re ]
+        [#return {}]
+    [/#if]
+
+    [#local ip = re?groups[1] ]
+    [#local mask = re?groups[2]?number ]
+    [#local parts = re?groups[1]?split(".") ]
+    [#local partMasks = [] ]
+    [#list 0..3 as index]
+        [#local partMask = mask - 8*index ]
+        [#if partMask gte 8]
+            [#local partMask = 8 ]
+        [/#if]
+        [#if partMask lte 0]
+            [#local partMask = 0 ]
+        [/#if]
+        [#local partMasks += [partMask] ]
+    [/#list]
+
+    [#local base = [] ]
+    [#list 0..3 as index]
+        [#local partBits = partMasks[index] ]
+        [#local partValue = parts[index]?number ]
+        [#local baseValue = 0]
+        [#list 7..0 as bit]
+            [#if partBits lte 0]
+                [#break]
+            [/#if]
+            [#if partValue gte powersOf2[bit] ]
+                [#local baseValue += powersOf2[bit] ]
+                [#local partValue -= powersOf2[bit] ]
+            [/#if]
+            [#local partBits -= 1]
+        [/#list]
+        [#local base += [baseValue] ]
+    [/#list]
+    [#local offset = base[3] + 256*(base[2] + 256*(base[1] + 256*base[0])) ]
+
+    [#return
+        {
+            "IP" : ip,
+            "Mask" : mask,
+            "Parts" : parts,
+            "PartMasks" : partMasks,
+            "Base" : base,
+            "Offset" : offset
+        }
+    ]
+[/#function]
+
+[#function expandCIDR cidrs... ]
+    [#local boundaries=[8,16,24,32] ]
+    [#local boundaryOffsets=[24,16,8,0] ]
+    [#local result = [] ]
+    [#list asFlattenedArray(cidrs) as cidr]
+
+        [#local analyzedCIDR = analyzeCIDR(cidr) ]
+
+        [#if !analyzedCIDR?has_content]
+            [#continue]
+        [/#if]
+        [#list 0..boundaries?size-1 as index]
+            [#local boundary = boundaries[index] ]
+            [#if boundary == analyzedCIDR.Mask]
+                [#local result += [cidr] ]
+                [#break]
+            [/#if]
+            [#if boundary > analyzedCIDR.Mask]
+                [#local nextCIDR = analyzedCIDR.Offset ]
+                [#list 0..powersOf2[boundary - analyzedCIDR.Mask]-1 as increment]
+                    [#local result += [asCIDR(nextCIDR, boundary)] ]
+                    [#local nextCIDR += powersOf2[boundaryOffsets[index]] ]
+                [/#list]
+                [#break]
+            [/#if]
+        [/#list]
+    [/#list]
+    [#return result]
+[/#function]
+

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -33,12 +33,12 @@
         APIGATEWAY_COMPONENT_TYPE : [
             {
                 "Names" : ["Fragment", "Container"],
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Default" : ""
             },
             {
                 "Name" : "Links",
-                "Type" : "object",
+                "Type" : OBJECT_TYPE,
                 "Default" : {}
             },
             {
@@ -47,18 +47,18 @@
             },
             {
                 "Name" : "EndpointType",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Values" : ["EDGE", "REGIONAL"],
                 "Default" : "EDGE"
             },
             {
                 "Name" : "IPAddressGroups",
-                "Type" : "array",
+                "Type" : ARRAY_OF_STRING_TYPE,
                 "Default" : []
             },
             {
                 "Name" : "Authentication",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Values" : ["IP", "SIG4ORIP", "SIG4ANDIP"],
                 "Default" : "IP"
             },
@@ -67,32 +67,32 @@
                 "Children" : [
                     {
                         "Name" : "AssumeSNI",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "EnableLogging",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "CountryGroups",
-                        "Type" : "array",
+                        "Type" : ARRAY_OF_STRING_TYPE,
                         "Default" : []
                     },
                     {
                         "Name" : "CustomHeaders",
-                        "Type" : "array",
+                        "Type" : ARRAY_OF_ANY_TYPE,
                         "Default" : []
                     },
                     {
                         "Name" : "Mapping",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : false
                     },
                     {
                         "Name" : "Compress",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     }
                 ]
@@ -110,12 +110,12 @@
                 "Children" : [
                     {
                         "Name" : "DnsNamePrefix",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : "docs"
                     },
                     {
                         "Name" : "IPAddressGroups",
-                        "Type" : "array",
+                        "Type" : ARRAY_OF_STRING_TYPE,
                         "Default" : []
                     }
                 ]
@@ -125,7 +125,7 @@
                 "Children" : [
                     {
                         "Name" : "IncludeStage",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     }
                 ]

--- a/aws/templates/id/id_cache.ftl
+++ b/aws/templates/id/id_cache.ftl
@@ -13,23 +13,23 @@
         CACHE_COMPONENT_TYPE : [
             {
                 "Name" : "Engine",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Mandatory" : true
             },
             {
                 "Name" : "EngineVersion",
-                "Type" : "string"
+                "Type" : STRING_TYPE
             },
             {
                 "Name" : "Port",
-                "Type" : "string"
+                "Type" : STRING_TYPE
             },
             {
                 "Name" : "Backup",
                 "Children" : [
                     {
                         "Name" : "RetentionPeriod",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : ""
                     }
                 ]

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -17,47 +17,47 @@
         USERPOOL_COMPONENT_TYPE : [
             { 
                 "Name" : "MFA",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : false
             },
             {
                 "Name" : "AdminCreatesUser",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : true
             },
             {
                 "Name" : "UnusedAccountTimeout",
-                "Type" : "number",
+                "Type" : NUMBER_TYPE,
                 "Default" : 7
             },
             {
                 "Name" : "VerifyEmail",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : true
             },
             {
                 "Name" : "VerifyPhone",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : false
             },
             {
                 "Name" : "LoginAliases",
-                "Type" : "array",
+                "Type" : ARRAY_OF_STRING_TYPE,
                 "Default" : ["email"]
             },
             {
                 "Name" : "ClientGenerateSecret",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : false
             },
             {
                 "Name" : "ClientTokenValidity",
-                "Type" : "number",
+                "Type" : NUMBER_TYPE,
                 "Default" : 30
             },
             {
                 "Name" : "AllowUnauthenticatedIds",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : false
             },
             {
@@ -65,12 +65,12 @@
                 "Children" : [
                     {
                         "Name" : "Scopes",
-                        "Type" : "array",
+                        "Type" : ARRAY_OF_STRING_TYPE,
                         "Default" : [ "openid" ]
                     },
                     {
                         "Name" : "Flows",
-                        "Type" : "array",
+                        "Type" : ARRAY_OF_STRING_TYPE,
                         "Default" : [ "code" ]
                     }
                 ]
@@ -80,27 +80,27 @@
                 "Children" : [
                     {
                         "Name" : "MinimumLength",
-                        "Type" : "number",
+                        "Type" : NUMBER_TYPE,
                         "Default" : 10
                     },
                     {
                         "Name" : "Lowercase",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "Uppercase",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "Numbers",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "SpecialCharacters",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     }
                 ] 

--- a/aws/templates/id/id_computecluster.ftl
+++ b/aws/templates/id/id_computecluster.ftl
@@ -6,7 +6,7 @@
         COMPUTECLUSTER_COMPONENT_TYPE : [
             {
                 "Name" : ["Fragment", "Container"],
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Default" : ""
             },
             {
@@ -16,32 +16,32 @@
             },
             {
                 "Name" : "UseInitAsService",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : false
             },
             {
                 "Name" : "MinUpdateInstances",
-                "Type" : "number",
+                "Type" : NUMBER_TYPE,
                 "Default" : 1
             }
             {
                 "Name" : "ReplaceOnUpdate",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : false
             },
             {
                 "Name" : "UpdatePauseTime",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Default" : "5M"
             },
             {
                 "Name" : "StartupTimeout",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Default" : "15M"
             },
             {
                 "Name" : "DockerHost",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : false
             },
             {
@@ -50,7 +50,7 @@
                 "Children" : [
                     {
                         "Name" : "IPAddressGroups",
-                        "Type" : "array",
+                        "Type" : ARRAY_OF_STRING_TYPE,
                         "Default" : []
                     },
                     {

--- a/aws/templates/id/id_contenthub.ftl
+++ b/aws/templates/id/id_contenthub.ftl
@@ -13,17 +13,17 @@
             "Prefix",
             {
                 "Name" : "Engine",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Default" : "github"
             },
             {
                 "Name" : "Branch",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Default" : "master"
             },
             {
                 "Name" : "Repository",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Default" : ""
             }
         ]
@@ -64,12 +64,12 @@
                 "Children" : [
                     {
                         "Name" : "Host",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : ""
                     },
                     {
                         "Name" : "Style",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : "single"
                     },
                     {
@@ -78,47 +78,47 @@
 
                             {
                                 "Name" : "Product",
-                                "Type" : "boolean",
+                                "Type" : BOOLEAN_TYPE,
                                 "Default" : true
                             },
                             {
                                 "Name" : "Environment",
-                                "Type" : "boolean",
+                                "Type" : BOOLEAN_TYPE,
                                 "Default" : false
                             },
                             {
                                 "Name" : "Solution",
-                                "Type" : "boolean",
+                                "Type" : BOOLEAN_TYPE,
                                 "Default" : false
                             },
                             {
                                 "Name" : "Segment",
-                                "Type" : "boolean",
+                                "Type" : BOOLEAN_TYPE,
                                 "Default" : true
                             },
                             {
                                 "Name" : "Tier",
-                                "Type" : "boolean",
+                                "Type" : BOOLEAN_TYPE,
                                 "Default": false
                             },
                             {
                                 "Name" : "Component",
-                                "Type" : "boolean",
+                                "Type" : BOOLEAN_TYPE,
                                 "Default" : false
                             },
                             {
                                 "Name" : "Instance",
-                                "Type" : "boolean",
+                                "Type" : BOOLEAN_TYPE,
                                 "Default" : false
                             },
                             {
                                 "Name" : "Version",
-                                "Type" : "boolean",
+                                "Type" : BOOLEAN_TYPE,
                                 "Default" : false
                             },
                             {
                                 "Name" : "Host",
-                                "Type" : "boolean",
+                                "Type" : BOOLEAN_TYPE,
                                 "Default": false
                             }
                         ]

--- a/aws/templates/id/id_datapipeline.ftl
+++ b/aws/templates/id/id_datapipeline.ftl
@@ -11,7 +11,7 @@
         DATAPIPELINE_COMPONENT_TYPE : [
             {
                 "Name" : ["Fragment", "Container"],
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Default" : ""
             },
             {
@@ -19,22 +19,22 @@
                 "Children" : [
                     {
                         "Name" : "Decrypt",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "AsFile",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "AppData",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "AppPublic",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE",
                         "Default" : true
                     }
                 ]

--- a/aws/templates/id/id_ec2.ftl
+++ b/aws/templates/id/id_ec2.ftl
@@ -82,10 +82,12 @@
         EC2_COMPONENT_TYPE : [
             {
                 "Name" : "FixedIP",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : false
             },
             {
                 "Name" : "DockerHost",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : false
             },
             {
@@ -99,6 +101,7 @@
                 "Children" : [
                     {
                         "Name" : "IPAddressGroups",
+                        "Type" : ARRAY_OF_STRING_TYPE,
                         "Default" : []
                     },
                     {

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -14,7 +14,7 @@
     containerChildrenConfiguration = [
         {
             "Name" : "Cpu",
-            "Type" : "number",
+            "Type" : NUMBER_TYPE,
             "Default" : ""
         },
         {
@@ -24,38 +24,38 @@
         },
         {
             "Name" : "LocalLogging",
-            "Type" : "boolean",
+            "Type" : BOOLEAN_TYPE,
             "Default" : false
         },
         {
             "Name" : "LogDriver",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Values" : ["awslogs", "json-file", "fluentd"],
             "Default" : "awslogs"
         },
         {
             "Name" : "ContainerLogGroup",
-            "Type" : "boolean",
+            "Type" : BOOLEAN_TYPE,
             "Default" : false
         },
         {
             "Name" : "RunCapabilities",
-            "Type" : "array",
+            "Type" : ARRAY_OF_STRING_TYPE,
             "Default" : []
         },
         {
             "Name" : "Privileged",
-            "Type" : "boolean",
+            "Type" : BOOLEAN_TYPE,
             "Default" : false
         },
         {
             "Name" : ["MaximumMemory", "MemoryMaximum", "MaxMemory"],
-            "Types" : "number",
+            "Types" : NUMBER_TYPE,
             "Description" : "Set to 0 to not set a maximum"
         },
         {
             "Name" : ["MemoryReservation", "Memory", "ReservedMemory"],
-            "Type" : "number",
+            "Type" : NUMBER_TYPE,
             "Mandatory" : true
         },
         {
@@ -65,7 +65,7 @@
                 "Container",
                 {
                     "Name" : "DynamicHostPort",
-                    "Type" : "boolean",
+                    "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 }
                 {
@@ -74,19 +74,19 @@
                 },
                 {
                     "Name" : "IPAddressGroups",
-                    "Type" : "array",
+                    "Type" : ARRAY_OF_STRING_TYPE,
                     "Default" : []
                 }
             ]
         },
         {
             "Name" : "Version",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Default" : ""
         },
         {
             "Name" : "ContainerNetworkLinks",
-            "Type" : "array",
+            "Type" : ARRAY_OF_STRING_TYPE,
             "Default" : []
         }
     ]
@@ -98,18 +98,18 @@
             "Attributes" : [
                 {
                     "Name" : "FixedIP",
-                    "Type" : "boolean",
+                    "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
                     "Name" : "LogDriver",
-                    "Type" : "string",
+                    "Type" : STRING_TYPE,
                     "Values" : ["awslogs", "json-file", "fluentd"],
                     "Default" : "awslogs"
                 },
                 {
                     "Name" : "ClusterLogGroup",
-                    "Type" : "boolean",
+                    "Type" : BOOLEAN_TYPE,
                     "Default" : true
                 },
                 {
@@ -123,11 +123,11 @@
                     "Children" : [
                         {
                             "Name" : "UserName",
-                            "Type" : "string"
+                            "Type" : STRING_TYPE
                         },
                         {
                             "Name" : "UID",
-                            "Type" : "string",
+                            "Type" : STRING_TYPE,
                             "Mandatory" : true
                         }
                     ]
@@ -154,12 +154,12 @@
             },
             {
                 "Name" : "DesiredCount",
-                "Type" : "number",
+                "Type" : NUMBER_TYPE,
                 "Default" : -1
             },
             {
                 "Name" : "UseTaskRole",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : true
             },
             {
@@ -167,40 +167,40 @@
                 "Children" : [
                     {
                         "Name" : "Decrypt",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "AsFile",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "AppData",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "AppPublic",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     }
                 ]
             },
             {
                 "Name" : "TaskLogGroup",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : true
             },
             {
                 "Name" : "NetworkMode",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Values" : ["none", "bridge", "awsvpc", "host"],
                 "Default" : ""
             },
             {
                 "Name" : "ContainerNetworkLinks",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : false
             }
         ],
@@ -212,7 +212,7 @@
             },
             {
                 "Name" : "UseTaskRole",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : true
             },
             {
@@ -220,34 +220,34 @@
                 "Children" : [
                     {
                         "Name" : "Decrypt",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "AsFile",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "AppData",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "AppPublic",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     }
                 ]
             },
             {
                 "Name" : "TaskLogGroup",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : true
             },
             {
                 "Name" : "FixedName",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : false
             }
         ]

--- a/aws/templates/id/id_efs.ftl
+++ b/aws/templates/id/id_efs.ftl
@@ -30,7 +30,7 @@
             "Attributes" : [
                 {
                     "Name" : "Encrypted",
-                    "Type" : "boolean",
+                    "Type" : BOOLEAN_TYPE,
                     "Default" : true
                 }
             ],
@@ -45,7 +45,7 @@
         EFS_MOUNT_COMPONENT_TYPE : [
             {
                 "Name" : "Directory",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Mandatory" : true
             }
         ]

--- a/aws/templates/id/id_es.ftl
+++ b/aws/templates/id/id_es.ftl
@@ -20,28 +20,28 @@
         ES_COMPONENT_TYPE : [
             {
                 "Name" : "Authentication",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Values" : ["IP", "SIG4ORIP", "SIG4ANDIP"],
                 "Default" : "IP"
             },
             {
                 "Name" : "IPAddressGroups",
-                "Type" : "array",
+                "Type" : ARRAY_OF_STRING_TYPE,
                 "Mandatory" : true
             },
             {
                 "Name" : "AdvancedOptions",
-                "Type" : "array",
+                "Type" : ARRAY_OF_STRING_TYPE,
                 "Default" : []
             },
             {
                 "Name" : "Version",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Default" : "2.3"
             },
             {
                 "Name" : "Encrypted",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : false
             },
             {
@@ -49,7 +49,7 @@
                 "Children" : [
                     {
                         "Name" : "Hour",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : ""
                     }
                 ]

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -38,12 +38,12 @@
         LAMBDA_FUNCTION_COMPONENT_TYPE : [
             {
                 "Name" : ["Fragment", "Container"],
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Default" : ""
             },
             {
                 "Name" : "Handler",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Mandatory" : true
             },
             {
@@ -63,12 +63,12 @@
             }
             {
                 "Name" : ["Memory", "MemorySize"],
-                "Type" : "number",
+                "Type" : NUMBER_TYPE,
                 "Default" : 0
             },
             {
                 "Name" : "RunTime",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Values" : ["nodejs", "nodejs4.3", "nodejs6.10", "nodejs8.10", "java8", "python2.7", "python3.6", "dotnetcore1.0", "dotnetcore2.0", "dotnetcore2.1", "nodejs4.3-edge", "go1.x"],
                 "Mandatory" : true
             },
@@ -78,34 +78,34 @@
                 "Children" : [
                     {
                         "Name" : "Expression",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : "rate(6 minutes)"
                     },
                     {
                         "Name" : "InputPath",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : "/healthcheck"
                     },
                     {
                         "Name" : "Input",
-                        "Type" : "array",
+                        "Type" : OBJECT_TYPE,
                         "Default" : {}
                     }
                 ]
             },
             {
                 "Name" : "Timeout",
-                "Type" : "number",
+                "Type" : NUMBER_TYPE,
                 "Default" : 0
             },
             {
                 "Name" : "VPCAccess",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : true
             },
             {
                 "Name" : "UseSegmentKey",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : false
             },
             {
@@ -113,34 +113,34 @@
                 "Children" : [
                     {
                         "Name" : "Decrypt",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "AsFile",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "AppData",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "AppPublic",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     }
                 ]
             },
             {
                 "Name" : "PredefineLogGroup",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : false
             },
             {
                 "Name" : "EnvironmentAsFile",
-                "Type" : "boolean",
+                "Type" : BOOLEAN_TYPE,
                 "Default" : false
             }
         ]

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -21,23 +21,23 @@
             "Attributes" : [
                 {
                     "Name" : "Logs",
-                    "Type" : "boolean",
+                    "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
                     "Name" : "Engine",
-                    "Type" : "string",
+                    "Type" : STRING_TYPE,
                     "Values" : ["application", "network", "classic"],
                     "Default" : "application"
                 },
                 {
                     "Name" : "IdleTimeout", 
-                    "Type" : "number",
+                    "Type" : NUMBER_TYPE,
                     "Default" : 60
                 }
                 {
                     "Name" : "HealthCheckPort",
-                    "Type" : "string",
+                    "Type" : STRING_TYPE,
                     "Default" : ""
                 }
             ],
@@ -52,32 +52,32 @@
         LB_PORT_COMPONENT_TYPE : [
             {
                 "Name" : "IPAddressGroups",
-                "Type" : "array",
+                "Type" : ARRAY_OF_STRING_TYPE,
                 "Default" : []
             },
             {
                 "Name" : "Certificate",
-                "Type" : "object",
+                "Type" : OBJECT_TYPE,
                 "Default" : {}
             },
             {
                 "Name" : "Mapping",
-                "Type" : "string"
+                "Type" : STRING_TYPE
             },
             {
                 "Name" : "TargetType",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Values" : ["instance", "ip"],
                 "Default" : "instance"
             },
             {
                 "Name" : "Path",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Default" : "default"
             },
             {
                 "Name" : "Priority",
-                "Type" : "number",
+                "Type" : NUMBER_TYPE,
                 "Default" : 100
             },
             {
@@ -90,12 +90,12 @@
                 "Children" : [
                     {
                         "Name" : "SessionCookieName",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : "AWSELBAuthSessionCookie"
                     },
                     {
                         "Name" : "SessionTimeout",
-                        "Type" : "number",
+                        "Type" : NUMBER_TYPE,
                         "Default" : 604800
                     }
                 ]
@@ -105,32 +105,32 @@
                 "Children" : [
                     {
                         "Name" : "Protocol",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : "https"
                     },
                     {
                         "Name" : "Port",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : "443"
                     },
                     {
                         "Name" : "Host",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : "#\{host}"
                     },
                     {
                         "Name" : "Path",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : "#\{path}"
                     },
                     {
                         "Name" : "Query",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : "#\{query}"
                     },
                     {
                         "Name" : "Permanent",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : false
                     }
                 ]
@@ -140,17 +140,17 @@
                 "Children" : [
                     {
                         "Name" : "Message",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : "This application is currently unavailable. Please try again later."
                     },
                     {
                         "Name" : "ContentType",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : "text/plain"
                     },
                     {
                         "Name" : "StatusCode",
-                        "Type" : "number",
+                        "Type" : NUMBER_TYPE,
                         "Default" : 404
                     }
                 ]

--- a/aws/templates/id/id_mobilenotifier.ftl
+++ b/aws/templates/id/id_mobilenotifier.ftl
@@ -15,7 +15,7 @@
                 },
                 {
                     "Name" : "SuccessSampleRate",
-                    "Type" : "string",
+                    "Type" : STRING_TYPE,
                     "Default" : "100"
                 },
                 {
@@ -23,7 +23,7 @@
                     "Children" : [
                         {
                             "Name" : "EncryptionScheme",
-                            "Type" : "string",
+                            "Type" : STRING_TYPE,
                             "Values" : ["base64"],
                             "Default" : "base64"
                         }
@@ -41,18 +41,18 @@
         MOBILENOTIFIER_PLATFORM_COMPONENT_TYPE : [
             {
                 "Name" : "Engine",
-                "Type" : "string"
+                "Type" : STRING_TYPE
             },
             {
                 "Name" : "SuccessSampleRate",
-                "Type" : "string"
+                "Type" : STRING_TYPE
             },
             {
                     "Name" : "Credentials",
                     "Children" : [
                         {
                             "Name" : "EncryptionScheme",
-                            "Type" : "string",
+                            "Type" : STRING_TYPE,
                             "Values" : ["base64"]
                         }
                     ]

--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -31,10 +31,17 @@
                 "Name" : "Engine",
                 "Mandatory" : true
             },
-            "EngineVersion",
-            "Port",
+            {
+                "Name" : "EngineVersion",
+                "Type" : STRING_TYPE
+            },
+            {
+                "Name" : "Port",
+                "Type" : STRING_TYPE
+            },
             {
                 "Name" : "Encrypted",
+                "Type" : BOOLEAN_TYPE
                 "Default" : false
             },
             {
@@ -42,22 +49,22 @@
                 "Children" : [
                     {
                         "Name" : "Enabled",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : false
                     },
                     {
                         "Name" : "MasterUserName",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : "root"
                     },
                     {
                         "Name" : "CharacterLength",
-                        "Type" : "number",
+                        "Type" : NUMBER_TYPE,
                         "Default" : 20
                     },
                     {
                         "Name" : "EncryptionScheme",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Values" : ["base64"],
                         "Default" : ""
                     }
@@ -65,7 +72,7 @@
             },
             {
                 "Name" : "Size",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Default" : "20"
             },
             {
@@ -73,27 +80,27 @@
                 "Children" : [
                     {
                         "Name" : "RetentionPeriod",
-                        "Type" : "number",
+                        "Type" : NUMBER_TYPE,
                         "Default" : 35
                     },
                     {
                         "Name" : "SnapshotOnDeploy",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     }
                 ]
             },
             {
                 "Name" : "AutoMinorVersionUpgrade",
-                "Type" : "boolean"
+                "Type" : BOOLEAN_TYPE
             },
             {
                 "Name" : "DatabaseName",
-                "Type" : "string"
+                "Type" : STRING_TYPE
             },
             {
                 "Name" : "DBParameters",
-                "Type" : "object",
+                "Type" : OBJECT_TYPE,
                 "Default" : {}
             }
         ]

--- a/aws/templates/id/id_s3.ftl
+++ b/aws/templates/id/id_s3.ftl
@@ -79,17 +79,17 @@
                 "Children" : [
                     {
                         "Name" : "Expiration",
-                        "Types" : ["string", "number"],
+                        "Types" : [STRING_TYPE, NUMBER_TYPE],
                         "Description" : "Provide either a date or a number of days"
                     },
                     {
                         "Name" : "Offline",
-                        "Types" : ["string", "number"],
+                        "Types" : [STRING_TYPE, NUMBER_TYPE],
                         "Description" : "Provide either a date or a number of days"
                     },
                     {
                         "Name" : "Versioning",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : false
                     }
                 ]
@@ -99,12 +99,12 @@
                 "Children" : [
                     {
                         "Name": "Index",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default": "index.html"
                     },
                     {
                         "Name": "Error",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default": ""
                     }
                 ]
@@ -114,35 +114,35 @@
                 "Children" : [
                     {
                         "Name" : "Enabled",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : false
                     },
                     {
                         "Name" : "Permissions",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Values" : ["ro", "wo", "rw"],
                         "Default" : "ro"
                     },
                     {
                         "Name" : "IPAddressGroups",
-                        "Type" : "array",
+                        "Type" : ARRAY_OF_STRING_TYPE,
                         "Default" : [ "_localnet" ]
                     },
                     {
                         "Name" : "Prefix",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : ""
                     }
                 ]
             },
             {
                 "Name" : "Style",
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Description" : "TODO(mfl): Think this can be removed"
             },
             {
                 "Name" : "Notifications",
-                "Type" : "object"
+                "Type" : OBJECT_TYPE
             }
         ]
     }]

--- a/aws/templates/id/id_spa.ftl
+++ b/aws/templates/id/id_spa.ftl
@@ -8,11 +8,12 @@
         SPA_COMPONENT_TYPE : [
             {
                 "Name" : ["Fragment", "Container"],
-                "Type" : "string",
+                "Type" : STRING_TYPE,
                 "Default" : ""
             },
             {
                 "Name" : "Links",
+                "Type" : OBJECT_TYPE,
                 "Default" : {}
             },
             {
@@ -24,32 +25,32 @@
                 "Children" : [
                     {
                         "Name" : "AssumeSNI",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "EnableLogging",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     },
                     {
                         "Name" : "CountryGroups",
-                        "Type" : "array",
+                        "Type" : ARRAY_OF_STRING_TYPE,
                         "Default" : []
                     },
                     {
                         "Name" : "ErrorPage",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : "/index.html"
                     },
                     {
                         "Name" : "DeniedPage",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : ""
                     },
                     {
                         "Name" : "NotFoundPage",
-                        "Type" : "string",
+                        "Type" : STRING_TYPE,
                         "Default" : ""
                     },
                     {
@@ -57,24 +58,24 @@
                         "Children" : [
                             {
                                 "Name" : "Default",
-                                "Type" : "number",
+                                "Type" : NUMBER_TYPE,
                                 "Default" : 600
                             },
                             {
                                 "Name" : "Maximum",
-                                "Type" : "number",
+                                "Type" : NUMBER_TYPE,
                                 "Default" : 31536000
                             },
                             {
                                 "Name" : "Minimum",
-                                "Type" : "number",
+                                "Type" : NUMBER_TYPE,
                                 "Default" : 0
                             }
                         ]
                     },
                     {
                         "Name" : "Compress",
-                        "Type" : "boolean",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     }
                 ]

--- a/aws/templates/id/id_sqs.ftl
+++ b/aws/templates/id/id_sqs.ftl
@@ -11,33 +11,33 @@
         SQS_COMPONENT_TYPE : [
             {
                 "Name" : "DelaySeconds",
-                "Type" : "number"
+                "Type" : NUMBER_TYPE
             },
             {
                 "Name" : "MaximumMessageSize",
-                "Type" : "number"
+                "Type" : NUMBER_TYPE
             },
             {
                 "Name" : "MessageRetentionPeriod",
-                "Type" : "number"
+                "Type" : NUMBER_TYPE
             },
             {
                 "Name" : "ReceiveMessageWaitTimeSeconds",
-                "Type" : "number"
+                "Type" : NUMBER_TYPE
             },
             {
                 "Name" : "DeadLetterQueue",
                 "Children" : [
                     {
                         "Name" : "MaxReceives",
-                        "Type" : "number",
+                        "Type" : NUMBER_TYPE,
                         "Default" : 0
                     }
                 ]
             },
             {
                 "Name" : "VisibilityTimeout",
-                "Type" : "number"
+                "Type" : NUMBER_TYPE
             }
         ]
     }]

--- a/aws/templates/id/id_user.ftl
+++ b/aws/templates/id/id_user.ftl
@@ -9,7 +9,7 @@
             "Attributes" : [
                 {
                     "Name" : ["Fragment", "Container"],
-                    "Type" : "string",
+                    "Type" : STRING_TYPE,
                     "Default" : ""
                 },
                 { 
@@ -22,19 +22,19 @@
                     "Children" : [
                         {
                             "Name" : "Formats",
-                            "Type" : "string",
+                            "Type" : STRING_TYPE,
                             "Values" : ["system", "console"],
                             "Default"  : [ "system" ]
                         }
                         {
                             "Name" : "EncryptionScheme",
-                            "Type" : "string",
+                            "Type" : STRING_TYPE,
                             "Values" : ["base64"],
                             "Default" : ""
                         },
                         {
                             "Name" : "CharacterLength",
-                            "Type" : "number",
+                            "Type" : NUMBER_TYPE,
                             "Default" : 20
                         }
                     ]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -1,52 +1,72 @@
 [#ftl]
+[#include "base.ftl"]
 
 [#-- Component configuration is extended dynamically by each component type --]
 [#assign componentConfiguration = {} ]
+
 [#assign
     filterChildrenConfiguration = [
-        "Tenant",
-        "Product",
+        {
+            "Name" : "Any",
+            "Type" : STRING_TYPE
+        },
+        {
+            "Name" : "Tenant",
+            "Type" : STRING_TYPE
+        },
+        {
+            "Name" : "Product",
+            "Type" : STRING_TYPE
+        },
+        {
+            "Name" : "Environment",
+            "Type" : STRING_TYPE
+        },
+        {
+            "Name" : "Segment",
+            "Type" : STRING_TYPE
+        },
         {
             "Name" : "Tier",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Mandatory" : true
         },
         {
             "Name" : "Component",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Mandatory" : true
         },
         {
-            "Name" : ["Function", "Subcomponent"],
-            "Type" : "string"
+            "Name" : ["Function"],
+            "Type" : STRING_TYPE
         },
         {
-            "Name" : ["Service", "Subcomponent"],
-            "Type" : "string"
+            "Name" : ["Service"],
+            "Type" : STRING_TYPE
         },
         {
-            "Name" : ["Task", "Subcomponent"],
-            "Type" : "string"
+            "Name" : ["Task"],
+            "Type" : STRING_TYPE
         },
         {
-            "Name" : ["PortMapping", "Port", "Subcomponent"],
-            "Type" : "string"
+            "Name" : ["PortMapping", "Port"],
+            "Type" : STRING_TYPE
         },
         {
-            "Name" : ["Mount", "Subcomponent"],
-            "Type" : "string"
+            "Name" : ["Mount"],
+            "Type" : STRING_TYPE
         },
         {
             "Name" : ["Platform"],
-            "Type" : "string"
+            "Type" : STRING_TYPE
         },
         {
             "Name" : "Instance",
-            "Type" : "string"
+            "Type" : STRING_TYPE
         },
         {
             "Name" : "Version",
-            "Type" : "string"
+            "Type" : STRING_TYPE
         }
     ]
 ]
@@ -57,11 +77,11 @@
         [
             {
                 "Name" : "Role",
-                "Type" : "string"
+                "Type" : STRING_TYPE
             },
             {
                 "Name" : "Direction",
-                "Type" : "string"
+                "Type" : STRING_TYPE
             }
         ]
 ]
@@ -70,17 +90,17 @@
     metricChildrenConfiguration = [
         {
             "Name" : "Name",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Mandatory" : true
         }
         {
             "Name" : "Type",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Mandatory" : true
         }
         {
             "Name" : "LogPattern",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Default" : ""
         }
     ]
@@ -90,7 +110,7 @@
         "Description",
         {
             "Name" : "Name",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Mandatory" : true
         },
         {
@@ -98,64 +118,64 @@
             "Children" : [
                 {
                     "Name" : "Name",
-                    "Type" : "string",
+                    "Type" : STRING_TYPE,
                     "Mandatory" : true
                 },
                 {
                     "Name" : "Type",
-                    "Type" : "string",
+                    "Type" : STRING_TYPE,
                     "Mandatory" : true
                 }
             ]
         },
         {
             "Name" : "Threshold",
-            "Type" : "number",
+            "Type" : NUMBER_TYPE,
             "Default" : 1
         },
         {
             "Name" : "Severity",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Default" : "Info"
         },
         {
             "Name" : "Namespace",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Default" : ""
         },
         {
             "Name" : "Comparison",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Default" : "Threshold"
         },
         {
             "Name" : "Operator",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Default" : "GreaterThanOrEqualToThreshold"
         },
         {
             "Name" : "Time",
-            "Type" : "number",
+            "Type" : NUMBER_TYPE,
             "Default" : 300
         },
         {
             "Name" : "Periods",
-            "Type" : "number",
+            "Type" : NUMBER_TYPE,
             "Default" : 1
         },
         {
             "Name" : "Statistic",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Default" : "Sum"
         },
         {
             "Name" : "ReportOk",
-            "Type" : "boolean",
+            "Type" : BOOLEAN_TYPE,
             "Default" : false
         },
         {
             "Name" : "MissingData",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Default" : "notBreaching"
         }
     ]
@@ -164,45 +184,45 @@
 [#assign lbChildConfiguration = [
         {
             "Name" : "Tier",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Mandatory" : true
         },
         {
             "Name" : "Component",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Mandatory" : true
         },
         {
             "Name" : "LinkName",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Default" : "lb"
         },
         {
             "Name" : "Instance",
-            "Type" : "string"
+            "Type" : STRING_TYPE
         },
         {
             "Name" : "Version",
-            "Type" : "string"
+            "Type" : STRING_TYPE
         },
         {
             "Name" : "Path",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Default" : ""
         },
         {
             "Name" : ["PortMapping", "Port"],
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Default" : ""
         },
         {
             "Name" : "Priority",
-            "Type" : "number",
+            "Type" : NUMBER_TYPE,
             "Default" : 100
         },
         {
             "Name" : "TargetGroup",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Default" : ""
         }
     ]
@@ -211,18 +231,18 @@
 [#assign wafChildConfiguration = [
         {
             "Name" : "IPAddressGroups",
-            "Type" : "array",
+            "Type" : ARRAY_OF_STRING_TYPE,
             "Mandatory" : true
         },
         {
             "Name" : "Default",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Values" : ["ALLOW", "BLOCK"],
             "Default" : "BLOCK"
         },
         {
             "Name" : "RuleDefault",
-            "Type" : "string",
+            "Type" : STRING_TYPE,
             "Values" : ["ALLOW", "BLOCK"],
             "Default" : "ALLOW"
         }


### PR DESCRIPTION
Use constants for types

Introduce types for arrays of base types. The most common usage is array
of strings.

Update values checking to handle arrays of values.

Add some descriptive material in regards to qualifiers in prepraration
for its implementation.

Split all the "base" stuff from common.