### PR TITLE
LB Fixes and Improvements

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1181,7 +1181,13 @@
     "smtp": {
       "Port": 25,
       "Protocol": "TCP",
-      "IPProtocol": "tcp"
+      "IPProtocol": "tcp",
+      "HealthCheck" : {
+        "HealthyThreshold": "3",
+        "UnhealthyThreshold": "5",
+        "Interval": "30",
+        "Timeout": "5"
+      }
     },
     "hsmtp": {
       "Port": 2025,

--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1012,7 +1012,13 @@
     },
     "ednp": {
       "Port": 25672,
-      "IPProtocol": "tcp"
+      "IPProtocol": "tcp",
+      "HealthCheck" : {
+        "HealthyThreshold": "3",
+        "UnhealthyThreshold": "5",
+        "Interval": "30",
+        "Timeout": "5"
+      }
     },
     "elasticsearch": {
       "Port": 9200,
@@ -1028,7 +1034,13 @@
     },
     "epmd": {
       "Port": 4369,
-      "IPProtocol": "tcp"
+      "IPProtocol": "tcp",
+      "HealthCheck" : {
+        "HealthyThreshold": "3",
+        "UnhealthyThreshold": "5",
+        "Interval": "30",
+        "Timeout": "5"
+      }
     },
     "http": {
       "Port": 80,
@@ -1094,7 +1106,13 @@
     },
     "memcached": {
       "Port": 11211,
-      "IPProtocol": "tcp"
+      "IPProtocol": "tcp",
+      "HealthCheck" : {
+        "HealthyThreshold": "3",
+        "UnhealthyThreshold": "5",
+        "Interval": "30",
+        "Timeout": "5"
+      }
     },
     "meteor": {
       "Port": 3000,
@@ -1110,11 +1128,23 @@
     },
     "mongodb": {
       "Port": 27017,
-      "IPProtocol": "tcp"
+      "IPProtocol": "tcp",
+      "HealthCheck" : {
+        "HealthyThreshold": "3",
+        "UnhealthyThreshold": "5",
+        "Interval": "30",
+        "Timeout": "5"
+      }
     },
     "mysql": {
       "Port": 3306,
-      "IPProtocol": "tcp"
+      "IPProtocol": "tcp",
+      "HealthCheck" : {
+        "HealthyThreshold": "3",
+        "UnhealthyThreshold": "5",
+        "Interval": "30",
+        "Timeout": "5"
+      }
     },
     "node": {
       "Port": 9000,
@@ -1155,11 +1185,23 @@
     },
     "postgresql": {
       "Port": 5432,
-      "IPProtocol": "tcp"
+      "IPProtocol": "tcp",
+      "HealthCheck" : {
+        "HealthyThreshold": "3",
+        "UnhealthyThreshold": "5",
+        "Interval": "30",
+        "Timeout": "5"
+      }
     },
     "rabbit": {
       "Port": 5672,
-      "IPProtocol": "tcp"
+      "IPProtocol": "tcp",
+      "HealthCheck" : {
+        "HealthyThreshold": "3",
+        "UnhealthyThreshold": "5",
+        "Interval": "30",
+        "Timeout": "5"
+      }
     },
     "rabbit-ui": {
       "Port": 15672,
@@ -1176,7 +1218,13 @@
     "redis": {
       "Port": 6379,
       "Protocol": "TCP",
-      "IPProtocol": "tcp"
+      "IPProtocol": "tcp",
+      "HealthCheck" : {
+        "HealthyThreshold": "3",
+        "UnhealthyThreshold": "5",
+        "Interval": "30",
+        "Timeout": "5"
+      }
     },
     "smtp": {
       "Port": 25,
@@ -1192,12 +1240,24 @@
     "hsmtp": {
       "Port": 2025,
       "Protocol": "TCP",
-      "IPProtocol": "tcp"
+      "IPProtocol": "tcp",
+      "HealthCheck" : {
+        "HealthyThreshold": "3",
+        "UnhealthyThreshold": "5",
+        "Interval": "30",
+        "Timeout": "5"
+      }
     },
     "ssh": {
       "Port": 22,
       "Protocol": "TCP",
-      "IPProtocol": "tcp"
+      "IPProtocol": "tcp",
+      "HealthCheck" : {
+        "HealthyThreshold": "3",
+        "UnhealthyThreshold": "5",
+        "Interval": "30",
+        "Timeout": "5"
+      }
     },
     "ws": {
       "Port": 80,

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -188,12 +188,11 @@
 
                         [#case "application"]
                         [#case "network"]
-                            [#assign targetArn = (linkTargetAttributes["TARGET_GROUP_ARN"] )]
-                            [#assign targetGroups += [ targetArn] ]
+                            [#assign targetGroups += [ linkTargetAttributes["TARGET_GROUP_ARN"] ] ]
                             [#break]
 
                         [#case "classic" ]
-                            [#assign lbId =  linkTargetAttributes["LB"] ]
+                            [#assign lbId = linkTargetAttributes["LB"] ]
                             [#-- Classic ELB's register the instance so we only need 1 registration --]
                             [#assign loadBalancers += [ getExistingReference(lbId) ]]
                             [#break]

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -188,8 +188,8 @@
 
                         [#case "application"]
                         [#case "network"]
-                            [#assign targetId = (linkTargetResources["targetgroup"].Id) ]
-                            [#assign targetGroups += [ getReference(targetId, ARN_ATTRIBUTE_TYPE) ] ]
+                            [#assign targetArn = (linkTargetAttributes["TARGET_GROUP_ARN"] )]
+                            [#assign targetGroups += [ targetArn] ]
                             [#break]
 
                         [#case "classic" ]

--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -110,14 +110,12 @@
                                         [#switch linkAttributes["ENGINE"] ] 
                                             [#case "network" ]
                                             [#case "application" ]
-                                                [#assign targetArn = (linkAttributes["TARGET_GROUP_ARN"] )]
-
                                                 [#assign loadBalancers +=
                                                     [
                                                         {
                                                             "ContainerName" : container.Name,
                                                             "ContainerPort" : ports[portMapping.ContainerPort].Port,
-                                                            "TargetGroupArn" : targetArn
+                                                            "TargetGroupArn" : linkAttributes["TARGET_GROUP_ARN"]
                                                         }
                                                     ]
                                                 ]

--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -110,14 +110,14 @@
                                         [#switch linkAttributes["ENGINE"] ] 
                                             [#case "network" ]
                                             [#case "application" ]
-                                                [#assign targetId = (linkResources["targetgroup"].Id)!"" ]
+                                                [#assign targetArn = (linkAttributes["TARGET_GROUP_ARN"] )]
 
                                                 [#assign loadBalancers +=
                                                     [
                                                         {
                                                             "ContainerName" : container.Name,
                                                             "ContainerPort" : ports[portMapping.ContainerPort].Port,
-                                                            "TargetGroupArn" : getReference(targetId, ARN_ATTRIBUTE_TYPE)
+                                                            "TargetGroupArn" : targetArn
                                                         }
                                                     ]
                                                 ]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1891,8 +1891,7 @@ behaviour.
             "Id" : targetLinkName,
             "Name" : targetLinkName,
             "Tier" : targetTierId,
-            "Component" : targetComponentId,
-            "Priority" : port.LB.Priority
+            "Component" : targetComponentId
         } +
         attributeIfTrue("Instance", port.LB.Instance??, port.LB.Instance!"") +
         attributeIfTrue("Version",  port.LB.Version??, port.LB.Version!"") +

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -445,10 +445,7 @@
                         {
                             "LoadBalancer" :
                                 {
-                                    "Link" : loadBalancer.Name,
-                                    "TargetGroup" : loadBalancer.TargetGroup!"",
-                                    "Priority" : port.LB.Priority,
-                                    "Path" : loadBalancer.TargetPath!""
+                                    "Link" : loadBalancer.Name
                                 }
                         }
                     ]

--- a/aws/templates/resource/resource_ec2.ftl
+++ b/aws/templates/resource/resource_ec2.ftl
@@ -150,15 +150,15 @@
     ]
 [/#function]
 
-[#function getInitConfigLBTargetRegistration targetGroupId ignoreErrors=false]
+[#function getInitConfigLBTargetRegistration portId targetGroupArn ignoreErrors=false]
     [#return
         {
-            "RegisterWithTG_" + targetGroupId  : {
+            "RegisterWithTG_" + portId  : {
                 "commands" : {
                         "RegsiterWithTG" : {
                         "command" : "/opt/codeontap/bootstrap/register_targetgroup.sh",
                         "env" : {
-                            "TARGET_GROUP_ARN" : getReference(targetGroupId)
+                            "TARGET_GROUP_ARN" : targetGroupArn
                         },
                         "ignoreErrors" : ignoreErrors
                     }

--- a/aws/templates/resource/resource_lb.ftl
+++ b/aws/templates/resource/resource_lb.ftl
@@ -62,29 +62,33 @@
 
 [#macro createALB mode id name shortName tier component securityGroups type idleTimeout logs=false bucket=""]
 
-    [#assign loadBalancerAttributes = [
-        {
-            "Key" : "idle_timeout.timeout_seconds",
-            "Value" : idleTimeout
-        }
-    ] + 
-    (logs && type == "application")?then(
-        [
-            {
-                "Key" : "access_logs.s3.enabled",
-                "Value" : true
-            },
-            {
-                "Key" : "access_logs.s3.bucket",
-                "Value" : bucket
-            },
-            {
-                "Key" : "access_logs.s3.prefix",
-                "Value" : ""
-            }
-        ],
-        []
-    )
+    [#assign loadBalancerAttributes = 
+        ( type == "application" )?then(
+            [
+                {
+                    "Key" : "idle_timeout.timeout_seconds",
+                    "Value" : idleTimeout
+                }
+            ],
+            []
+        ) +
+        (logs && type == "application")?then(
+            [
+                {
+                    "Key" : "access_logs.s3.enabled",
+                    "Value" : true
+                },
+                {
+                    "Key" : "access_logs.s3.bucket",
+                    "Value" : bucket
+                },
+                {
+                    "Key" : "access_logs.s3.prefix",
+                    "Value" : ""
+                }
+            ],
+            []
+        )
     ]
 
     [@cfResource
@@ -254,6 +258,15 @@
         {
             "Field": "path-pattern",
             "Values": asArray(paths)
+        }
+    ]
+[/#function]
+
+[#function getListenerRuleHostCondition hosts ]
+    [#return 
+        {
+            "Field" : "host-header",
+            "Values" : asArray(hosts)
         }
     ]
 [/#function]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -206,22 +206,7 @@
             "Type" : STRING_TYPE
         },
         {
-            "Name" : "Path",
-            "Type" : STRING_TYPE,
-            "Default" : ""
-        },
-        {
             "Name" : ["PortMapping", "Port"],
-            "Type" : STRING_TYPE,
-            "Default" : ""
-        },
-        {
-            "Name" : "Priority",
-            "Type" : NUMBER_TYPE,
-            "Default" : 100
-        },
-        {
-            "Name" : "TargetGroup",
             "Type" : STRING_TYPE,
             "Default" : ""
         }

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -137,8 +137,7 @@
 
                         [#case "application"]
                         [#case "network"]
-                            [#assign targetGroupArn = (linkTargetAttributes["TARGET_GROUP_ARN"] )]
-                            [#assign configSets += getInitConfigLBTargetRegistration(linkTargetCore.Id, targetGroupArn)]
+                            [#assign configSets += getInitConfigLBTargetRegistration(linkTargetCore.Id, linkTargetAttributes["TARGET_GROUP_ARN"])]
 
                             [#break]
 

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -137,8 +137,9 @@
 
                         [#case "application"]
                         [#case "network"]
-                            [#assign targetId = (linkTargetResources["targetgroup"].Id) ]
-                            [#assign configSets += getInitConfigLBTargetRegistration(targetId)]
+                            [#assign targetGroupArn = (linkTargetAttributes["TARGET_GROUP_ARN"] )]
+                            [#assign configSets += getInitConfigLBTargetRegistration(linkTargetCore.Id, targetGroupArn)]
+
                             [#break]
 
                         [#case "classic" ]

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -872,7 +872,7 @@ function cleanup_elbv2_rules() {
 
   info "Removing all listener rules from ${listenerarn}"
   if [[ -n "${all_listener_rules}" ]]; then 
-    echo "${all_listener_rules}" | jq --arg region "${region}" -r '.[] | "aws --region \($region) elbv2 delete-rule --rule-arn \(.) || return $?"' > "${tmp_file}"
+    echo "${all_listener_rules}" | jq --arg region "${region}" -r '.[] | "aws --region \($region) elbv2 delete-rule --rule-arn \(.) || { status=$?; popTempDir; return $status; } >"' > "${tmp_file}"
     if [[ -f "${tmp_file}" ]]; then 
       chmod u+x "${tmp_file}"
       "${tmp_file}"

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -872,13 +872,14 @@ function cleanup_elbv2_rules() {
 
   info "Removing all listener rules from ${listenerarn}"
   if [[ -n "${all_listener_rules}" ]]; then 
-    echo "${all_listener_rules}" | jq --arg region "${region}" -r '.[] | "aws --region \($region) elbv2 delete-rule --rule-arn \(.)"' > "${tmp_file}"
+    echo "${all_listener_rules}" | jq --arg region "${region}" -r '.[] | "aws --region \($region) elbv2 delete-rule --rule-arn \(.) || return $?"' > "${tmp_file}"
     if [[ -f "${tmp_file}" ]]; then 
       chmod u+x "${tmp_file}"
       "${tmp_file}"
     fi
   fi
 
+  popTempDir
   return 0
 }
 


### PR DESCRIPTION
This PR includes a number of changes and fixes for the LB component 

**Features** 
- Host Filtering - Adds a condition on a listener rule for the generated DNS hostname of the site. This prevents requests to the load balancer IP addresses which can be used for malicious probing. The option is applied on each port mapping and can only be used on ports with certificates configured 

**Changes**
- For Application Load balancers all listener rules are now created via CLI instead of cloudformation. This allows the rules to be managed easier and stops overalaps between cli and cloudformation which prevents updates 
- As part of this process all listener rules are removed before adding the new rules. This ensures that rules are cleaned up and only the configured rules will be applied. This will cause a brief (seconds) outage between the removal of the rules and the new ones being added 
- A default target group is created for all listeners and the default listener is always configured to use this rule 
- When a forwarding action is required for an application load balancer a separate target group is created along with a listener rule. This allows for conditions to be applied to all forwarding rules
- Network load balancers can only use a single target group per listener at the moment so applications will receive the default target group arn when linking to a network LB
- Targetgroup ARN look ups by linking components will receive the ARN via Attributes instead of a getReference lookup 

**Fixes** 
-  Align Security group name to the Id configuration which uses the parent details to create the property. This stops the security group from being recreated when a portmapping is renamed
- Move all listener rule creation to cli based config, this stops issues when a cli listener rule has been created and a cloudformation based run is added with the same priority
- Use the parent configuration details + priority for the listener rule Ids - if we move back to cloudformation this is required to ensure that rules are updated instead of trying to create a new rule with the same priority during updates 
- Add Health check configuration to all ports in master data 
- Update status code type for fixed response
- Cleanup extended link configuration that is no longer required for latest lb config 
- Make sure listener rule and target group config is only applied on application load balancers 
- Make sure cli commands error when they break 
- cleanup listener rules as part of deletion process
