### PR TITLE
use CONFIG_FILE with s3 url value instead of SETTINGS_FILE

### DIFF
--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -380,7 +380,7 @@
                 ) +
                 valueIfTrue(
                     {
-                        "SETTINGS_FILE" : "config/config_" + runId + ".json",
+                        "CONFIG_FILE" : ["s3:/", operationsBucket, getSettingsFilePrefix(occurrence), "config/config_" + runId + ".json"]?join("/"),
                         "RUN_ID" : runId
                     },
                     asFile,

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -380,7 +380,7 @@
                 ) +
                 valueIfTrue(
                     {
-                        "CONFIG_FILE" : ["s3:/", operationsBucket, getSettingsFilePrefix(occurrence), "config/config_" + runId + ".json"]?join("/"),
+                        "SETTINGS_FILE" : ["s3:/", operationsBucket, getSettingsFilePrefix(occurrence), "config/config_" + runId + ".json"]?join("/"),
                         "RUN_ID" : runId
                     },
                     asFile,


### PR DESCRIPTION
Set `CONFIG_FILE` with an s3 url value so it can be used in code instead of `OPSDATA_BUCKET`, `SETTINGS_PREFIX`, `SETTINGS_FILE` combination.