### PR TITLE
Add finer grained control over environment serialisation

### DIFF
--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -95,8 +95,8 @@
             [#assign containerId = fragmentId]
             [#include fragmentList?ensure_starts_with("/")]
 
-            [#assign finalEnvironment = getFinalEnvironment(fn, context, solution.EnvironmentAsFile) ]
-            [#assign finalAsFileEnvironment = getFinalEnvironment(fn, context, false) ]
+            [#assign finalEnvironment = getFinalEnvironment(fn, context, solution.Environment) ]
+            [#assign finalAsFileEnvironment = getFinalEnvironment(fn, context, solution.Environment + {"AsFile" : false}) ]
             [#assign context += finalEnvironment ]
 
             [#assign roleId = formatDependentRoleId(fnId)]
@@ -286,7 +286,7 @@
                 [#assign fragmentListMode = listMode]
                 [#include fragmentList?ensure_starts_with("/")]
             [/#if]
-            [#if solution.EnvironmentAsFile && deploymentSubsetRequired("config", false)]
+            [#if solution.Environment.AsFile && deploymentSubsetRequired("config", false)]
                 [@cfConfig
                     mode=listMode
                     content=finalAsFileEnvironment.Environment
@@ -308,7 +308,7 @@
                                 getOccurrenceSettingValue(fn, "SETTINGS_PREFIX")
                             ) /]
                 [/#if]
-                [#if solution.EnvironmentAsFile]
+                [#if solution.Environment.AsFile]
                     [@cfScript
                         mode=listMode
                         content=

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -147,9 +147,8 @@
                 "Default" : false
             },
             {
-                "Name" : "EnvironmentAsFile",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
+                "Name" : "Environment",
+                "Children" : settingsChildConfiguration
             }
         ]
     }

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -234,6 +234,31 @@
     ]
 ]
 
+[#assign settingsChildConfiguration = [
+        {
+            "Name" : "AsFile",
+            "Type" : BOOLEAN_TYPE,
+            "Default" : false
+        },
+        {
+            "Name" : "Json",
+            "Children" : [
+                {
+                    "Name" : "Escaped",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Name" : "Prefix",
+                    "Type" : STRING_TYPE,
+                    "Values" : ["json"],
+                    "Default" : "json"
+                }
+            ]
+        }
+    ]
+]
+
 [#include idList]
 [#include nameList]
 [#include policyList]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -251,7 +251,7 @@
                 {
                     "Name" : "Prefix",
                     "Type" : STRING_TYPE,
-                    "Values" : ["json"],
+                    "Values" : ["json", ""],
                     "Default" : "json"
                 }
             ]


### PR DESCRIPTION
Add the ability to select whether environment values should be serialised as strings or native JSON types
When everything is serialised as a string, add an optional prefix for objects and arrays so the consumer knows to process the contents as serialisable as JSON