### PR TITLE
Add fragment support for file and directory creation

### DIFF
--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -106,7 +106,9 @@
 
         [#assign environmentVariables += getFinalEnvironment(occurrence, context).Environment ]
 
-        [#assign configSets +=  getInitConfigEnvFacts(environmentVariables, false) ]
+        [#assign configSets +=  
+            getInitConfigEnvFacts(environmentVariables, false) +
+            getInitConfigDirsFiles(context.Files, context.Directories) ]
 
         [#if deploymentSubsetRequired("iam", true) &&
                 isPartOfCurrentDeploymentUnit(computeClusterRoleId)]

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -295,6 +295,38 @@
     [/#if]
 [/#macro]
 
+[#-- Compute instance fragment macros --]
+[#macro File path mode="644" owner="root" group="root" content=[] ]
+    [#if (fragmentListMode!"") == "model"]
+        [#assign context += 
+            {
+                "Files" : (context.Files!{}) + {
+                    path : {
+                        "mode" : mode,
+                        "owner" : owner,
+                        "group" : group,
+                        "content" : content
+                    }
+                }
+            }]
+    [/#if]
+[/#macro]
+
+[#macro Directory path mode="755" owner="root" group="root" ]
+    [#if (fragmentListMode!"") == "model"]
+        [#assign context +=
+            {
+                "Directories" : (context.Directories!{}) + {
+                    path : {
+                        "mode" : mode,
+                        "owner" : owner,
+                        "group" : group
+                    }
+                }
+            }]
+    [/#if]
+[/#macro]
+
 [#assign ECS_DEFAULT_MEMORY_LIMIT_MULTIPLIER=1.5 ]
 
 [#function defaultEnvironment occurrence links]

--- a/aws/templates/id/id_ec2.ftl
+++ b/aws/templates/id/id_ec2.ftl
@@ -91,6 +91,11 @@
                 "Default" : false
             },
             {
+                "Name" : ["Fragment", "Container"],
+                "Type" : "string",
+                "Default" : ""
+            },
+            {
                 "Name" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -67,11 +67,14 @@
             [/#if]
         [/#list]
 
+        [#assign fragment =
+            contentIfContent(solution.Fragment, getComponentId(component)) ]
+
         [#assign contextLinks = getLinkTargets(occurrence, links) ]
         [#assign context =
             {
-                "Id" : getComponentId(component),
-                "Name" : getComponentId(component),
+                "Id" : fragment,
+                "Name" : fragment,
                 "Instance" : core.Instance.Id,
                 "Version" : core.Version.Id,
                 "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks),
@@ -83,9 +86,16 @@
             }
         ]
 
+        [#-- Add in fragment specifics including override of defaults --]
+        [#assign fragmentListMode = "model"]
+        [#assign fragmentId = formatFragmentId(context)]
+        [#include fragmentList?ensure_starts_with("/")]
+
         [#assign environmentVariables += getFinalEnvironment(occurrence, context).Environment ]
 
-        [#assign configSets +=  getInitConfigEnvFacts(environmentVariables, false) ]
+        [#assign configSets +=  
+            getInitConfigEnvFacts(environmentVariables, false) +
+            getInitConfigDirsFiles(context.Files, context.Directories) ]
 
         [#list links?values as link]
             [#assign linkTarget = getLinkTarget(occurrence, link) ]

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -63,6 +63,9 @@
         [#assign fragmentId = formatFragmentId(context)]
         [#include fragmentList?ensure_starts_with("/")]
 
+        [#assign configSets += 
+            getInitConfigDirsFiles(context.Files, context.Directories) ]
+            
         [#if deploymentSubsetRequired("iam", true) &&
                 isPartOfCurrentDeploymentUnit(ecsRoleId)]
             [#assign linkPolicies = getLinkTargetsOutboundRoles(context.Links) ]


### PR DESCRIPTION
Adds the ability to create files and directories on ec2 based instance components with fragment macros

- File - creates a file with optionally specified contents
- Directory - Creates a directory, if the directory already exists updates dir permissions and its child with the settings in the macro 

