### PR TITLE
Force the content type for SMS requests

### DIFF
--- a/aws/templates/swagger.ftl
+++ b/aws/templates/swagger.ftl
@@ -369,6 +369,7 @@
             [#break]
 
         [#case "sms"]
+            [#-- Force the content type so the api returns the response body as JSON --]
             [#local result +=
                 {
                     "x-amazon-apigateway-integration" : {
@@ -378,7 +379,8 @@
                         "httpMethod" : "POST",
                         "requestParameters": {
                           "integration.request.querystring.PhoneNumber": "method.request.querystring.PhoneNumber",
-                          "integration.request.querystring.Message": "method.request.querystring.Message"
+                          "integration.request.querystring.Message": "method.request.querystring.Message",
+                          "integration.request.header.Content-type": "'application/json'"
                         },
                         "credentials" : context[formatAbsolutePath(path,"rolearn")],
                         "responses" : {


### PR DESCRIPTION
The SNS api seems to rely on the content type to determine the format of the output, especially when the accept header is non-specific.