### PR TITLE
LogWatchers - Trigger Lambda based on log events

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1625,5 +1625,40 @@
         "HTTPSProfile" : "TLSv1"
       }
     }
+  },
+  "LogFilters" : {
+    "_all" : {
+      "Pattern" : "*"
+    },
+    "_pylog-critical" : {
+      "Pattern" : "CRITICAL"
+    },
+    "_pylog-error" : {
+      "Pattern" : "?CRITICAL ?ERROR"
+    },
+    "_pylog-warning" : {
+      "Pattern" : "?CRITICAL ?ERROR ?WARNING"
+    },
+    "_pylog-info" : {
+      "Pattern" : "?CRITICAL ?ERROR ?WARNING ?INFO"
+    },
+    "_pylog-debug" : {
+      "Pattern" : "?CRITICAL ?ERROR ?WARNING ?INFO ?DEBUG" 
+    },
+    "apache" : {
+      "Pattern" : "[ip, id, user, timestamp, request, status_code=*, size]"
+    },
+    "_apache-4xx" : {
+      "Pattern" : "[ip, id, user, timestamp, request, status_code=4*, size]"
+    },
+    "_apache-5xx" : {
+      "Pattern" : "[ip, id, user, timestamp, request, status_code=5*, size]"
+    },
+    "_sns-success" : {
+      "Pattern" : "{ $.status = \"SUCCESS\" }"
+    },
+    "_sns-failure" : {
+      "Pattern" : "{ $.status = \"FAILURE\" }"
+    }
   }
 }

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -59,12 +59,6 @@
                     [#assign linkDirection = linkTarget.Direction ]
                     [#assign linkRole = linkTarget.Role]
 
-                    [#if linkTarget.Role == "logwatch" && 
-                        linkTargetRoles.Inbound["logwatch"]?has_content  &&
-                        linkDirection == "inbound" ]
-
-                    [/#if]
-
                     [#switch linkDirection ]
                         [#case "inbound" ]
                             [#switch linkRole ]

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -232,6 +232,8 @@
 
                 [#list solution.LogWatchers as logWatcherName,logwatcher ]
 
+                    [#assign logFilter = logFilters[logwatcher.logFilter].Pattern ]
+
                     [#if deploymentSubsetRequired("lambda", true)]
                         [#switch logwatcher.Type ]
                             [#case "Metric" ]
@@ -240,7 +242,7 @@
                                     id=formatDependentLogMetricId(fnId, logwatcher.Id)
                                     name=formatName(logWatcherName, fnName)
                                     logGroup=fnLgName
-                                    filter=logwatcher.LogPattern
+                                    filter=logFilter
                                     namespace=formatProductRelativePath()
                                     value=1
                                     dependencies=fnId
@@ -252,7 +254,12 @@
                                     [#assign logWatcherLinkTarget = getLinkTarget(occurrence, logWatcherLink) ]
                                     [#assign logWatcherLinkTargetCore = logWatcherLinkTarget.Core ]
                                     [#assign logWatcherLinkTargetAttributes = logWatcherLinkTarget.State.Attributes ]
-                                    [#switch logWatcherLinkTargetCore.Type]
+
+                                    [#if !logWatcherLinkTarget?has_content]
+                                        [#continue]
+                                    [/#if]
+
+                                    [#switch logWatcherLinkTargetCore.Type
 
                                         [#case LAMBDA_FUNCTION_COMPONENT_TYPE]
 
@@ -260,7 +267,7 @@
                                                 mode=listMode
                                                 id=formatDependentLogSubscriptionId(fnId, logWatchLink.Id)
                                                 logGroupName=fnLgName
-                                                filter=logwatcher.LogPattern
+                                                filter=logFilter
                                                 destination=logWatcherLinkTargetAttributes["ARN"]
                                             /]
                                             
@@ -271,7 +278,6 @@
                         [/#switch]
                     [/#if]
                 [/#list]
-
 
                 [#list solution.Alerts?values as alert ]
 

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -283,6 +283,11 @@
                             [#case "Subscription" ]
                                 [#list logwatcher.Links as logWatchLinkName,logWatcherLink ]
                                     [#assign logWatcherLinkTarget = getLinkTarget(occurrence, logWatcherLink) ]
+
+                                    [#if !logWatcherLinkTarget?has_content]
+                                        [#continue]
+                                    [/#if]
+
                                     [#assign logWatcherLinkTargetCore = logWatcherLinkTarget.Core ]
                                     [#assign logWatcherLinkTargetAttributes = logWatcherLinkTarget.State.Attributes ]
 

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -19,8 +19,6 @@
             [#assign fnLgId = resources["lg"].Id ]
             [#assign fnLgName = resources["lg"].Name ]
 
-            [#assign cwLogsPermissionRequired = false ]
-
             [#assign fragment =
                 contentIfContent(solution.Fragment, getComponentId(core.Component)) ]
 
@@ -258,8 +256,6 @@
 
                                         [#case LAMBDA_FUNCTION_COMPONENT_TYPE]
 
-                                            [#assign cwLogsPermissionRequired true /]
-
                                             [@createLogSubscription 
                                                 mode=listMode
                                                 id=formatDependentLogSubscriptionId(fnId, logWatchLink.Id)
@@ -268,13 +264,6 @@
                                                 destination=logWatcherLinkTargetAttributes["ARN"]
                                             /]
                                             
-                                            [@createLambdaPermission
-                                                mode=listMode
-                                                id=formatLambdaPermissionId(fn, "cwLogs", logWatchLink.Id)
-                                                targetId=logWatcherLinkTargetCore.Id
-                                                sourcePrincipal="logs." + regionId + ".amazonaws.com" 
-                                                sourceId=fnLgId
-                                            /]
                                             [#break]
                                     [/#switch]
                                 [/#list]

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -291,10 +291,6 @@
                                     [#assign logWatcherLinkTargetCore = logWatcherLinkTarget.Core ]
                                     [#assign logWatcherLinkTargetAttributes = logWatcherLinkTarget.State.Attributes ]
 
-                                    [#if !logWatcherLinkTarget?has_content]
-                                        [#continue]
-                                    [/#if]
-
                                     [#switch logWatcherLinkTargetCore.Type ]
 
                                         [#case LAMBDA_FUNCTION_COMPONENT_TYPE]

--- a/aws/templates/id/id_cw.ftl
+++ b/aws/templates/id/id_cw.ftl
@@ -4,6 +4,7 @@
 [#assign AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE = "lg" ]
 [#assign AWS_CLOUDWATCH_DASHBOARD_RESOURCE_TYPE = "dashboard" ]
 [#assign AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE = "lmetric" ]
+[#assign AWS_CLOUDWATCH_LOG_SUBSCRIPTION_RESOURCE_TYPE = "lsubscription" ]
 [#assign AWS_CLOUDWATCH_ALARM_RESOURCE_TYPE = "alarm" ]
 
 [#function formatLogGroupId ids...]
@@ -27,15 +28,16 @@
                 extensions)]
 [/#function]
 
-[#function formatLogMetricId ids...]
-    [#return formatResourceId(
-                AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE,
-                ids)]
-[/#function]
-
 [#function formatDependentLogMetricId resourceId extensions...]
     [#return formatDependentResourceId(
                 AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE,
+                resourceId,
+                extensions)]
+[/#function]
+
+[#function formatDependentLogSubscriptionId resourceId extensions... ]
+    [#return formatDependentResourceId(
+                AWS_CLOUDWATCH_LOG_SUBSCRIPTION_RESOURCE_TYPE,
                 resourceId,
                 extensions)]
 [/#function]

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -181,9 +181,9 @@
 [#function getFunctionState occurrence]
     [#local core = occurrence.Core]
 
-    [#assign id = formatResourceId(AWS_LAMBDA_FUNCTION_RESOURCE_TYPE, core.Id)]
+    [#local id = formatResourceId(AWS_LAMBDA_FUNCTION_RESOURCE_TYPE, core.Id)]
 
-    [#assign lgName = formatAbsolutePath("aws", "lambda", core.FullName)]
+    [#local lgName = formatAbsolutePath("aws", "lambda", core.FullName)]
 
     [#return
         {
@@ -216,7 +216,7 @@
                         "Principal" : "logs." + regionId + "amazonaws.com",
                         "SourceArn" : formatCloudWatchLogArn(lgName)
                     }
-                }
+                },
                 "Outbound" : {
                     "invoke" : lambdaInvokePermission(id)
                 }

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -60,15 +60,15 @@
                 "Children" : linkChildrenConfiguration
             },
             {
-                "Name" : "Metrics",
+                "Name" : "LogWatchers",
                 "Subobjects" : true,
-                "Children" : metricChildrenConfiguration
+                "Children" : logWatcherChildrenConfiguration
             },
             {
                 "Name" : "Alerts",
                 "Subobjects" : true,
                 "Children" : alertChildrenConfiguration
-            }
+            },
             {
                 "Name" : ["Memory", "MemorySize"],
                 "Type" : NUMBER_TYPE,
@@ -183,6 +183,8 @@
 
     [#assign id = formatResourceId(AWS_LAMBDA_FUNCTION_RESOURCE_TYPE, core.Id)]
 
+    [#assign lgName = formatAbsolutePath("aws", "lambda", core.FullName)]
+
     [#return
         {
             "Resources" : {
@@ -193,7 +195,7 @@
                 },
                 "lg" : {
                     "Id" : formatLogGroupId(core.Id),
-                    "Name" : formatAbsolutePath("aws", "lambda", core.FullName),
+                    "Name" : lgName,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
                 }
             },
@@ -209,7 +211,12 @@
                 "NAME" : core.FullName
             },
             "Roles" : {
-                "Inbound" : {},
+                "Inbound" : {
+                    "logwatch" : {
+                        "Principal" : "logs." + regionId + "amazonaws.com",
+                        "SourceArn" : formatCloudWatchLogArn(lgName)
+                    }
+                }
                 "Outbound" : {
                     "invoke" : lambdaInvokePermission(id)
                 }

--- a/aws/templates/id/id_mobilenotifier.ftl
+++ b/aws/templates/id/id_mobilenotifier.ftl
@@ -161,12 +161,29 @@
                 }
             },
             "Attributes" : {
-                "ARN" : getExistingReference(id, ARN_ATTRIBUTE_TYPE),
+                "ARN" : (engine == "SMS")?then(
+                            formatArn(
+                                regionObject.Partition,
+                                "sns", 
+                                regionId,
+                                accountObject.AWSId,
+                                "smsPlaceHolder"
+                            ),
+                            getExistingReference(id, ARN_ATTRIBUTE_TYPE)
+                ),
                 "ENGINE" : engine,
                 "TOPIC_PREFIX" : topicPrefix
             },
             "Roles" : {
-                "Inbound" : {},
+                "Inbound" : {
+                    "logwatch" : {
+                        "Principal" : "logs." + regionId + "amazonaws.com",
+                        "SourceArn" : [
+                            formatCloudWatchLogArn(lgName),
+                            formatCloudWatchLogArn(lgFailureName)
+                        ]
+                    }
+                },
                 "Outbound" : {
                     "default" : "publish",
                     "publish" : (engine == "SMS")?then(

--- a/aws/templates/id/id_mobilenotifier.ftl
+++ b/aws/templates/id/id_mobilenotifier.ftl
@@ -48,19 +48,24 @@
                 "Type" : STRING_TYPE
             },
             {
-                    "Name" : "Credentials",
-                    "Children" : [
-                        {
-                            "Name" : "EncryptionScheme",
-                            "Type" : STRING_TYPE,
-                            "Values" : ["base64"]
-                        }
-                    ]
-                }
+                "Name" : "Credentials",
+                "Children" : [
+                    {
+                        "Name" : "EncryptionScheme",
+                        "Type" : STRING_TYPE,
+                        "Values" : ["base64"]
+                    }
+                ]
+            },
             { 
                 "Name" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration
+            },
+            {
+                "Name" : "LogWatchers",
+                "Subobjects" : true,
+                "Children" : logWatcherChildrenConfiguration
             }
         ]
     }]
@@ -97,6 +102,44 @@
     [#local topicPrefix = core.ShortFullName]
     [#local engine = solution.Engine!core.SubComponent.Name?upper_case  ]
 
+    [#local lgNameComponents = 
+        [
+            "sns",
+            { "Ref" : "AWS::Region" },
+            { "Ref" : "AWS::AccountId" }
+        ]]
+
+    [#if engine != "SMS" ] 
+        [#local lgNameComponents += [
+            "app",
+            engine,
+            name
+        ]]
+
+    [#else]
+        [#local lgNameComponents += [
+            "DirectPublishToPhoneNumber"
+        ]]
+    [/#if]
+
+    [#local lgName = 
+        {
+            "Fn::Join" : [
+                "/",
+                lgNameComponents
+            ]
+        }
+    ]
+
+    [#local lgFailureName = 
+        {
+            "Fn::Join" : [
+                "/",
+                lgNameComponents + [ "Failure" ]
+            ]
+        }
+    ]
+
     [#local result =
         {
             "Resources" : {
@@ -105,6 +148,16 @@
                     "Name" : core.FullName,
                     "Engine" : engine,
                     "Type" : AWS_SNS_PLATFORMAPPLICATION_RESOURCE_TYPE 
+                },
+                "lg" : {
+                    "Id" : formatLogGroupId(core.Id),
+                    "Name" : lgName,
+                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+                },
+                "lgfailure" : {
+                    "Id" : formatLogGroupId(core.Id, "failure"),
+                    "Name" : lgFailureName,
+                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
                 }
             },
             "Attributes" : {
@@ -116,7 +169,10 @@
                 "Inbound" : {},
                 "Outbound" : {
                     "default" : "publish",
-                    "publish" : snsPublishPlatformApplication(name, engine, topicPrefix)
+                    "publish" : (engine == "SMS")?then(
+                        snsSMSPermission(),
+                        snsPublishPlatformApplication(name, engine, topicPrefix)
+                    )
                 }
             }
         }

--- a/aws/templates/policy/policy_sns.ftl
+++ b/aws/templates/policy/policy_sns.ftl
@@ -42,6 +42,21 @@
             id)]
 [/#function]
 
+[#function snsSMSPermission ]
+    [#return 
+        getPolicyStatement(
+            "sns:Publish",
+            "*",
+            "",
+            {
+                "StringEquals":{
+                    "sns:Protocol" : "sms" 
+                }
+            }
+        )
+    ]
+[/#function]
+
 [#function snsPublishPlatformApplication platformAppName engine topic_prefix ]
     [#return 
         [

--- a/aws/templates/resource/resource_cw.ftl
+++ b/aws/templates/resource/resource_cw.ftl
@@ -52,6 +52,28 @@
     /]
 [/#macro]
 
+[#macro createLogSubscription mode id logGroup filter destination role="" dependencies=""  ]
+
+    [#destinationArn = destination?starts_with("arn:")?then(
+        destination,
+        getReference(destination, ARN_ATTRIBUTE_TYPE )
+    )]
+
+    [@cfResource
+        mode=mode
+        id=id
+        type="AWS::Logs::SubscriptionFilter"
+        properties=
+            {
+                "DestinationArn" : destinationArn,
+                "FilterPattern" : filter,
+                "LogGroupName" : logGroup
+            } + 
+            attributeIfContent("RoleArn", role, getReference(role) )
+        dependencies=dependencies
+    /]
+[/#macro]
+
 [#assign DASHBOARD_OUTPUT_MAPPINGS =
     {
         REFERENCE_ATTRIBUTE_TYPE : {
@@ -259,3 +281,12 @@
     /]
 [/#macro]
 
+
+[#function formatCloudWatchLogArn lgName account={ "Ref" : "AWS::AccountId" }]
+    [#return
+        formatRegionalArn(
+            "logs",
+            lgName
+        )
+    ]
+[/#function]

--- a/aws/templates/resource/resource_cw.ftl
+++ b/aws/templates/resource/resource_cw.ftl
@@ -54,10 +54,10 @@
 
 [#macro createLogSubscription mode id logGroup filter destination role="" dependencies=""  ]
 
-    [#destinationArn = destination?starts_with("arn:")?then(
-        destination,
-        getReference(destination, ARN_ATTRIBUTE_TYPE )
-    )]
+    [#local destinationArn = destination?starts_with("arn:")?then(
+                                destination,
+                                getReference(destination, ARN_ATTRIBUTE_TYPE )
+                            )]
 
     [@cfResource
         mode=mode

--- a/aws/templates/resource/resource_cw.ftl
+++ b/aws/templates/resource/resource_cw.ftl
@@ -52,7 +52,7 @@
     /]
 [/#macro]
 
-[#macro createLogSubscription mode id logGroup filter destination role="" dependencies=""  ]
+[#macro createLogSubscription mode id logGroupName filter destination role="" dependencies=""  ]
 
     [#local destinationArn = destination?starts_with("arn:")?then(
                                 destination,
@@ -67,7 +67,7 @@
             {
                 "DestinationArn" : destinationArn,
                 "FilterPattern" : filter,
-                "LogGroupName" : logGroup
+                "LogGroupName" : logGroupName
             } + 
             attributeIfContent("RoleArn", role, getReference(role) )
         dependencies=dependencies

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -87,26 +87,27 @@
 ]
 
 [#assign
-    metricChildrenConfiguration = [
-        {
-            "Name" : "Name",
-            "Type" : STRING_TYPE,
-            "Mandatory" : true
-        }
+    logWatcherChildrenConfiguration = [
         {
             "Name" : "Type",
             "Type" : STRING_TYPE,
             "Mandatory" : true
-        }
+        },
         {
             "Name" : "LogPattern",
             "Type" : STRING_TYPE,
             "Default" : ""
+        },
+        {
+            "Name" : "Links",
+            "Subobjects" : true,
+            "Children" : linkChildrenConfiguration
         }
     ]
 ]
 
-[#assign alertChildrenConfiguration = [
+[#assign 
+    alertChildrenConfiguration = [
         "Description",
         {
             "Name" : "Name",

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -94,9 +94,9 @@
             "Mandatory" : true
         },
         {
-            "Name" : "LogPattern",
+            "Name" : "LogFilter",
             "Type" : STRING_TYPE,
-            "Default" : ""
+            "Mandatory" : true
         },
         {
             "Name" : "Links",
@@ -277,6 +277,7 @@
 [#assign bootstraps = blueprintObject.Bootstraps ]
 [#assign bootstrapProfiles = blueprintObject.BootstrapProfiles]
 [#assign securityProfiles = blueprintObject.SecurityProfiles ]
+[#assign logFilters = blueprintObject.LogFilters]
 
 [#-- Regions --]
 [#if region?has_content]

--- a/aws/templates/solution/solution_mobilenotifier.ftl
+++ b/aws/templates/solution/solution_mobilenotifier.ftl
@@ -19,21 +19,6 @@
 
         [#assign roleId = resources["role"].Id]
 
-        [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(roleId)]
-            [@createRole
-                mode=listMode
-                id=roleId
-                trustedServices=["sns.amazonaws.com" ]
-                policies=
-                    [
-                        getPolicyDocument(
-                                cwLogsProducePermission() +
-                                cwLogsConfigurePermission(),
-                            "logging")
-                    ]
-            /]
-        [/#if]
-
         [#assign platformAppAttributesCommand = "attributesPlatformApp" ]
         [#assign platformAppDeleteCommand = "deletePlatformApp" ]
 
@@ -56,7 +41,7 @@
             [#assign lgName = resources["lg"].Name ]
             [#assign lgFailureId = resources["lgfailure"].Id ] 
             [#assign lgFailureName = resources["lgfailure"].Name ]
-
+            
             [#assign platformAppAttributesCliId = formatId( platformAppId, "attributes" )]
 
             [#assign platformArn = getExistingReference( platformAppId, ARN_ATTRIBUTE_TYPE) ] 
@@ -131,7 +116,8 @@
                     [#break]
             [/#switch]
 
-            [#if deploymentSubsetRequired(MOBILENOTIFIER_COMPONENT_TYPE, true)]
+            [#if deploymentSubsetRequired("lg", true) &&
+                isPartOfCurrentDeploymentUnit(lgId)]     
 
                 [@createLogGroup
                     mode=listMode
@@ -142,6 +128,9 @@
                     mode=listMode
                     id=lgFailureId
                     name=lgFailureName /]
+            [/#if]
+            
+            [#if deploymentSubsetRequired(MOBILENOTIFIER_COMPONENT_TYPE, true)]
 
                 [#list solution.LogWatchers as logWatcherName,logwatcher ]
                     [@cfDebug listMode logwatcher false /]
@@ -292,6 +281,23 @@
                             "       esac"   
                         ]
                         
+                /]
+            [/#if]
+
+            [#if deploymentSubsetRequired("iam", true) 
+                && isPartOfCurrentDeploymentUnit(roleId)]
+                
+                [@createRole
+                    mode=listMode
+                    id=roleId
+                    trustedServices=["sns.amazonaws.com" ]
+                    policies=
+                        [
+                            getPolicyDocument(
+                                    cwLogsProducePermission() +
+                                    cwLogsConfigurePermission(),
+                                "logging")
+                        ]
                 /]
             [/#if]
         [/#if]

--- a/aws/templates/solution/solution_mobilenotifier.ftl
+++ b/aws/templates/solution/solution_mobilenotifier.ftl
@@ -147,7 +147,7 @@
                     [@cfDebug listMode logwatcher false /]
                     [#assign logFilter = logFilters[logwatcher.LogFilter].Pattern ]
 
-                    [#if deploymentSubsetRequired("lambda", true)]
+                    [#if deploymentSubsetRequired(MOBILENOTIFIER_COMPONENT_TYPE, true)]
                         [#switch logwatcher.Type ]
                             [#case "Metric" ]
                                 [@createLogMetric
@@ -158,6 +158,7 @@
                                     filter=logFilter
                                     namespace=formatProductRelativePath()
                                     value=1
+                                    dependencies=lgId
                                 /]
 
                                 [@createLogMetric
@@ -168,6 +169,7 @@
                                     filter=logFilter
                                     namespace=formatProductRelativePath()
                                     value=1
+                                    dependencies=lgFailureId
                                 /]
                             [#break]
 
@@ -187,18 +189,20 @@
 
                                             [@createLogSubscription 
                                                 mode=listMode
-                                                id=formatDependentLogSubscriptionId(platformAppId, logWatchLink.Id)
+                                                id=formatDependentLogSubscriptionId(platformAppId, logwatcher.Id, logWatcherLink.Id)
                                                 logGroupName=lgName
                                                 filter=logFilter
                                                 destination=logWatcherLinkTargetAttributes["ARN"]
+                                                dependencies=lgId
                                             /]
 
                                             [@createLogSubscription 
                                                 mode=listMode
-                                                id=formatDependentLogSubscriptionId(platformAppId, logWatchLink.Id, "failure")
+                                                id=formatDependentLogSubscriptionId(platformAppId, logwatcher.Id, logWatcherLink.Id, "failure")
                                                 logGroupName=lgFailureName
                                                 filter=logFilter
                                                 destination=logWatcherLinkTargetAttributes["ARN"]
+                                                dependencies=lgFailureId
                                             /]
                                             
                                             [#break]


### PR DESCRIPTION
This PR adds support for a LogWatcher, logwatchers can be configured with 2 types
 - Metric - When the given filter is matched increment a cloudwatch metric by 1. Combine this with alerts to generate alerts based on log events
 - Subscription - When the given filter is matched forward the log to the linked component. This is use to provide log forwarding functionality 

Links are used with log subscriptions to join them to a lambda function which is triggered when the log message and the message will be provided to the lambda function event call 

Also adds a LogFilters master data section which allows you to use predefined filters across mutiple log watchers. 

Currently supported on the following Components
- Lambda
- Mobile Notifier 

**Exmaple** 

```
                "notifier" : {
                    "DeploymentUnits" : ["notifier"],
                    "mobilenotifier" : {
                        "Platforms" : {
                            "SMS" : {
                                "Engine" : "SMS",
                                "LogWatchers" : {
                                    "error" : {
                                        "Type" : "Metric",
                                        "LogFilter" : "_pylog-warning"
                                    },
                                    "allforward" : {
                                        "Type" : "Subscription",
                                        "LogFilter" : "_all",
                                        "Links" : {
                                            "loglamb" : {
                                                "Tier" : "app",
                                                "Component" : "loglamb",
                                                "Function" : "forward"
                                            }
                                        }
                                    }
                                }
                            }
                        }
                    }
                }
```

This has two logwatchers on the the mobile notifier, a metric for any warnings along with a forward for everything

Also adds a couple of semi related features 
- Create Log Groups for Mobile notifier components on deploy
- Add SMS permissions for linking to a mobile notifier component 
- Refactor Lambda Role processing config to allow for new roles
