### PR TITLE
HTTPS Security Profile as master data

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1607,5 +1607,23 @@
         "BootStraps" : []
       }
     }
+  },
+  "SecurityProfiles" : {
+    "default" : {
+      "lb" : {
+        "application" : {
+          "HTTPSProfile" : "ELBSecurityPolicy-TLS-1-2-2017-01"
+        },
+        "classic" : {
+          "HTTPSProfile" : "ELBSecurityPolicy-2016-08"
+        }
+      },
+      "apigateway" : {
+        "HTTPSProfile" : "TLSv1"
+      },
+      "spa" : {
+        "HTTPSProfile" : "TLSv1"
+      }
+    }
   }
 }

--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -148,6 +148,8 @@
         [#assign endpointType           = solution.EndpointType ]
         [#assign isEdgeEndpointType     = endpointType == "EDGE" ]
 
+        [#assign securityProfile        = getSecurityProfile(solution.Profiles.SecurityProfile, "apigateway")]
+
         [#assign certificatePresent     = solution.Certificate.Configured && solution.Certificate.Enabled ]
 
         [#assign mappingPresent         = solution.Mapping.Configured && solution.Mapping.Enabled ]
@@ -394,6 +396,7 @@
                     certificate=valueIfTrue(
                         getCFCertificate(
                             cfCertificateId,
+                            securityProfile.HTTPSProfile,
                             solution.CloudFront.AssumeSNI),
                         certificatePresent)
                     comment=cfName

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1741,6 +1741,20 @@ behaviour.
     [/#if]
 [/#function]
 
+[#function getSecurityProfile profileName type engine="" ]
+    [#local profile = {} ]
+    
+    [#if (securityProfiles[profileName][type])??]
+        [#local profile = securityProfiles[profileName][type]]
+    [/#if]
+    
+    [#if engine?has_content && profile[engine]?has_content ]
+        [#return profile[engine] ]
+    [#else]
+        [#return profile ]
+    [/#if]
+[/#function]
+
 [#-- Get storage settings --]
 [#function getStorage tier component type extensions...]
     [#local tc = formatComponentShortName(

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -129,6 +129,16 @@
                         "Default" : true
                     }
                 ]
+            },
+            {
+                "Name" : "Profiles",
+                "Children" : [
+                    {
+                        "Name" : "SecurityProfile",
+                        "Type" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
             }
         ]
     }]

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -31,6 +31,16 @@
                     "Default" : "application"
                 },
                 {
+                    "Name" : "Profiles",
+                    "Children" : [
+                        {
+                            "Name" : "SecurityProfile",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        }
+                    ]
+                },
+                {
                     "Name" : "IdleTimeout", 
                     "Type" : NUMBER_TYPE,
                     "Default" : 60

--- a/aws/templates/id/id_spa.ftl
+++ b/aws/templates/id/id_spa.ftl
@@ -87,6 +87,16 @@
                         "Name" : "*"
                     }
                 ]
+            },
+            {
+                "Name" : "Profiles",
+                "Children" : [
+                    {
+                        "Name" : "SecurityProfile",
+                        "Type" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
             }
         ]
     }]

--- a/aws/templates/resource/resource_cf.ftl
+++ b/aws/templates/resource/resource_cf.ftl
@@ -198,7 +198,7 @@
     ]
 [/#function]
 
-[#function getCFCertificate id assumeSNI=true]
+[#function getCFCertificate id httpsProtocolPolicy assumeSNI=true ]
     [#local acmCertificateArn = getExistingReference(id, ARN_ATTRIBUTE_TYPE, "us-east-1") ]
     [#return
         {
@@ -215,7 +215,7 @@
                         "us-east-1"
                     )
                 ),
-            "MinimumProtocolVersion" : "TLSv1",
+            "MinimumProtocolVersion" : httpsProtocolPolicy,
             "SslSupportMethod" : assumeSNI?then("sni-only", "vip")
         }
     ]

--- a/aws/templates/resource/resource_lb.ftl
+++ b/aws/templates/resource/resource_lb.ftl
@@ -288,7 +288,17 @@
     /]
 [/#macro]
 
-[#macro createClassicLB mode id name shortName tier component listeners healthCheck securityGroups idleTimeout deregistrationTimeout stickinessPolicies=[] logs=false bucket="" dependencies="" ]
+[#macro createClassicLB mode id name shortName tier component 
+            listeners 
+            healthCheck 
+            securityGroups 
+            idleTimeout 
+            deregistrationTimeout
+            policies=[]
+            stickinessPolicies=[] 
+            logs=false 
+            bucket="" 
+            dependencies="" ]
         [@cfResource
         mode=listMode
         id=id
@@ -339,6 +349,10 @@
             attributeIfContent(
                 "LBCookieStickinessPolicy",
                 stickinessPolicies
+            ) +
+            attributeIfContent(
+                "Policies",
+                policies
             )
         tags=
             getCfTemplateCoreTags(

--- a/aws/templates/resource/resource_lb.ftl
+++ b/aws/templates/resource/resource_lb.ftl
@@ -118,7 +118,7 @@
     /]
 [/#macro]
 
-[#macro createALBListener mode id port albId defaultTargetGroupId certificateId=""]
+[#macro createALBListener mode id port albId defaultTargetGroupId certificateId="" sslPolicy="" ]
 
     [@cfResource
         mode=mode
@@ -143,7 +143,7 @@
                             "CertificateArn" : getReference(certificateId, ARN_ATTRIBUTE_TYPE, regionId)
                         }
                     ],
-                    "SslPolicy" : "ELBSecurityPolicy-TLS-1-2-2017-01"
+                    "SslPolicy" : sslPolicy
                 },
                 port.Certificate!false)
         outputs=ALB_LISTENER_OUTPUT_MAPPINGS

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -275,6 +275,7 @@
 [#assign scriptStores = blueprintObject.ScriptStores ]
 [#assign bootstraps = blueprintObject.Bootstraps ]
 [#assign bootstrapProfiles = blueprintObject.BootstrapProfiles]
+[#assign securityProfiles = blueprintObject.SecurityProfiles ]
 
 [#-- Regions --]
 [#if region?has_content]

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -40,16 +40,18 @@
         [#assign classicConnectionDrainingTimeouts = []]
 
         [#assign classicHTTPSPolicyName = "ELBSecurityPolicy"]
-        [#assign classicPolicies += [
-            {
-                "PolicyName" : classicHTTPSPolicyName,
-                "PolicyType" : "SSLNegotiationPolicyType",
-                "Attributes" : [{
-                    "Name"  : "Reference-Security-Policy",
-                    "Value" : securityProfile.HTTPSProfile
-                }]
-            }
-        ]]
+        [#if engine == "classic" ]
+            [#assign classicPolicies += [
+                {
+                    "PolicyName" : classicHTTPSPolicyName,
+                    "PolicyType" : "SSLNegotiationPolicyType",
+                    "Attributes" : [{
+                        "Name"  : "Reference-Security-Policy",
+                        "Value" : securityProfile.HTTPSProfile
+                    }]
+                }
+            ]]
+        [/#if]
 
         [#list occurrence.Occurrences![] as subOccurrence]
 

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -35,8 +35,21 @@
         [#assign ingressRules = [] ]
         [#assign listenerPortsSeen = [] ]
 
+        [#assign classicPolicies = []]
         [#assign classicStickinessPolicies = []]
         [#assign classicConnectionDrainingTimeouts = []]
+
+        [#assign classicHTTPSPolicyName = "ELBSecurityPolicy"]
+        [#assign classicPolicies += [
+            {
+                "PolicyName" : classicHTTPSPolicyName,
+                "PolicyType" : "SSLNegotiationPolicyType",
+                "Attributes" : [{
+                    "Name"  : "Reference-Security-Policy",
+                    "Value" : securityProfile.HTTPSProfile
+                }]
+            }
+        ]]
 
         [#list occurrence.Occurrences![] as subOccurrence]
 
@@ -450,9 +463,7 @@
 
                     [#if classicSSLRequired ]
                         [#assign classicListenerPolicyNames += [
-                            {
-                                "PolicyName" : securityProfile.HTTPSProfile
-                            }
+                            classicHTTPSPolicyName
                         ]]
                     [/#if]
 
@@ -566,6 +577,7 @@
                         idleTimeout=idleTimeout
                         deregistrationTimeout=(classicConnectionDrainingTimeouts?reverse)[0]
                         stickinessPolicies=classicStickinessPolicies
+                        policies=classicPolicies
                         /]
                 [/#if]
                 [#break]

--- a/aws/templates/solution/solution_spa.ftl
+++ b/aws/templates/solution/solution_spa.ftl
@@ -12,6 +12,8 @@
         [#assign resources = occurrence.State.Resources]
         [#assign solution = occurrence.Configuration.Solution ]
 
+        [#assign securityProfile    = getSecurityProfile(solution.Profiles.SecurityProfile, SPA_COMPONENT_TYPE)]
+
         [#assign certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers) ]
         [#assign hostName = getHostName(certificateObject, occurrence) ]
         [#assign dns = formatDomainName(hostName, certificateObject.Domain.Name) ]
@@ -86,6 +88,7 @@
                 certificate=valueIfTrue(
                     getCFCertificate(
                         certificateId,
+                        securityProfile.HTTPSProfile,
                         solution.CloudFront.AssumeSNI),
                         solution.Certificate.Configured && solution.Certificate.Enabled)
                 comment=cfName


### PR DESCRIPTION
Moves the HTTPS cipher profile configuration out of hard coded temaplate config into a profile stored i the master data file.

This allows for the profile to be configured at all levels and also adds support for profiles to be set as part of the component configuration. 

