### PR TITLE
getLinkTarget always returns the effective role

### DIFF
--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -76,10 +76,10 @@
                                                 /]
                                             [/#if]
                                             [#break]
-                                            
-                                    [/#switch]    
+
+                                    [/#switch]
                                     [#break]
-                                
+
                             [/#switch]
                             [#break]
                         [#case "outbound" ]
@@ -182,7 +182,7 @@
                         value=1
                         dependencies=fnLgId
                     /]
- 
+
                 [/#list]
             [/#if]
 
@@ -262,7 +262,7 @@
                             [#continue]
                         [/#if]
 
-                        [#assign roleSource = logWatcherLinkTarget.State.Roles.Inbound["logwatch"]] 
+                        [#assign roleSource = logWatcherLinkTarget.State.Roles.Inbound["logwatch"]]
 
                         [#list asArray(roleSource.LogGroupIds) as logGroupId ]
 
@@ -281,7 +281,7 @@
                                     dependencies=fnId
                                 /]
 
-                                [@createLogSubscription 
+                                [@createLogSubscription
                                     mode=listMode
                                     id=formatDependentLogSubscriptionId(fnId, logWatcherLink.Id, logGroupId?index)
                                     logGroupName=getExistingReference(logGroupId)
@@ -291,7 +291,7 @@
                                 /]
 
                             [/#if]
-                        [/#list]    
+                        [/#list]
                     [/#list]
                 [/#list]
 

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1588,9 +1588,9 @@ behaviour.
             targetOccurrence +
             {
                 "State" : getOccurrenceState(targetOccurrence, {}),
-                "Direction" : link.Direction!"outbound"
-            } +
-            attributeIfContent("Role", link.Role!"")
+                "Direction" : link.Direction!"outbound",
+                "Role" : link.Role!"external"
+            }
         ]
     [/#if]
 
@@ -1658,12 +1658,19 @@ behaviour.
 
             [@cfDebug listMode "Link matched target" false /]
 
+            [#-- Determine the role --]
+            [#local direction = link.Direction!"outbound"]
+
+            [#local role =
+                link.Role!
+                (targetSubOccurrence.State.Roles[direction?capitalize]["default"])!""]
+
             [#return
                 targetSubOccurrence +
                 {
-                    "Direction" : link.Direction!"outbound"
-                } +
-                attributeIfContent("Role", link.Role!"") ]
+                    "Direction" : direction,
+                    "Role" : role
+                } ]
         [/#list]
     [/#list]
 
@@ -1704,9 +1711,7 @@ behaviour.
         [#if !isOneResourceDeployed((linkTarget.State.Resources)!{})]
             [#continue]
         [/#if]
-        [#local linkTargetOutboundRoles = (linkTarget.State.Roles.Outbound)!{} ]
-        [#local roleName = linkTarget.Role!linkTargetOutboundRoles["default"]!""]
-        [#local role = linkTargetOutboundRoles[roleName]!{} ]
+        [#local role = (linkTarget.State.Roles.Outbound[linkTarget.Role])!{} ]
         [#if (linkTarget.Direction == "outbound") && role?has_content ]
             [#local roles += asArray(role![]) ]
         [/#if]

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -300,15 +300,16 @@
                 "DOCS_URL" : "http://" + getExistingReference(docsId, NAME_ATTRIBUTE_TYPE)
             },
             "Roles" : {
-                "Outbound" : {
-                    "default" : "invoke",
-                    "invoke" : apigatewayInvokePermission(apiId, stageName)
-                },
                 "Inbound" : {
+                    "default" : "invoke",
                     "invoke" : {
                         "Principal" : "apigateway.amazonaws.com",
                         "SourceArn" : formatInvokeApiGatewayArn(apiId, stageName)
                     }
+                },
+                "Outbound" : {
+                    "default" : "invoke",
+                    "invoke" : apigatewayInvokePermission(apiId, stageName)
                 }
             }
         }

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -223,6 +223,7 @@
                     }
                 },
                 "Outbound" : {
+                    "default" : "invoke",
                     "invoke" : lambdaInvokePermission(id)
                 }
             }


### PR DESCRIPTION
Processing can always assume a link target object has a Role attribute,
though it may be empty.

Also add "invoke" as the default inbound and outbound role for lambda.