### PR TITLE
Correct syntax errors with managed policy changes

### DIFF
--- a/aws/createExtendedSwaggerSpecification.sh
+++ b/aws/createExtendedSwaggerSpecification.sh
@@ -134,6 +134,7 @@ done
 # If the target is a zip file, zip up the generated files
 cd "${tmp_results_dir}"
 if [[ "${EXTENDED_SWAGGER_FILE_EXTENSION}" == "zip" ]]; then
+    cp "${SWAGGER_FILE}" "${EXTENDED_SWAGGER_FILE_BASE}-extended-base.json"
     zip ${EXTENDED_SWAGGER_FILE_BASE}.zip *.json
     rm *.json
 fi

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -96,7 +96,7 @@
                 "DefaultEnvironmentVariables" : true,
                 "DefaultLinkVariables" : true,
                 "Policy" : [],
-                "ManagedPolicy: [],
+                "ManagedPolicy" : [],
                 "Files" : {},
                 "Directories" : {}
             }

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -44,7 +44,7 @@
                     "DefaultEnvironmentVariables" : true,
                     "DefaultLinkVariables" : true,
                     "Policy" : standardPolicies(fn),
-                    "ManagedPolicy: []
+                    "ManagedPolicy" : []
                 }
             ]
 


### PR DESCRIPTION
Fix a couple of syntax errors with recent changes related to managed
policies.

Also include the base file used when generating the swagger zip file.

This will be used by the deployment based processing of swagger files.