### PR TITLE
Add CORS Profiles and enable for S3

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1476,5 +1476,44 @@
         "LogFileGroups" : ["system", "aws-system", "security", "docker", "aws-ecs"]
       }
     }
+  },
+  "CORSProfiles" : {
+    "S3Read" : {
+      "AllowedOrigins" : [ "*" ],
+      "AllowedMethods" : [ "GET", "HEAD" ],
+      "AllowedHeaders" : [ "*" ],
+      "ExposeHeaders"  : [ "ETag" ],
+      "MaxAge"         : 1800
+    },
+    "S3Write" : {
+      "AllowedOrigins" : [ "*" ],
+      "AllowedMethods" : [ "PUT", "POST" ],
+      "AllowedHeaders" : [ 
+        "Content-Length", 
+        "Content-Type", 
+        "Content-MD5", 
+        "Authorization",
+        "Expect",
+        "x-amz-content-sha256",
+        "x-amz-security-token"
+      ],
+      "ExposeHeaders"  : [ "ETag" ],
+      "MaxAge"         : 1800
+    },
+    "S3Delete" : {
+      "AllowedOrigins" : [ "*" ],
+      "AllowedMethods" : [ "DELETE" ],
+      "AllowedHeaders" : [ 
+        "Content-Length", 
+        "Content-Type", 
+        "Content-MD5", 
+        "Authorization",
+        "Expect",
+        "x-amz-content-sha256",
+        "x-amz-security-token"
+      ],
+      "ExposeHeaders"  : [ "ETag" ],
+      "MaxAge"         : 1800
+    }
   }
 }

--- a/aws/templates/id/id_s3.ftl
+++ b/aws/templates/id/id_s3.ftl
@@ -143,6 +143,11 @@
             {
                 "Name" : "Notifications",
                 "Type" : OBJECT_TYPE
+            },
+            {
+                "Name" : "CORSBehaviours",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
             }
         ]
     }]

--- a/aws/templates/resource/resource_s3.ftl
+++ b/aws/templates/resource/resource_s3.ftl
@@ -129,6 +129,7 @@
                         versioning=false
                         websiteConfiguration={}
                         cannedACL=""
+                        CORSBehaviours=[]
                         dependencies="" 
                         outputId=""]
 
@@ -145,6 +146,23 @@
             "Status" : "Enabled"
         } ]
     [/#if]
+
+    [#assign CORSRules = [] ]
+    [#list CORSBehaviours as behaviour ]
+        [#assign CORSBehaviour = CORSProfiles[behaviour] ]
+        [#if CORSBehaviour?has_content ]
+            [#assign CORSRules += [
+                {
+                    "Id" : behaviour,
+                    "AllowedHeaders" : CORSBehaviour.AllowedHeaders!["*"],
+                    "AllowedMethods" : CORSBehaviour.AllowedMethods!["*"],
+                    "AllowedOrigins" : CORSBehaviour.AllowedOrigins!["*"],
+                    "ExposedHeaders" : CORSBehaviour.ExposedHeaders![],
+                    "MaxAge" : (CORSBehaviour.MaxAge)?c!"30"
+                }
+            ]]
+        [/#if]
+    [/#list]
 
     [@cfResource 
         mode=mode
@@ -181,6 +199,13 @@
             attributeIfContent(
                 "VersioningConfiguration",
                 versionConfiguration
+            ) + 
+            attributeIfContent(
+                "CorsConfiguration",
+                CORSRules,
+                {
+                    "CorsRules" : CORSRules
+                }
             )
         tags=getCfTemplateCoreTags("", tier, component)
         outputs=S3_OUTPUT_MAPPINGS

--- a/aws/templates/resource/resource_s3.ftl
+++ b/aws/templates/resource/resource_s3.ftl
@@ -154,11 +154,11 @@
             [#assign CORSRules += [
                 {
                     "Id" : behaviour,
-                    "AllowedHeaders" : CORSBehaviour.AllowedHeaders!["*"],
-                    "AllowedMethods" : CORSBehaviour.AllowedMethods!["*"],
-                    "AllowedOrigins" : CORSBehaviour.AllowedOrigins!["*"],
-                    "ExposedHeaders" : CORSBehaviour.ExposedHeaders![],
-                    "MaxAge" : (CORSBehaviour.MaxAge)?c!"30"
+                    "AllowedHeaders" : CORSBehaviour.AllowedHeaders,
+                    "AllowedMethods" : CORSBehaviour.AllowedMethods,
+                    "AllowedOrigins" : CORSBehaviour.AllowedOrigins,
+                    "ExposedHeaders" : CORSBehaviour.ExposedHeaders,
+                    "MaxAge" : (CORSBehaviour.MaxAge)?c
                 }
             ]]
         [/#if]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -282,6 +282,7 @@
 [#assign logFiles = blueprintObject.LogFiles ]
 [#assign logFileGroups = blueprintObject.LogFileGroups]
 [#assign logFileProfiles = blueprintObject.LogFileProfiles ]
+[#assign CORSProfiles = blueprintObject.CORSProfiles ]
 
 [#-- Regions --]
 [#if region?has_content]

--- a/aws/templates/solution/solution_s3.ftl
+++ b/aws/templates/solution/solution_s3.ftl
@@ -117,6 +117,7 @@
                     getS3WebsiteConfiguration(solution.Website.Index, solution.Website.Error),
                     {})
             versioning=solution.Lifecycle.Versioning
+            CORSBehaviours=solution.CORSBehaviours
             dependencies=dependencies
         /]
 


### PR DESCRIPTION
Fixes: https://github.com/codeontap/codeontap/issues/35 

Adds support for CORS Profiles to be defined and applied to S3 Buckets. Created a set of basic default CORS Profiles which can be used for S3 bucket actions S3Read,S3Write,S3Delete. 
