### PR TITLE
RunId Fixes for Lambda And .sh scripts

### DIFF
--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -432,8 +432,29 @@ function process_template() {
 
       case "$(fileExtension "${template_result_file}")" in
         sh)
-          # Strip out the whitespace added by freemarker
-          sed 's/^ *//; s/ *$//; /^$/d; /^\s*$/d' "${template_result_file}" > "${output_file}"
+          # Ignore if only the metadata/timestamps have changed
+          sed_patterns=("-e" 's/^ *//; s/ *$//; /^$/d; /^\s*$/d')
+          sed_patterns+=("-e" "s/${request_reference}//g")
+          sed_patterns+=("-e" "s/${configuration_reference}//g")
+          
+          existing_request_reference="$( grep "#--COT-RequestReference=" "${output_file}" )"
+          [[ -n "${existing_request_reference}" ]] && sed_patterns+=("-e" "s/${existing_request_reference#"#--COT-RequestReference="}//g")
+
+          existing_configuration_reference="$( grep "#--COT-ConfigurationReference=" "${output_file}" )"
+          [[ -n "${existing_configuration_reference}" ]] && sed_patterns+=("-e" "s/${existing_configuration_reference#"#--COT-ConfigurationReference="}//g")
+
+          if [[ -z "${TREAT_RUN_ID_DIFFERENCES_AS_SIGNIFICANT}" ]]; then
+            sed_patterns+=("-e" "s/${run_id}//g")
+            existing_run_id="$( grep "#--COT-RunId=" "${output_file}" )"
+            [[ -n "${existing_run_id}" ]] && sed_patterns+=("-e" "s/${existing_run_id#"#--COT-RunId="}//g")
+          fi
+
+          cat "${template_result_file}" | sed "${sed_patterns[@]}" > "${template_result_file}-new"
+          cat "${output_file}" | sed "${sed_patterns[@]}" > "${template_result_file}-existing"
+
+          diff "${template_result_file}-existing" "${template_result_file}-new" > "${template_result_file}-difference" &&
+            info "Ignoring unchanged ${file_description} file ...\n" ||
+            cat "${template_result_file}" | sed "-e" 's/^ *//; s/ *$//; /^$/d; /^\s*$/d' > "${output_file}"
 
           if [[ "${pass}" == "pregeneration" ]]; then
             info "Processing pregeneration script ..."
@@ -472,6 +493,7 @@ function process_template() {
           if [[ -z "${TREAT_RUN_ID_DIFFERENCES_AS_SIGNIFICANT}" ]]; then
             sed_patterns+=("-e" "s/${run_id}//g")
             existing_run_id="$( jq -r ".Metadata.RunId | select(.!=null)" < "${output_file}" )"
+            [[ -z "${existing_run_id}" ]] && existing_run_id="$( jq -r ".RUN_ID | select(.!=null)" < "${output_file}" )"
             [[ -n "${existing_run_id}" ]] && sed_patterns+=("-e" "s/${existing_run_id}//g")
           fi
 

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -374,7 +374,10 @@
                     context.DefaultCoreVariables || asFile
                 ) +
                 valueIfTrue(
-                    { "SETTINGS_FILE" : "config/config_" + runId + ".json"},
+                    { 
+                        "SETTINGS_FILE" : "config/config_" + runId + ".json",
+                        "RUN_ID" : runId 
+                    },
                     asFile,
                     valueIfTrue(
                         getSettingsAsEnvironment(occurrence.Configuration.Settings.Build) +

--- a/aws/templates/resource/start.ftl
+++ b/aws/templates/resource/start.ftl
@@ -697,6 +697,9 @@
       /]
     [#elseif templateScript?has_content]
       #!/bin/bash
+      #--COT-RequestReference=${requestReference}
+      #--COT-ConfigurationReference=${configurationReference}
+      #--COT-RunId=${runId}
       [#list templateScript as line]
           ${line}
       [/#list]


### PR DESCRIPTION
Adds a fix for Lambda functions using config files stored in s3 where the config file changes but the lambda funciton doesn't. This change ensures that they should update together

Also adds diff checking on *.sh scripts that are generated. This allows for .sh files to be ignored if they haven't changed 