### PR TITLE
Move SMS cloudwatch log creation to account level

### DIFF
--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -711,7 +711,7 @@ function isValidUnit() {
   # Check unit if required
   if [[ "${unit_required[${level}]}" == "true" ]]; then
     # Default deployment units for each level
-    declare -ga ACCOUNT_UNITS_ARRAY=("iam" "audit" "s3" "cert" "roles" "apigateway" "waf" "sms")
+    declare -ga ACCOUNT_UNITS_ARRAY=("iam" "lg" "audit" "s3" "cert" "roles" "apigateway" "waf" "sms")
     declare -ga PRODUCT_UNITS_ARRAY=("s3" "sns" "cert" "cmk")
     declare -ga BUILDBLUEPRINT_UNITS_ARRAY=(${unit})
     declare -ga APPLICATION_UNITS_ARRAY=(${unit})

--- a/aws/templates/account/account_sms.ftl
+++ b/aws/templates/account/account_sms.ftl
@@ -15,6 +15,20 @@
         /]
     [/#if]
 
+    [#assign lgId = formatMobileNotifierLogGroupId(MOBILENOTIFIER_SMS_ENGINE, "", false) ]
+    [#assign lgFailureId = formatMobileNotifierLogGroupId(MOBILENOTIFIER_SMS_ENGINE, "", true) ]
+    [#if deploymentSubsetRequired("lg", true) && isPartOfCurrentDeploymentUnit(lgId) ]
+        [@createLogGroup
+            mode=listMode
+            id=lgId
+            name=formatMobileNotifierLogGroupName(MOBILENOTIFIER_SMS_ENGINE, "", false) /]
+
+        [@createLogGroup
+            mode=listMode
+            id=lgFailureId
+            name=formatMobileNotifierLogGroupName(MOBILENOTIFIER_SMS_ENGINE, "", true) /]
+    [/#if]
+
     [#assign smsS3Id = formatAccountS3Id("ops") ]
     [#assign smsResourceId = "sms" ]
     [#assign smsCliCommand = "setsmsattributes" ]

--- a/aws/templates/createAccountTemplate.ftl
+++ b/aws/templates/createAccountTemplate.ftl
@@ -6,6 +6,7 @@
 [#-- Special processing --]
 [#switch deploymentUnit]
     [#case "iam"]
+    [#case "lg"]
         [#if !(deploymentUnitSubset?has_content)]
             [#assign allDeploymentUnits = true]
             [#assign deploymentUnitSubset = deploymentUnit]

--- a/aws/templates/id/id_cw.ftl
+++ b/aws/templates/id/id_cw.ftl
@@ -28,6 +28,12 @@
                 extensions)]
 [/#function]
 
+[#function formatAccountLogGroupId ids...]
+    [#return formatAccountResourceId(
+                AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,
+                ids)]
+[/#function]
+
 [#function formatDependentLogMetricId resourceId extensions...]
     [#return formatDependentResourceId(
                 AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE,

--- a/aws/templates/name/name_mobilenotifier.ftl
+++ b/aws/templates/name/name_mobilenotifier.ftl
@@ -1,0 +1,26 @@
+[#-- Mobile Notifier --]
+
+[#function formatMobileNotifierLogGroupName engine name="" failure=false]
+
+    [#return
+        {
+            "Fn::Join" : [
+                "/",
+                [
+                    "sns",
+                    { "Ref" : "AWS::Region" },
+                    { "Ref" : "AWS::AccountId" }
+                ] +
+                valueIfTrue(
+                    ["DirectPublishToPhoneNumber"],
+                    engine == MOBILENOTIFIER_SMS_ENGINE,
+                    ["app", engine, name]
+                ) +
+                arrayIfTrue(
+                    [ "Failure" ],
+                    failure
+                )
+            ]
+        } ]
+[/#function]
+

--- a/aws/templates/swagger.ftl
+++ b/aws/templates/swagger.ftl
@@ -378,12 +378,8 @@
                         "uri" : "arn:aws:apigateway:" + context["Region"] + ":sns:action/Publish",
                         "passthroughBehavior" : "never",
                         "httpMethod" : "POST",
-                        "requestParameters": {
-                            "integration.request.querystring.PhoneNumber": "method.request.querystring.PhoneNumber",
-                            "integration.request.querystring.Message": "method.request.querystring.Message"
-                        },
                         "requestTemplates" : {
-                            "application/json" : "#set($qs = $input.params().querystring)\r\n#if($!{qs.get(\"SenderID\")} ne \"\")\r\n#set($context.requestOverride.querystring[\"MessageAttributes.entry.1.Name\"] = \"AWS.SNS.SMS.SenderID\")\r\n#set($context.requestOverride.querystring[\"MessageAttributes.entry.1.Value.DataType\"] = \"String\")\r\n#set($context.requestOverride.querystring[\"MessageAttributes.entry.1.Value.StringValue\"] = $qs.get(\"SenderID\"))\r\n#end"
+                            "application/json" : "\r\n#set($phoneNumber = $input.json(\"$.PhoneNumber\"))\r\n#set($message = $input.json(\"$.Message\"))\r\n#set($sender = $input.json(\"$.SenderId\"))\r\n#set($environment = $stageVariables[\"ENVIRONMENT\"])\r\n#set( $newline=\"\r\n\")\r\n#if($sender ne \"\")\r\n#set($context.requestOverride.querystring[\"MessageAttributes.entry.1.Name\"] = \"AWS.SNS.SMS.SenderID\")\r\n#set($context.requestOverride.querystring[\"MessageAttributes.entry.1.Value.DataType\"] = \"String\")\r\n#set($context.requestOverride.querystring[\"MessageAttributes.entry.1.Value.StringValue\"] = \"$sender\")\r\n#end\r\n#if($!{stageVariables[\"ENVIRONMENT\"]} ne \"\")\r\n#set($message = \"${message}${newline}${newline}ENV=$environment\")\r\n#end\r\n#set($context.requestOverride.querystring[\"PhoneNumber"\] = \"${phoneNumber}\")\r\n#set($context.requestOverride.querystring[\"Message\"] = \"${message}\")
                         },
                         "credentials" : context[formatAbsolutePath(path,"rolearn")],
                         "responses" :


### PR DESCRIPTION
The SMS service only supports one pair of sms logs so shift their
management to the account level.

The local notifier is still supported to allow linking but will always
return the same logs.