### PR TITLE
Rework Log Watchers to be based on the receiver of the log

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1628,7 +1628,7 @@
   },
   "LogFilters" : {
     "_all" : {
-      "Pattern" : "*"
+      "Pattern" : ""
     },
     "_pylog-critical" : {
       "Pattern" : "CRITICAL"

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -62,34 +62,6 @@
                     [#switch linkDirection ]
                         [#case "inbound" ]
                             [#switch linkRole ]
-                                [#case "logwatch" ]
-                                    [#if (linkTargetResources[(linkTargetCore.Type)].Deployed)!false ||
-                                            (linkTargetAttributes["ARN"]!"")?has_content ]
-
-                                        [#assign roleSource = linkTargetRoles.Inbound["logwatch"] ]
-                                        [#if roleSource.SourceArn?is_enumerable ]
-                                            [#list roleSource.SourceArn as arn ]
-                                                [@createLambdaPermission
-                                                    mode=listMode
-                                                    id=formatLambdaPermissionId(fn, "logwatch", linkName, arn?index)
-                                                    targetId=fnId
-                                                    source={
-                                                        "Principal" : roleSource.Principal,
-                                                        "SourceArn" : arn
-                                                    }
-                                                /]
-                                            [/#list]
-                                        [#else]
-                                            [@createLambdaPermission
-                                                    mode=listMode
-                                                    id=formatLambdaPermissionId(fn, "logwatch", linkName)
-                                                    targetId=fnId
-                                                    source=roleSource
-                                                /]
-                                        [/#if]
-                                    [/#if]
-                                    [#break]
-
                                 [#case "invoke" ]
                                     [#switch linkTargetCore.Type]
                                         [#case USERPOOL_COMPONENT_TYPE ]
@@ -190,10 +162,28 @@
             [#if solution.PredefineLogGroup &&
                   deploymentSubsetRequired("lg", true) &&
                   isPartOfCurrentDeploymentUnit(fnLgId) ]
+
                 [@createLogGroup
                     mode=listMode
                     id=fnLgId
                     name=fnLgName /]
+
+                [#list solution.LogMetrics as logMetricName,logMetric ]
+
+                    [#assign logFilter = logFilters[logMetric.LogFilter].Pattern ]
+
+                    [@createLogMetric
+                        mode=listMode
+                        id=formatDependentLogMetricId(fnId, logMetric.Id)
+                        name=formatName(logMetricName, fnName)
+                        logGroup=fnLgName
+                        filter=logFilter
+                        namespace=formatProductRelativePath()
+                        value=1
+                        dependencies=fnLgId
+                    /]
+ 
+                [/#list]
             [/#if]
 
             [#if deploymentSubsetRequired("lambda", true)]
@@ -263,52 +253,46 @@
 
                 [#list solution.LogWatchers as logWatcherName,logwatcher ]
 
-                    [#assign logFilter = logFilters[logwatcher.logFilter].Pattern ]
+                    [#assign logFilter = logFilters[logwatcher.LogFilter].Pattern ]
 
-                    [#if deploymentSubsetRequired("lambda", true)]
-                        [#switch logwatcher.Type ]
-                            [#case "Metric" ]
-                                [@createLogMetric
+                    [#list logwatcher.Links as logWatcherLinkName,logWatcherLink ]
+                        [#assign logWatcherLinkTarget = getLinkTarget(occurrence, logWatcherLink) ]
+
+                        [#if !logWatcherLinkTarget?has_content]
+                            [#continue]
+                        [/#if]
+
+                        [#assign roleSource = logWatcherLinkTarget.State.Roles.Inbound["logwatch"]] 
+
+                        [#list roleSource.LogGroupIds as logGroupId ]
+
+                            [#assign logGroupArn = getExistingReference(logGroupId, ARN_ATTRIBUTE_TYPE)]
+
+                            [#if logGroupArn?has_content ]
+
+                                [@createLambdaPermission
                                     mode=listMode
-                                    id=formatDependentLogMetricId(fnId, logwatcher.Id)
-                                    name=formatName(logWatcherName, fnName)
-                                    logGroup=fnLgName
-                                    filter=logFilter
-                                    namespace=formatProductRelativePath()
-                                    value=1
+                                    id=formatLambdaPermissionId(fn, "logwatch", logWatcherLink.Id, logGroupId?index)
+                                    targetId=fnId
+                                    source={
+                                        "Principal" : roleSource.Principal,
+                                        "SourceArn" : logGroupArn
+                                    }
                                     dependencies=fnId
                                 /]
-                            [#break]
 
-                            [#case "Subscription" ]
-                                [#list logwatcher.Links as logWatchLinkName,logWatcherLink ]
-                                    [#assign logWatcherLinkTarget = getLinkTarget(occurrence, logWatcherLink) ]
+                                [@createLogSubscription 
+                                    mode=listMode
+                                    id=formatDependentLogSubscriptionId(fnId, logWatcherLink.Id, logGroupId?index)
+                                    logGroupName=getExistingReference(logGroupId)
+                                    filter=logFilter
+                                    destination=fnId
+                                    dependencies=fnId
+                                /]
 
-                                    [#if !logWatcherLinkTarget?has_content]
-                                        [#continue]
-                                    [/#if]
-
-                                    [#assign logWatcherLinkTargetCore = logWatcherLinkTarget.Core ]
-                                    [#assign logWatcherLinkTargetAttributes = logWatcherLinkTarget.State.Attributes ]
-
-                                    [#switch logWatcherLinkTargetCore.Type ]
-
-                                        [#case LAMBDA_FUNCTION_COMPONENT_TYPE]
-
-                                            [@createLogSubscription 
-                                                mode=listMode
-                                                id=formatDependentLogSubscriptionId(fnId, logWatchLink.Id)
-                                                logGroupName=fnLgName
-                                                filter=logFilter
-                                                destination=logWatcherLinkTargetAttributes["ARN"]
-                                            /]
-                                            
-                                            [#break]
-                                    [/#switch]
-                                [/#list]
-                            [#break]
-                        [/#switch]
-                    [/#if]
+                            [/#if]
+                        [/#list]    
+                    [/#list]
                 [/#list]
 
                 [#list solution.Alerts?values as alert ]

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -264,7 +264,7 @@
 
                         [#assign roleSource = logWatcherLinkTarget.State.Roles.Inbound["logwatch"]] 
 
-                        [#list roleSource.LogGroupIds as logGroupId ]
+                        [#list asArray(roleSource.LogGroupIds) as logGroupId ]
 
                             [#assign logGroupArn = getExistingReference(logGroupId, ARN_ATTRIBUTE_TYPE)]
 

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -60,6 +60,11 @@
                 "Children" : linkChildrenConfiguration
             },
             {
+                "Name" : "LogMetrics",
+                "Subobjects" : true,
+                "Children" : logMetricChildrenConfiguration
+            },
+            {
                 "Name" : "LogWatchers",
                 "Subobjects" : true,
                 "Children" : logWatcherChildrenConfiguration
@@ -182,6 +187,7 @@
 
     [#local id = formatResourceId(AWS_LAMBDA_FUNCTION_RESOURCE_TYPE, core.Id)]
 
+    [#local lgId = formatLogGroupId(core.Id)]
     [#local lgName = formatAbsolutePath("aws", "lambda", core.FullName)]
 
     [#return
@@ -213,7 +219,7 @@
                 "Inbound" : {
                     "logwatch" : {
                         "Principal" : "logs." + regionId + "amazonaws.com",
-                        "SourceArn" : formatCloudWatchLogArn(lgName)
+                        "LogGroupIds" : [ lgId ]
                     }
                 },
                 "Outbound" : {

--- a/aws/templates/id/id_mobilenotifier.ftl
+++ b/aws/templates/id/id_mobilenotifier.ftl
@@ -63,9 +63,9 @@
                 "Children" : linkChildrenConfiguration
             },
             {
-                "Name" : "LogWatchers",
+                "Name" : "LogMetrics",
                 "Subobjects" : true,
-                "Children" : logWatcherChildrenConfiguration
+                "Children" : logMetricChildrenConfiguration
             }
         ]
     }]
@@ -122,6 +122,8 @@
         ]]
     [/#if]
 
+    [#local lgId = formatLogGroupId(core.Id)]
+    [#local lgFailureId = formatLogGroupId(core.Id, "failure")]
     [#local lgName = 
         {
             "Fn::Join" : [
@@ -150,12 +152,12 @@
                     "Type" : AWS_SNS_PLATFORMAPPLICATION_RESOURCE_TYPE 
                 },
                 "lg" : {
-                    "Id" : formatLogGroupId(core.Id),
+                    "Id" : lgId,
                     "Name" : lgName,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
                 },
                 "lgfailure" : {
-                    "Id" : formatLogGroupId(core.Id, "failure"),
+                    "Id" : lgFailureId,
                     "Name" : lgFailureName,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
                 }
@@ -178,10 +180,7 @@
                 "Inbound" : {
                     "logwatch" : {
                         "Principal" : "logs." + regionId + "amazonaws.com",
-                        "SourceArn" : [
-                            formatCloudWatchLogArn(lgName),
-                            formatCloudWatchLogArn(lgFailureName)
-                        ]
+                        "LogGroupIds" : [ lgId, lgFailureId ]
                     }
                 },
                 "Outbound" : {

--- a/aws/templates/resource/resource_cw.ftl
+++ b/aws/templates/resource/resource_cw.ftl
@@ -54,18 +54,13 @@
 
 [#macro createLogSubscription mode id logGroupName filter destination role="" dependencies=""  ]
 
-    [#local destinationArn = destination?starts_with("arn:")?then(
-                                destination,
-                                getReference(destination, ARN_ATTRIBUTE_TYPE )
-                            )]
-
     [@cfResource
         mode=mode
         id=id
         type="AWS::Logs::SubscriptionFilter"
         properties=
             {
-                "DestinationArn" : destinationArn,
+                "DestinationArn" : getReference(destination),
                 "FilterPattern" : filter,
                 "LogGroupName" : logGroupName
             } + 

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -89,11 +89,6 @@
 [#assign
     logWatcherChildrenConfiguration = [
         {
-            "Name" : "Type",
-            "Type" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
             "Name" : "LogFilter",
             "Type" : STRING_TYPE,
             "Mandatory" : true
@@ -102,6 +97,16 @@
             "Name" : "Links",
             "Subobjects" : true,
             "Children" : linkChildrenConfiguration
+        }
+    ]
+]
+
+[#assign
+    logMetricChildrenConfiguration = [
+        {
+            "Name" : "LogFilter",
+            "Type" : STRING_TYPE,
+            "Mandatory" : true
         }
     ]
 ]

--- a/aws/templates/solution/solution_mobilenotifier.ftl
+++ b/aws/templates/solution/solution_mobilenotifier.ftl
@@ -117,7 +117,7 @@
             [/#switch]
 
             [#if deploymentSubsetRequired("lg", true) &&
-                isPartOfCurrentDeploymentUnit(lgId)]     
+                isPartOfCurrentDeploymentUnit(lgId)]   
 
                 [@createLogGroup
                     mode=listMode
@@ -128,81 +128,35 @@
                     mode=listMode
                     id=lgFailureId
                     name=lgFailureName /]
-            [/#if]
-            
-            [#if deploymentSubsetRequired(MOBILENOTIFIER_COMPONENT_TYPE, true)]
 
-                [#list solution.LogWatchers as logWatcherName,logwatcher ]
-                    [@cfDebug listMode logwatcher false /]
-                    [#assign logFilter = logFilters[logwatcher.LogFilter].Pattern ]
+                [#list solution.LogMetrics as logMetricName,logMetric ]
 
-                    [#if deploymentSubsetRequired(MOBILENOTIFIER_COMPONENT_TYPE, true)]
-                        [#switch logwatcher.Type ]
-                            [#case "Metric" ]
-                                [@createLogMetric
-                                    mode=listMode
-                                    id=formatDependentLogMetricId(platformAppId, logwatcher.Id)
-                                    name=formatName(logWatcherName, platformAppName)
-                                    logGroup=lgName
-                                    filter=logFilter
-                                    namespace=formatProductRelativePath()
-                                    value=1
-                                    dependencies=lgId
-                                /]
+                    [#assign logFilter = logFilters[logMetric.LogFilter].Pattern ]
 
-                                [@createLogMetric
-                                    mode=listMode
-                                    id=formatDependentLogMetricId(platformAppId, logwatcher.Id, "failure")
-                                    name=formatName(logWatcherName, platformAppName, "failure")
-                                    logGroup=lgFailureName
-                                    filter=logFilter
-                                    namespace=formatProductRelativePath()
-                                    value=1
-                                    dependencies=lgFailureId
-                                /]
-                            [#break]
+                    [@createLogMetric
+                        mode=listMode
+                        id=formatDependentLogMetricId(platformAppId, logMetric.Id)
+                        name=formatName(logMetricName, platformAppName)
+                        logGroup=lgName
+                        filter=logFilter
+                        namespace=formatProductRelativePath()
+                        value=1
+                        dependencies=lgId
+                    /]
 
-                            [#case "Subscription" ]
-                                [#list logwatcher.Links as logWatchLinkName,logWatcherLink ]
-                                    [#assign logWatcherLinkTarget = getLinkTarget(occurrence, logWatcherLink) ]
-
-                                    [#if !logWatcherLinkTarget?has_content]
-                                        [#continue]
-                                    [/#if]
-
-                                    [#assign logWatcherLinkTargetCore = logWatcherLinkTarget.Core ]
-                                    [#assign logWatcherLinkTargetAttributes = logWatcherLinkTarget.State.Attributes ]
-                                    [#switch logWatcherLinkTargetCore.Type]
-
-                                        [#case LAMBDA_FUNCTION_COMPONENT_TYPE]
-
-                                            [@createLogSubscription 
-                                                mode=listMode
-                                                id=formatDependentLogSubscriptionId(platformAppId, logwatcher.Id, logWatcherLink.Id)
-                                                logGroupName=lgName
-                                                filter=logFilter
-                                                destination=logWatcherLinkTargetAttributes["ARN"]
-                                                dependencies=lgId
-                                            /]
-
-                                            [@createLogSubscription 
-                                                mode=listMode
-                                                id=formatDependentLogSubscriptionId(platformAppId, logwatcher.Id, logWatcherLink.Id, "failure")
-                                                logGroupName=lgFailureName
-                                                filter=logFilter
-                                                destination=logWatcherLinkTargetAttributes["ARN"]
-                                                dependencies=lgFailureId
-                                            /]
-                                            
-                                            [#break]
-                                    [/#switch]
-                                [/#list]
-                            [#break]
-                        [/#switch]
-                    [/#if]
+                    [@createLogMetric
+                        mode=listMode
+                        id=formatDependentLogMetricId(platformAppId, logMetric.Id, "failure")
+                        name=formatName(logMetricName, platformAppName, "failure")
+                        logGroup=lgFailureName
+                        filter=logFilter
+                        namespace=formatProductRelativePath()
+                        value=1
+                        dependencies=lgFailureId
+                    /]  
                 [/#list]
             [/#if]
-
+            
             [#if isPlatformApp ]
                 [#if deploymentSubsetRequired("cli", false ) ]
                 


### PR DESCRIPTION
Instead of making a logwatcher part of the logging component it is now part of the destination receiving the log at the moment this is just Lambda 

In this setup the lambda with a log watch links to a component that it wants to watch. This will configure the log subscription as part of the lambda deployment. 

Log metrics stay with the component that generates the log but they are now part of the logs pass to make sure they are created with their log. 

Minor fix for the wall logs log filter pattern as well