### PR TITLE
Add hostname fix for RDS and minor type lookup fix

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -494,7 +494,7 @@ behaviour.
                     description="Mandatory attribute missing"
                     context=
                         {
-                            "ExpectedNames" : attributeNames,
+                            "ExpectedNames" : attribute.Names,
                             "CandidateObjects" : objects
                         }
                 /]

--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -72,8 +72,8 @@
             },
             {
                 "Name" : "Size",
-                "Type" : STRING_TYPE,
-                "Default" : "20"
+                "Type" : NUMBER_TYPE,
+                "Default" : 20
             },
             {
                 "Name" : "Backup",

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -382,11 +382,14 @@
                         " \"" + rdsFullName + "\" " +
                         " \"$\{master_password}\" || return $?",
                         "info \"Generating URL... \"",
+                        "rds_hostname=\"$(get_rds_hostname" + 
+                        " \"" + region + "\" " +
+                        " \"" + rdsFullName + "\" || return $?)\"",
                         "rds_url=\"$(get_rds_url" +
                         " \"" + engine + "\" " +
                         " \"" + rdsUsername + "\" " +
                         " \"$\{master_password}\" " +
-                        " \"" + rdsFQDN + "\" " +
+                        " \"$\{rds_hostname}\" " +
                         " \"" + port?c + "\" " +
                         " \"" + rdsDatabaseName + "\" || return $?)\"",
                         "encrypted_rds_url=\"$(encrypt_kms_string" +

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -266,6 +266,7 @@
                 [#break]
 
                 [#case "replace2"]
+                    [#assign multiAZ = false]
                     [#if rdsManualSnapshot?has_content ]
                         [#assign snapshotId = rdsManualSnapshot ]
                     [#else]
@@ -342,11 +343,14 @@
                         "\"$\{password_pseudo_stack_file}\"" + " " +
                         "\"" + rdsId + "Xgeneratedpassword\" \"$\{encrypted_master_password}\" || return $?",
                         "info \"Generating URL... \"",
+                        "rds_hostname=\"$(get_rds_hostname" + 
+                        " \"" + region + "\" " +
+                        " \"" + rdsFullName + "\" || return $?)\"",
                         "rds_url=\"$(get_rds_url" +
                         " \"" + engine + "\" " +
                         " \"" + rdsUsername + "\" " +
                         " \"$\{master_password}\" " +
-                        " \"" + rdsFQDN + "\" " +
+                        " \"$\{rds_hostname}\" " +
                         " \"" + port?c + "\" " +
                         " \"" + rdsDatabaseName + "\" || return $?)\"",
                         "encrypted_rds_url=\"$(encrypt_kms_string" +

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -1231,6 +1231,21 @@ function set_rds_master_password() {
   aws --region "${region}" rds modify-db-instance --db-instance-identifier ${db_identifier} --master-user-password "${password}" 1> /dev/null
 }
 
+function get_rds_hostname() {
+  local region="$1"; shift
+  local db_identifier="$1"; shift
+
+  hostname="$(aws --region "${region}" rds describe-db-instances --db-instance-identifier ${db_identifier} --query 'DBInstances[0].Endpoint.Address' --output text)"
+
+  if [[ "${hostname}" != "None" ]]; then
+    echo "${hostname}"
+    return 0
+  else
+    fatal "hostname not found for rds instance ${db_identifier}"
+    return 255
+  fi
+}
+
 function check_rds_snapshot_username() {
   local region="$1"; shift
   local db_snapshot_identifier="$1"; shift


### PR DESCRIPTION
Fixes #431 
Instead of using a getExistingRefernce to determine the hostname the RDS hostname is looked up using the AWS cli when generating the encrypted URL. 

Also a couple of extra fixes for the size type attribute exceptions