### PR TITLE
LB Forwarding Attributes

### DIFF
--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -65,12 +65,6 @@
                 "Type" : STRING_TYPE
             },
             {
-                "Name" : "TargetType",
-                "Type" : STRING_TYPE,
-                "Values" : ["instance", "ip"],
-                "Default" : "instance"
-            },
-            {
                 "Name" : "Path",
                 "Type" : STRING_TYPE,
                 "Default" : "default"
@@ -158,6 +152,12 @@
             {
                 "Name" : "Forward",
                 "Children" : [
+                    {
+                        "Name" : "TargetType",
+                        "Type" : STRING_TYPE,
+                        "Values" : ["instance", "ip"],
+                        "Default" : "instance"
+                    },
                     {
                         "Name" : "SlowStartTime",
                         "Type" : NUMBER_TYPE,

--- a/aws/templates/resource/resource_lb.ftl
+++ b/aws/templates/resource/resource_lb.ftl
@@ -275,7 +275,7 @@
     /]
 [/#macro]
 
-[#macro createClassicLB mode id name shortName tier component listeners healthCheck securityGroups idleTimeout logs=false bucket="" dependencies="" ]
+[#macro createClassicLB mode id name shortName tier component listeners healthCheck securityGroups idleTimeout deregistrationTimeout stickinessPolicies=[] logs=false bucket="" dependencies="" ]
         [@cfResource
         mode=listMode
         id=id
@@ -313,6 +313,19 @@
                     }
                 },
                 {}
+            ) + 
+            ( deregistrationTimeout > 0 )?then(
+                {
+                    "ConnectionDrainingPolicy" : {
+                        "Enabled" : true,
+                        "Timeout" : deregistrationTimeout
+                    }
+                },
+                {}
+            ) + 
+            attributeIfContent(
+                "LBCookieStickinessPolicy",
+                stickinessPolicies
             )
         tags=
             getCfTemplateCoreTags(


### PR DESCRIPTION
Adds LB Forwarding attributes to LB component
 - Stickiness - Cookie based stickiness to pin a user to a specific backend target for a given period of time ( Application and Classic Type) 
 - Slow Ramp up - Introduces a new backend target to the load balancing pool slowly to allow the backend to warm up ( Application Type) 
 - DeregistrationTimeout - How long connections should be drained on a target if it is being removed from LB ( All Types ) 

Also fixes up TargetType ( instance based or IP based ) and moves it under the forwarding options. 