### PR TITLE
Add conversion of boolean and number in string setup

### DIFF
--- a/aws/templates/base.ftl
+++ b/aws/templates/base.ftl
@@ -82,7 +82,11 @@
     [#if arg?is_hash || arg?is_sequence ]
         [#return getJSON(arg) ]
     [#else]
-        [#return arg ]
+        [#if arg?is_boolean || arg?is_number ]
+            [#return arg?c]
+        [#else]
+            [#return arg ]
+        [/#if]
     [/#if]
 [/#function]
 


### PR DESCRIPTION
When an appsettings is set as a boolean or number in the app settings it should be converted to a string when it is converted into environment variables. 