### PR TITLE
Make settings stores optional

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1163,10 +1163,10 @@ behaviour.
 [#function getOccurrenceSetting occurrence names emptyIfNotProvided=false]
     [#return getSetting(
         [
-            occurrence.Configuration.Settings.Core
-            occurrence.Configuration.Settings.Account,
-            occurrence.Configuration.Settings.Product,
-            occurrence.Configuration.Settings.Build
+            (occurrence.Configuration.Settings.Account)!{},
+            (occurrence.Configuration.Settings.Product)!{},
+            (occurrence.Configuration.Settings.Core)!{},
+            (occurrence.Configuration.Settings.Build)!{}
         ],
         names,
         emptyIfNotProvided)


### PR DESCRIPTION
Not all settings categories are available for all components so we need to allow for them to be undefined.