### PR TITLE
Add SQS as an event source for lambda

### DIFF
--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -4,10 +4,18 @@
 [#assign AWS_LAMBDA_RESOURCE_TYPE = "lambda"]
 [#assign AWS_LAMBDA_FUNCTION_RESOURCE_TYPE = "lambda"]
 [#assign AWS_LAMBDA_PERMISSION_RESOURCE_TYPE = "permission"]
+[#assign AWS_LAMBDA_EVENT_SOURCE_TYPE = "source"]
 
 [#function formatLambdaPermissionId occurrence extensions...]
     [#return formatResourceId(
                 AWS_LAMBDA_PERMISSION_RESOURCE_TYPE,
+                occurrence.Core.Id,
+                extensions)]
+[/#function]
+
+[#function formatLambdaEventSourceId occurrence extensions...]
+    [#return formatResourceId(
+                AWS_LAMBDA_EVENT_SOURCE_TYPE,
                 occurrence.Core.Id,
                 extensions)]
 [/#function]

--- a/aws/templates/id/id_sqs.ftl
+++ b/aws/templates/id/id_sqs.ftl
@@ -75,6 +75,7 @@
                 "Inbound" : {},
                 "Outbound" : {
                     "all" : sqsAllPermission(id),
+                    "event" : sqsAllPermission(id),
                     "produce" : sqsProducePermission(id),
                     "consume" : sqsConsumePermission(id)
                 }

--- a/aws/templates/resource/resource_lambda.ftl
+++ b/aws/templates/resource/resource_lambda.ftl
@@ -5,7 +5,7 @@
         REFERENCE_ATTRIBUTE_TYPE : {
             "UseRef" : true
         },
-        ARN_ATTRIBUTE_TYPE : { 
+        ARN_ATTRIBUTE_TYPE : {
             "Attribute" : "Arn"
         }
     }
@@ -19,10 +19,19 @@
     }
 ]
 
+[#assign LAMBDA_EVENT_SOURCE_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+
 [#assign outputMappings +=
     {
         AWS_LAMBDA_FUNCTION_RESOURCE_TYPE : LAMBDA_FUNCTION_OUTPUT_MAPPINGS,
-        AWS_LAMBDA_PERMISSION_RESOURCE_TYPE : LAMBDA_PERMISSION_OUTPUT_MAPPINGS
+        AWS_LAMBDA_PERMISSION_RESOURCE_TYPE : LAMBDA_PERMISSION_OUTPUT_MAPPINGS,
+        AWS_LAMBDA_EVENT_SOURCE_TYPE : LAMBDA_EVENT_SOURCE_MAPPINGS
     }
 ]
 [#macro createLambdaFunction mode id settings roleId securityGroupIds=[] subnetIds=[] dependencies=""]
@@ -35,20 +44,20 @@
                 "Code" : {
                     "S3Bucket" : settings.S3Bucket,
                     "S3Key" : settings.S3Key
-                },                                            
+                },
                 "FunctionName" : settings.Name,
                 "Description" : settings.Description,
                 "Handler" : settings.Handler,
                 "Role" : getReference(roleId, ARN_ATTRIBUTE_TYPE),
                 "Runtime" : settings.RunTime
-            } + 
+            } +
             attributeIfContent("Environment", settings.Environment!{}, {"Variables" : settings.Environment}) +
             attributeIfTrue("MemorySize", settings.MemorySize > 0, settings.MemorySize) +
             attributeIfTrue("Timeout", settings.Timeout > 0, settings.Timeout) +
             attributeIfTrue(
                 "KmsKeyArn",
                 settings.UseSegmentKey!false,
-                getReference(formatSegmentCMKId(), ARN_ATTRIBUTE_TYPE)) + 
+                getReference(formatSegmentCMKId(), ARN_ATTRIBUTE_TYPE)) +
             attributeIfContent(
                 "VpcConfig",
                 securityGroupIds,
@@ -80,6 +89,25 @@
                 }
             )
         outputs=LAMBDA_PERMISSION_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]
+
+[#macro createLambdaEventSource mode id targetId source enabled=true batchSize="" startingPosition="" dependencies=""]
+
+    [@cfResource
+        mode=mode
+        id=id
+        type="AWS::Lambda::EventSourceMapping"
+        properties=
+            {
+                "Enabled" : enabled,
+                "EventSourceArn" : getArn(source),
+                "FunctionName" : getReference(targetId)
+            } +
+            attributeIfContent("BatchSize", batchSize) +
+            attributeIfContent("StartingPosition", startingPosition)
+        outputs=LAMBDA_EVENT_SOURCE_MAPPINGS
         dependencies=dependencies
     /]
 [/#macro]

--- a/aws/templates/resource/start.ftl
+++ b/aws/templates/resource/start.ftl
@@ -19,7 +19,7 @@
 
 [#function formatArn partition service region account resource asString=false]
     [#if asString ]
-        [#return 
+        [#return
             [
                 "arn",
                 partition,
@@ -45,6 +45,19 @@
                 ]
             }
         ]
+    [/#if]
+[/#function]
+
+[#function getArn idOrArn existingOnly=false]
+    [#if idOrArn?contains(":")]
+        [#return idOrArn]
+    [#else]
+        [#return
+            valueIfTrue(
+                getExistingReference(idOrArn, ARN_ATTRIBUTE_TYPE),
+                existingOnly,
+                getReference(idOrArn, ARN_ATTRIBUTE_TYPE)
+            ) ]
     [/#if]
 [/#function]
 
@@ -293,14 +306,14 @@
                 ]
             ]
         [/#list]
-        [#local result=returnValue]        
+        [#local result=returnValue]
     [/#if]
     [#if flatten ]
         [#local returnValue = {} ]
         [#list result as entry ]
-            [#local returnValue += 
+            [#local returnValue +=
                 {
-                    entry.Key, entry.Value 
+                    entry.Key, entry.Value
                 }
             ]
         [/#list]
@@ -446,7 +459,7 @@
     [/#switch]
 [/#macro]
 
-[#macro cfCli 
+[#macro cfCli
     mode
     id
     command
@@ -454,10 +467,10 @@
     [#switch mode]
         [#case "cli"]
         [#if content?has_content ]
-            [#assign templateCli += 
+            [#assign templateCli +=
                 {
                     id : {
-                        command : content 
+                        command : content
                     }
                 }
             ]


### PR DESCRIPTION
Add a resource for lambda "pull" event sources.

Add a new link role called "event" to detect when an event source should
be created.

Add processing for SQS as an event source to lambd support.

Normal outbound link processing provides the mechanism to permit lambda
to poll the SQS queue and manage message removal.