### PR TITLE
Add manged Policy fragment support to lambda and compute cluster

### DIFF
--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -135,6 +135,11 @@
                                 "loadbalancing")
                         ],
                         [])
+                managedArns=
+                    arrayIfContent(
+                        context.ManagedPolicy
+                        context.ManagedPolicy
+                    )
             /]
 
         [/#if]

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -85,17 +85,24 @@
 
             [#assign roleId = formatDependentRoleId(fnId)]
             [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(roleId)]
+                [#assign managedPolicies = 
+                        (vpc?has_content && solution.VPCAccess)?then(
+                            ["arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"],
+                            ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
+                        ) + 
+                        arrayIfContent(
+                            context.ManagedPolicy
+                            context.ManagedPolicy
+                        )]
+
                 [#-- Create a role under which the function will run and attach required policies --]
                 [#-- The role is mandatory though there may be no policies attached to it --]
                 [@createRole
                     mode=listMode
                     id=roleId
                     trustedServices=["lambda.amazonaws.com"]
-                    managedArns=
-                        (vpc?has_content && solution.VPCAccess)?then(
-                            ["arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"],
-                            ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
-                        )
+                    managedArns=managedPolicies
+
                 /]
 
                 [#if context.Policy?has_content]


### PR DESCRIPTION
Add the ability to attach extra managed polices to lambda and compute cluster components through fragements using the managedPolicy macro. 