### PR TITLE
Correct permissions for SQS as lambda event source

### DIFF
--- a/aws/templates/id/id_sqs.ftl
+++ b/aws/templates/id/id_sqs.ftl
@@ -75,7 +75,7 @@
                 "Inbound" : {},
                 "Outbound" : {
                     "all" : sqsAllPermission(id),
-                    "event" : sqsAllPermission(id),
+                    "event" : sqsConsumePermission(id),
                     "produce" : sqsProducePermission(id),
                     "consume" : sqsConsumePermission(id)
                 }


### PR DESCRIPTION
Lambda doesn't need to be able to send messages, only read/delete them.