### PR TITLE
Add fragment support for ecs solution

### DIFF
--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -208,7 +208,7 @@ function process_template() {
       ;;
 
     solution)
-      template_composites+=("SOLUTION" )
+      template_composites+=("SOLUTION" "FRAGMENT")
       passes=("${passes[@]}" "cli")
       if [[ -f "${cf_dir}/solution-${region}-template.json" ]]; then
         for pass in "${pass_list[@]}"; do

--- a/aws/templates/base.ftl
+++ b/aws/templates/base.ftl
@@ -11,6 +11,10 @@
     [#return valueIfTrue(value, content?has_content, otherwise) ]
 [/#function]
 
+[#function arrayIfContent value content otherwise=[]]
+    [#return valueIfContent(asArray(value), content, otherwise) ]
+[/#function]
+
 [#function contentIfContent value otherwise={}]
     [#return valueIfTrue(value, value?has_content, otherwise) ]
 [/#function]

--- a/aws/templates/id/id_datapipeline.ftl
+++ b/aws/templates/id/id_datapipeline.ftl
@@ -34,7 +34,7 @@
                     },
                     {
                         "Name" : "AppPublic",
-                        "Type" : BOOLEAN_TYPE",
+                        "Type" : BOOLEAN_TYPE,
                         "Default" : true
                     }
                 ]

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -97,6 +97,11 @@
         ECS_COMPONENT_TYPE : {
             "Attributes" : [
                 {
+                    "Name" : ["Fragment", "Container"],
+                    "Type" : "string",
+                    "Default" : ""
+                },
+                {
                     "Name" : "FixedIP",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
@@ -347,8 +352,8 @@
                 {
                     "Id" : formatDependentRoleId(taskId),
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
-                }    
-            ) + 
+                }
+            ) +
             attributeIfTrue(
                 "securityGroup",
                 solution.NetworkMode == "awsvpc",
@@ -403,11 +408,11 @@
                 {
                     "Id" : taskRoleId,
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
-                }    
+                }
             ),
             "Attributes" : {
                 "ECSHOST" : getExistingReference(ecsId)
-            } + 
+            } +
                 attributeIfTrue(
                     "DEFINITION",
                     solution.FixedName,
@@ -422,8 +427,8 @@
                                 getExistingReference(taskRoleId, ARN_ATTRIBUTE_TYPE)
                             ),
                             []
-                        ) 
-                } 
+                        )
+                }
             }
         }
     ]

--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -41,7 +41,7 @@
             },
             {
                 "Name" : "Encrypted",
-                "Type" : BOOLEAN_TYPE
+                "Type" : BOOLEAN_TYPE,
                 "Default" : false
             },
             {

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -65,6 +65,8 @@
 
         [#if deploymentSubsetRequired("iam", true) &&
                 isPartOfCurrentDeploymentUnit(ecsRoleId)]
+            [#assign linkPolicies = getLinkTargetsOutboundRoles(context.Links) ]
+
             [@createRole
                 mode=listMode
                 id=ecsRoleId
@@ -85,10 +87,17 @@
                                 s3ListPermission(operationsBucket) +
                                 s3WritePermission(operationsBucket, getSegmentBackupsFilePrefix()) +
                                 s3WritePermission(operationsBucket, "DOCKERLogs") +
-                                cwLogsProducePermission(ecsLogGroupName) +
-                                context.Policy,
+                                cwLogsProducePermission(ecsLogGroupName),
                             "docker")
-                    ]
+                    ] +
+                    valueIfContent(
+                        [getPolicyDocument(context.Policy, "fragment")],
+                        context.Policy,
+                        []) +
+                    valueIfContent(
+                        [getPolicyDocument(linkPolicies, "links")],
+                        linkPolicies,
+                        [])
             /]
 
             [@createRole

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -30,20 +30,48 @@
         [#assign logFileProfile = getLogFileProfile(tier, component, "ECS")]
 
         [#assign configSetName = componentType ]
-        [#assign configSets =  
-                getInitConfigDirectories() + 
+        [#assign configSets =
+                getInitConfigDirectories() +
                 getInitConfigBootstrap(component.Role!"") +
                 getInitConfigECSAgent(ecsId, defaultLogDriver, solution.DockerUsers) ]
-        
+
         [#assign efsMountPoints = {}]
-    
+
+        [#assign fragment =
+            contentIfContent(solution.Fragment, getComponentId(component)) ]
+
+        [#assign contextLinks = getLinkTargets(occurrence) ]
+        [#assign context =
+            {
+                "Id" : fragment,
+                "Name" : fragment,
+                "Instance" : core.Instance.Id,
+                "Version" : core.Version.Id,
+                "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks),
+                "Environment" : {},
+                "Links" : contextLinks,
+                "DefaultCoreVariables" : true,
+                "DefaultEnvironmentVariables" : true,
+                "DefaultLinkVariables" : true,
+                "Policy" : [],
+                "ManagedPolicy" : []
+            }
+        ]
+
+        [#-- Add in fragment specifics including override of defaults --]
+        [#assign fragmentListMode = "model"]
+        [#assign fragmentId = formatFragmentId(context)]
+        [#include fragmentList?ensure_starts_with("/")]
+
         [#if deploymentSubsetRequired("iam", true) &&
                 isPartOfCurrentDeploymentUnit(ecsRoleId)]
             [@createRole
                 mode=listMode
                 id=ecsRoleId
                 trustedServices=["ec2.amazonaws.com" ]
-                managedArns=["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"]
+                managedArns=
+                    ["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"] +
+                    context.ManagedPolicy
                 policies=
                     [
                         getPolicyDocument(
@@ -52,36 +80,37 @@
                                 fixedIP?then(
                                     ec2IPAddressUpdatePermission(),
                                     []
-                                ) +                            
+                                ) +
                                 s3ReadPermission(codeBucket) +
                                 s3ListPermission(operationsBucket) +
                                 s3WritePermission(operationsBucket, getSegmentBackupsFilePrefix()) +
-                                s3WritePermission(operationsBucket, "DOCKERLogs") + 
-                                cwLogsProducePermission(ecsLogGroupName),
+                                s3WritePermission(operationsBucket, "DOCKERLogs") +
+                                cwLogsProducePermission(ecsLogGroupName) +
+                                context.Policy,
                             "docker")
                     ]
             /]
-    
+
             [@createRole
                 mode=listMode
                 id=ecsServiceRoleId
                 trustedServices=["ecs.amazonaws.com" ]
                 managedArns=["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"]
             /]
-        
+
         [/#if]
-    
+
         [#if solution.ClusterLogGroup &&
                 deploymentSubsetRequired("lg", true) &&
                 isPartOfCurrentDeploymentUnit(ecsLogGroupId)]
-            [@createLogGroup 
+            [@createLogGroup
                 mode=listMode
                 id=ecsLogGroupId
                 name=ecsLogGroupName /]
         [/#if]
 
         [#if deploymentSubsetRequired("lg", true) && isPartOfCurrentDeploymentUnit(ecsInstanceLogGroupId) ]
-            [@createLogGroup 
+            [@createLogGroup
                 mode=listMode
                 id=ecsInstanceLogGroupId
                 name=ecsInstanceLogGroupName /]
@@ -92,56 +121,46 @@
                 logFileProfile,
                 ecsInstanceLogGroupName
             )]
-            
+
         [#if deploymentSubsetRequired("ecs", true)]
-    
-            [#list solution.Links?values as link]
-                [#if link?is_hash]
-                    [#assign linkTarget = getLinkTarget(occurrence, link) ]
 
-                    [@cfDebug listMode linkTarget false /]
+            [#list contextLinks?values as linkTarget]
+                [#assign linkTargetCore = linkTarget.Core ]
+                [#assign linkTargetConfiguration = linkTarget.Configuration ]
+                [#assign linkTargetResources = linkTarget.State.Resources ]
+                [#assign linkTargetAttributes = linkTarget.State.Attributes ]
 
-                    [#if !linkTarget?has_content]
-                        [#continue]
-                    [/#if]
-
-                    [#assign linkTargetCore = linkTarget.Core ]
-                    [#assign linkTargetConfiguration = linkTarget.Configuration ]
-                    [#assign linkTargetResources = linkTarget.State.Resources ]
-                    [#assign linkTargetAttributes = linkTarget.State.Attributes ]
-
-                    [#switch linkTargetCore.Type]
-                        [#case EFS_MOUNT_COMPONENT_TYPE]
-                            [#assign configSets += 
-                                getInitConfigEFSMount(
-                                    linkTargetCore.Id, 
-                                    linkTargetAttributes.EFS, 
-                                    linkTargetAttributes.DIRECTORY, 
-                                    link.Id
-                                )]
-                            [#break]
-                    [/#switch]
-                [/#if]
+                [#switch linkTargetCore.Type]
+                    [#case EFS_MOUNT_COMPONENT_TYPE]
+                        [#assign configSets +=
+                            getInitConfigEFSMount(
+                                linkTargetCore.Id,
+                                linkTargetAttributes.EFS,
+                                linkTargetAttributes.DIRECTORY,
+                                link.Id
+                            )]
+                        [#break]
+                [/#switch]
             [/#list]
 
             [@createComponentSecurityGroup
                 mode=listMode
                 tier=tier
                 component=component /]
-    
+
             [#assign processorProfile = getProcessor(tier, component, "ECS")]
             [#assign maxSize = processorProfile.MaxPerZone]
             [#if multiAZ]
                 [#assign maxSize = maxSize * zones?size]
             [/#if]
             [#assign storageProfile = getStorage(tier, component, "ECS")]
-            
+
             [@cfResource
                 mode=listMode
                 id=ecsId
                 type="AWS::ECS::Cluster"
             /]
-            
+
             [@cfResource
                 mode=listMode
                 id=ecsInstanceProfileId
@@ -153,7 +172,7 @@
                     }
                 outputs={}
             /]
-        
+
             [#assign allocationIds = [] ]
             [#if fixedIP]
                 [#list 1..maxSize as index]
@@ -168,12 +187,12 @@
                     ]
                 [/#list]
             [/#if]
-            
+
             [#if allocationIds?has_content ]
-                [#assign configSets += 
+                [#assign configSets +=
                     getInitConfigEIPAllocation(allocationIds)]
             [/#if]
-        
+
             [@cfResource
                 mode=listMode
                 id=ecsAutoScaleGroupId
@@ -207,9 +226,9 @@
                         true)
                 outputs={}
             /]
-                    
-            
-            [@createEC2LaunchConfig 
+
+
+            [@createEC2LaunchConfig
                 mode=listMode
                 id=ecsLaunchConfigId
                 processorProfile=processorProfile

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -90,14 +90,12 @@
                                 cwLogsProducePermission(ecsLogGroupName),
                             "docker")
                     ] +
-                    valueIfContent(
+                    arrayIfContent(
                         [getPolicyDocument(context.Policy, "fragment")],
-                        context.Policy,
-                        []) +
-                    valueIfContent(
+                        context.Policy) +
+                    arrayIfContent(
                         [getPolicyDocument(linkPolicies, "links")],
-                        linkPolicies,
-                        [])
+                        linkPolicies)
             /]
 
             [@createRole


### PR DESCRIPTION
For legacy containers that don't support task roles, allow permissions
to be added to the ecs instance service role.

The main target at this point is the rabbit container.

An alternative was to attach container policies to the ecs role rather than task roles, but this got messy in terms of ensuring everything was included into the iam subset and handling use of managed policies, so I just opted for adding the same policy via fragments at the solution level.