### PR TITLE
Fix redirect config

### DIFF
--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -100,7 +100,7 @@
                     {
                         "Name" : "Protocol",
                         "Type" : STRING_TYPE,
-                        "Values" : ["HTTPS", "#\{[protocol}" ]
+                        "Values" : ["HTTPS", "#\{protocol}" ],
                         "Default" : "HTTPS"
                     },
                     {
@@ -116,7 +116,7 @@
                     {
                         "Name" : "Path",
                         "Type" : STRING_TYPE,
-                        "Default" : "#\{path}"
+                        "Default" : "/#\{path}"
                     },
                     {
                         "Name" : "Query",

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -100,7 +100,8 @@
                     {
                         "Name" : "Protocol",
                         "Type" : STRING_TYPE,
-                        "Default" : "https"
+                        "Values" : ["HTTPS", "#\{[rotocol}" ]
+                        "Default" : "HTTPS"
                     },
                     {
                         "Name" : "Port",
@@ -125,7 +126,7 @@
                     {
                         "Name" : "Permanent",
                         "Type" : BOOLEAN_TYPE,
-                        "Default" : false
+                        "Default" : true
                     }
                 ]
             },

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -100,7 +100,7 @@
                     {
                         "Name" : "Protocol",
                         "Type" : STRING_TYPE,
-                        "Values" : ["HTTPS", "#\{[rotocol}" ]
+                        "Values" : ["HTTPS", "#\{[protocol}" ]
                         "Default" : "HTTPS"
                     },
                     {

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -375,14 +375,14 @@
                                                         "       \"" + region + "\" " +
                                                         "       \"" + getExistingReference(listenerRuleId) + "\" " +
                                                         "       \"$\{tmpdir}/cli-" +
-                                                                listenerRuleId + "-" + listenerRuleCommand + ".json\""
+                                                                listenerRuleId + "-" + listenerRuleCommand + ".json\" || return $?"
                                                     ],
                                                     [
                                                         "       listener_rule_arn=$( create_elbv2_rule" +
                                                         "       \"" + region + "\" " +
                                                         "       \"" + getExistingReference(listenerId) + "\" " +
                                                         "       \"$\{tmpdir}/cli-" +
-                                                                listenerRuleId + "-" + listenerRuleCommand + ".json\")",
+                                                                listenerRuleId + "-" + listenerRuleCommand + ".json\" || return $?)",
                                                         "       pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-pseudo-stack.json\" ",
                                                         "       create_pseudo_stack" + " " +
                                                         "       \"LB Listener Rule\"" + " " +

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -857,6 +857,7 @@ function create_elbv2_rule() {
     return 255
   else
     echo "${rule_arn}"
+    return 0
   fi
 }
 


### PR DESCRIPTION
Minor fix for redirect policy. When applying the current redirect rule I get the following error: 

> An error occurred (ValidationError) when calling the CreateRule operation: 1 validation error detected: Value 'https' at 'actions.1.member.redirectConfig.protocol' failed to satisfy constraint: Member must satisfy regular expression pattern: ^(HTTPS?|#\{protocol\})$

Looks like the protocol can either be HTTPS or the protocol variable. 

Also made Permanent enabled by default since this would make the default redirect config perform an http -> https redirect as it would be expected.