### PR TITLE
Change to find for baseline permissions

### DIFF
--- a/aws/templates/resource/resource_ec2.ftl
+++ b/aws/templates/resource/resource_ec2.ftl
@@ -143,7 +143,8 @@
                                     "exec > >(tee /var/log/codeontap/fetch.log|logger -t codeontap-fetch -s 2>/dev/console) 2>&1\n",
                                     "REGION=$(/etc/codeontap/facts.sh | grep cot:accountRegion | cut -d '=' -f 2)\n",
                                     "CODE=$(/etc/codeontap/facts.sh | grep cot:code | cut -d '=' -f 2)\n",
-                                    "aws --region " + r"${REGION}" + " s3 sync s3://" + r"${CODE}/" + scriptStorePrefix + " " + bootstrapScriptsDir + " && chmod 0500 " + bootstrapScriptsDir + "*.sh\n"
+                                    "aws --region " + r"${REGION}" + " s3 sync s3://" + r"${CODE}/" + scriptStorePrefix + " " + bootstrapScriptsDir + "\n",
+                                    "find \"" + bootstrapScriptsDir + "\" -type f -exec chmod u+rwx {} \\;\n"
                                 ]
                             ]
                         },


### PR DESCRIPTION
Since the bootstrap directories are user defined we can't reliably use a wild card search to update the file permissions. 

Instead we will use find to update the permissions on all files downloaded into the bootstrap directory