### PR TITLE
Refactor account level support

### DIFF
--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -685,7 +685,7 @@ function isValidUnit() {
   # Check unit if required
   if [[ "${unit_required[${level}]}" == "true" ]]; then
     # Default deployment units for each level
-    declare -ga ACCOUNT_UNITS_ARRAY=("audit" "s3" "cert" "roles" "apigateway" "waf")
+    declare -ga ACCOUNT_UNITS_ARRAY=("iam" "audit" "s3" "cert" "roles" "apigateway" "waf" "sms")
     declare -ga PRODUCT_UNITS_ARRAY=("s3" "sns" "cert" "cmk")
     declare -ga BUILDBLUEPRINT_UNITS_ARRAY=(${unit})
     declare -ga APPLICATION_UNITS_ARRAY=(${unit})

--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -155,8 +155,8 @@ function process_template() {
     ["prologue"]="prologue.sh"
     ["template"]="template.json"
     ["epilogue"]="epilogue.sh"
-    ["config"]="config.json"
-    ["cli"]="cli.json")
+    ["cli"]="cli.json"
+    ["config"]="config.json")
 
   # Template pass specifics
   pass_deployment_unit_subset["template"]="${deployment_unit_subset}"
@@ -171,7 +171,6 @@ function process_template() {
   case "${level}" in
     blueprint)
       cf_dir="${PRODUCT_INFRASTRUCTURE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
-      pass_list=("template")
       passes=("template")
       template_composites+=("SEGMENT" "SOLUTION" "APPLICATION" "FRAGMENT" )
 
@@ -189,7 +188,6 @@ function process_template() {
     buildblueprint)
       # this is expected to run from an automation context
       cf_dir="${AUTOMATION_DATA_DIR:-${PRODUCT_INFRASTRUCTURE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}}/"
-      pass_list=("template")
       passes=("template")
       template_composites+=("APPLICATION" "FRAGMENT" )
 
@@ -208,6 +206,7 @@ function process_template() {
       cf_dir="${ACCOUNT_INFRASTRUCTURE_DIR}/cf/shared"
       for pass in "${pass_list[@]}"; do pass_region_prefix["${pass}"]="${account_region}-"; done
       template_composites+=("ACCOUNT")
+      passes=("${passes[@]}" "cli")
 
       # LEGACY: Support stacks created before deployment units added to account level
       [[ ("${DEPLOYMENT_UNIT}" =~ s3) &&

--- a/aws/templates/account/account_apigateway.ftl
+++ b/aws/templates/account/account_apigateway.ftl
@@ -1,16 +1,18 @@
-[#-- Account level roles --]
-[#if deploymentUnit?contains("apigateway")]
-    [#if deploymentSubsetRequired("apigateway", true)]
-        [#assign cloudWatchRoleId = formatAccountRoleId("cloudwatch")]
-        [#assign apiAccountId = formatAccountResourceId("apiAccount","cloudwatch")]
-        
+[#-- API Gateway --]
+[#if deploymentUnit?contains("apigateway") || (allDeploymentUnits!false) ]
+    [#assign cloudWatchRoleId = formatAccountRoleId("cloudwatch")]
+    [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(cloudWatchRoleId)]
         [@createRole
             mode=listMode
             id=cloudWatchRoleId
             trustedServices=["apigateway.amazonaws.com"]
             managedArns=["arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"]
         /]
-        
+    [/#if]
+
+    [#if deploymentSubsetRequired("apigateway", true)]
+        [#assign apiAccountId = formatAccountResourceId("apiAccount","cloudwatch")]
+
         [@cfResource
             mode=listMode
             id=apiAccountId

--- a/aws/templates/account/account_audit.ftl
+++ b/aws/templates/account/account_audit.ftl
@@ -1,5 +1,5 @@
 [#-- Auditing configuration --]
-[#if deploymentUnit?contains("audit")]
+[#if deploymentUnit?contains("audit") || (allDeploymentUnits!false) ]
 
     [#if accountObject.Seed?has_content]
 

--- a/aws/templates/account/account_cert.ftl
+++ b/aws/templates/account/account_cert.ftl
@@ -1,5 +1,5 @@
 [#-- Generate certificate --]
-[#if deploymentUnit?contains("cert")]
+[#if deploymentUnit?contains("cert") || (allDeploymentUnits!false) ]
     [#if deploymentSubsetRequired("cert", true)]
         [#assign certificateId = formatCertificateId(accountDomainCertificateId)]
     

--- a/aws/templates/account/account_roles.ftl
+++ b/aws/templates/account/account_roles.ftl
@@ -1,6 +1,6 @@
 [#-- Account level roles --]
-[#if deploymentUnit?contains("roles")]
-    [#if deploymentSubsetRequired("iam", true)]
+[#if deploymentUnit?contains("roles")  || (allDeploymentUnits!false) ]
+    [#if deploymentSubsetRequired("roles", true)]
         [#assign automationRoleId = formatAccountRoleId("automation")]
         [#assign administratorRoleId = formatAccountRoleId("administrator")]
         [#assign viewerRoleId = formatAccountRoleId("viewer")]

--- a/aws/templates/account/account_s3.ftl
+++ b/aws/templates/account/account_s3.ftl
@@ -1,14 +1,14 @@
 [#-- Standard set of buckets for an account --]
-[#if deploymentUnit?contains("s3")]
+[#if deploymentUnit?contains("s3") || (allDeploymentUnits!false) ]
     [#if accountObject.Seed?has_content]
         [#if deploymentSubsetRequired("s3", true)]
-        
+
             [#assign buckets = ["credentials", "code", "registry"] ]
             [#list buckets as bucket]
-            
+
                 [#-- TODO: Should be using formatAccountS3Id() not formatS3Id() --]
                 [#-- TODO: Remove outputId parameter below when TODO addressed --]
-                
+
                 [#assign existingName = getExistingReference(formatAccountS3Id(bucket))]
                 [#assign bucketName = valueIfContent(
                                             existingName,
@@ -36,12 +36,12 @@
                                             awsAccount)
                         }]
 
-                        [#assign policyStatements += 
+                        [#assign policyStatements +=
                                 s3ReadPermission(
                                     bucketName,
                                     "",
                                     "*",
-                                    accountPrincipal 
+                                    accountPrincipal
                                 ) + s3ListPermission(
                                     bucketName,
                                     "",
@@ -84,7 +84,7 @@
                         "  info \"Synching the code bucket ...\"",
                         "  if [[ -d \"$\{GENERATION_STARTUP_DIR}\" ]]; then",
                         "      aws --region \"$\{ACCOUNT_REGION}\" s3 sync --delete --exclude=\".git*\" \"$\{GENERATION_STARTUP_DIR}/bootstrap/\" \"s3://" +
-                                  codeBucket + 
+                                  codeBucket +
                                   "/bootstrap/\" ||",
                         "         { exit_status=$?; fatal \"Can't sync the code bucket\"; return \"$\{exit_status}\"; }",
                         "  else",

--- a/aws/templates/account/account_sms.ftl
+++ b/aws/templates/account/account_sms.ftl
@@ -1,0 +1,90 @@
+[#-- SMS --]
+[#if deploymentUnit?contains("sms") || (allDeploymentUnits!false) ]
+    [#assign cloudWatchRoleId = formatAccountRoleId("sms","cloudwatch")]
+    [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(cloudWatchRoleId)]
+        [@createRole
+            mode=listMode
+            id=cloudWatchRoleId
+            trustedServices=["sns.amazonaws.com"]
+            policies=
+                getPolicyDocument(
+                    cwLogsProducePermission() +
+                    cwLogsConfigurePermission(),
+                    "sms"
+                )
+        /]
+    [/#if]
+
+    [#assign smsS3Id = formatAccountS3Id("ops") ]
+    [#assign smsResourceId = "sms" ]
+    [#assign smsCliCommand = "set-sms-attributes" ]
+
+    [#-- Need to run the unit twice or use an IAM unit so the role can be included in the CLI --]
+    [#if deploymentSubsetRequired("cli", false) ]
+
+        [#assign smsSettings = getAccountSettings() ]
+        [#assign successSamplingRate =
+            contentIfContent(
+                getSetting(smsSettings, ["SMS", "SUCCESS", "SAMPLING", "RATE"], true).Value,
+                100
+            ) ]
+        [#assign smsType =
+            contentIfContent(
+                getSetting(smsSettings, ["SMS", "DEFAULT", "TYPE"], true).Value,
+                "Transactional"
+            ) ]
+        [@cfCli
+            mode=listMode
+            id=smsResourceId
+            command=smsCliCommand
+            content=
+                {
+                    "attributes": {
+                        "DeliveryStatusSuccessSamplingRate" : successSamplingRate,
+                        "DefaultSMSType" : smsType
+                    } +
+                    attributeIfContent(
+                        "MonthlySpendLimit",
+                        getSetting(smsSettings, ["SMS", "MONTHLY", "SPEND", "LIMIT"], true).Value
+                    ) +
+                    attributeIfContent(
+                        "DefaultSenderID",
+                        getSetting(smsSettings, ["SMS", "SENDER", "ID"], true).Value
+                    ) +
+                    attributeIfContent(
+                        "DeliveryStatusIAMRole",
+                        getExistingReference(cloudWatchRoleId, ARN_ATTRIBUTE_TYPE)
+                    ) +
+                    attributeIfContent(
+                        "UsageReportS3Bucket",
+                        getExistingReference(smsS3Id)
+                    )
+                }
+        /]
+    [/#if]
+
+    [#if deploymentSubsetRequired("epilogue", false) ]
+        [@cfScript
+            mode=listMode
+            content=
+                [
+                    "case $\{STACK_OPERATION} in",
+                    "  create|update)",
+                    "      # Get cli config file",
+                    "      split_cli_file \"$\{CLI}\" \"$\{tmpdir}\" || return $?",
+                    "      # Apply SMS account settings",
+                    "      info \"Applying SMS account settings ...\"",
+                    "      #",
+                    "      update_sms_account_attributes" +
+                    "      \"" + region + "\" " +
+                    "      \"$\{tmpdir}/cli-" +
+                               smsResourceId + "-" + smsCliCommand + ".json\" || return $?"
+                ] +
+                [
+                    "      ;;",
+                    "esac"
+                ]
+        /]
+    [/#if]
+[/#if]
+

--- a/aws/templates/account/account_waf.ftl
+++ b/aws/templates/account/account_waf.ftl
@@ -1,30 +1,32 @@
 [#-- WAF IP setup --]
-[#if deploymentUnit?contains("waf") && deploymentSubsetRequired("waf", true)]
-    [#list ipAddressGroups?values as group]
-        [#assign ipSetId = formatWAFIPSetId(group)]
-        [#assign ipSetName = formatWAFIPSetName(group)]
-        [#assign ipRuleId = formatWAFIPSetRuleId(group)]
-        [#assign cidrs = getGroupCIDRs(group.Id, false) ]
-        [#if cidrs?has_content]
-            [@createWAFIPSet
-                listMode,
-                ipSetId,
-                ipSetName,
-                expandCIDR(cidrs)
-            /]
-            [@createWAFRule
-                listMode,
-                ipRuleId,
-                ipSetName,
-                ipSetName,
-                [
-                    {
-                        "Id" : ipSetId,
-                        "Type" : "IPMatch"
-                    }
-                ]
-            /]
-        [/#if]
-    [/#list]
+[#if deploymentUnit?contains("waf")  || (allDeploymentUnits!false) ]
+    [#if deploymentSubsetRequired("waf", true)]
+        [#list ipAddressGroups?values as group]
+            [#assign ipSetId = formatWAFIPSetId(group)]
+            [#assign ipSetName = formatWAFIPSetName(group)]
+            [#assign ipRuleId = formatWAFIPSetRuleId(group)]
+            [#assign cidrs = getGroupCIDRs(group.Id, false) ]
+            [#if cidrs?has_content]
+                [@createWAFIPSet
+                    listMode,
+                    ipSetId,
+                    ipSetName,
+                    expandCIDR(cidrs)
+                /]
+                [@createWAFRule
+                    listMode,
+                    ipRuleId,
+                    ipSetName,
+                    ipSetName,
+                    [
+                        {
+                            "Id" : ipSetId,
+                            "Type" : "IPMatch"
+                        }
+                    ]
+                /]
+            [/#if]
+        [/#list]
+    [/#if]
 [/#if]
 

--- a/aws/templates/createAccountTemplate.ftl
+++ b/aws/templates/createAccountTemplate.ftl
@@ -3,6 +3,17 @@
 
 [#assign categoryId = "account"]
 
+[#-- Special processing --]
+[#switch deploymentUnit]
+    [#case "iam"]
+        [#if !(deploymentUnitSubset?has_content)]
+            [#assign allDeploymentUnits = true]
+            [#assign deploymentUnitSubset = deploymentUnit]
+            [#assign ignoreDeploymentUnitSubsetInOutputs = true]
+        [/#if]
+        [#break]
+[/#switch]
+
 [@cfTemplate
     level="account"
     include=accountList /]

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -1021,6 +1021,13 @@ function cleanup_sns_platformapps() {
   return $?
 }
 
+function update_sms_account_attributes() {
+  local region="$1"; shift
+  local configfile="$1"; shift
+
+  aws --region "${region}" sns set-sms-attributes --cli-input-json "file://${configfile}" || return $?
+}
+
 # -- PKI --
 function create_pki_credentials() {
   local dir="$1"; shift


### PR DESCRIPTION
Support IAM pass to create roles before they are needed for other units
such as SMS.

Reorganise settings so account level settings can be accessed separate
from the tier/component occurrence setting processing.

Add SMS unit for account level SMS setting control.