### PR TITLE
Component reference and id properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.iml
 dist/*
 build/*
+cache/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 .idea/*
 *.iml
+dist/*
+build/*

--- a/aws/createReference.sh
+++ b/aws/createReference.sh
@@ -63,7 +63,7 @@ function process_template() {
   export COMPOSITE_BLUEPRINT="${CACHE_DIR}/composite_blueprint.json"
   debug "BLUEPRINT=${blueprint_array[*]}"
   if [[ ! $(arrayIsEmpty "blueprint_array") ]]; then
-      addToArrayHead "blueprint_array" "${GENERATION_MASTER_DATA_DIR:-${GENERATION_BASE_DIR}/data}"/masterData.json
+      addToArrayHead "blueprint_array" "${GENERATION_MASTER_DATA_DIR:-${GENERATION_DIR}/data}"/masterData.json
       ${GENERATION_DIR}/manageJSON.sh -d -o "${COMPOSITE_BLUEPRINT}" "${blueprint_array[@]}"
   else
       echo "{}" > "${COMPOSITE_BLUEPRINT}"
@@ -205,15 +205,14 @@ function process_template() {
 
     case "$(fileExtension "${template_result_file}")" in
       md)
+        npm install -g remark-cli
+
         info "${output_file}"
-        if [[ ! -f "${output_file}" ]]; then
-          
+        if [[ ! -d "${output_dir}" ]]; then
           mkdir -p "${output_dir}"
-          # First generation - just format
-          cat "${template_result_file}"  > "${output_file}"
-        else
-          cat "${template_result_file}"  > "${output_file}"
         fi
+        
+        remark "${template_result_file}" -o "${output_file}"
 
         ;;
     esac

--- a/aws/createReference.sh
+++ b/aws/createReference.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+
+[[ -n "${GENERATION_DEBUG}" ]] && set ${GENERATION_DEBUG}
+trap '. ${GENERATION_DIR}/cleanupContext.sh' EXIT SIGHUP SIGINT SIGTERM
+. "${GENERATION_DIR}/common.sh"
+
+# Defaults
+REFERNCE_OUTPUT_DIR_DEFAULT="${GENERATION_BASE_DIR}/dist/reference/"
+
+function usage() {
+  cat <<EOF
+
+Create a Codeontap Component Reference
+
+Usage: $(basename $0) -l REFERENCE_TYPE -o OUTPUT_FILE
+
+where
+
+(m) -t REFERENCE_TYPE         is the type of object you need the reference for
+(o) -o REFERENCE_OUTPUT_DIR             is the output directory
+(m) mandatory, (o) optional, (d) deprecated
+
+DEFAULTS:
+
+REFERENCE_OUTPUT_DIR              = "${REFERNCE_OUTPUT_DIR_DEFAULT}"
+
+NOTES:
+
+
+EOF
+}
+
+function options() {
+
+  # Parse options
+  while getopts ":o:t:" option; do
+      case "${option}" in
+          t) REFERENCE_TYPE="${OPTARG}" ;;
+          o) REFERENCE_OUTPUT_DIR="${OPTARG}" ;;
+          \?) fatalOption; return 1 ;;
+          :) fatalOptionArgument; return 1 ;;
+      esac
+  done
+
+  # Defaults
+  REFERENCE_OUTPUT_DIR="${REFERENCE_OUTPUT_DIR:-${REFERNCE_OUTPUT_DIR_DEFAULT}}"
+
+  return 0
+}
+
+function process_template() {
+  local type="${1,,}"; shift
+  local output_dir="${1,,}"; shift
+
+  # Generate the list of files constituting the composites based on the contents
+  # of the account and product trees
+  # The blueprint is handled specially as its logic is different to the others
+
+  local GENERATION_DATA_DIR="${GENERATION_BASE_DIR}/build/"
+  local CACHE_DIR="${GENERATION_BASE_DIR}/cache"
+  mkdir -p "${CACHE_DIR}"
+
+  export COMPOSITE_BLUEPRINT="${CACHE_DIR}/composite_blueprint.json"
+  debug "BLUEPRINT=${blueprint_array[*]}"
+  if [[ ! $(arrayIsEmpty "blueprint_array") ]]; then
+      addToArrayHead "blueprint_array" "${GENERATION_MASTER_DATA_DIR:-${GENERATION_BASE_DIR}/data}"/masterData.json
+      ${GENERATION_DIR}/manageJSON.sh -d -o "${COMPOSITE_BLUEPRINT}" "${blueprint_array[@]}"
+  else
+      echo "{}" > "${COMPOSITE_BLUEPRINT}"
+  fi
+
+  TEMPLATE_COMPOSITES=( "id" "name" "policy" "resource" )
+  for composite in "${TEMPLATE_COMPOSITES[@]}"; do
+      # Define the composite
+      declare -gx COMPOSITE_${composite^^}="${CACHE_DIR}/composite_${composite}.ftl"
+
+      if [[ (("${GENERATION_USE_CACHE}" != "true")  &&
+              ("${GENERATION_USE_FRAGMENTS_CACHE}" != "true")) ||
+            (! -f "${CACHE_DIR}/composite_id.ftl") ]]; then
+          # define the array holding the list of composite fragment filenames
+          declare -ga "${composite}_array"
+
+          # Check for composite start fragment
+          addToArray "${composite}_array" "${GENERATION_DIR}"/templates/"${composite}"/start*.ftl
+
+          # If no composite specific start fragment, use a generic one
+          $(inArray "${composite}_array" "start.ftl") ||
+              addToArray "${composite}_array" "${GENERATION_DIR}"/templates/start.ftl
+      fi
+  done
+
+  # Add default composite fragments including end fragment
+  if [[ (("${GENERATION_USE_CACHE}" != "true")  &&
+          ("${GENERATION_USE_FRAGMENTS_CACHE}" != "true")) ||
+        (! -f "${CACHE_DIR}/composite_id.ftl") ]]; then
+
+      for composite in "${TEMPLATE_COMPOSITES[@]}"; do
+          for fragment in ${GENERATION_DIR}/templates/${composite}/${composite}_*.ftl; do
+                  $(inArray "${composite}_array" $(fileName "${fragment}")) ||
+                      addToArray "${composite}_array" "${fragment}"
+          done
+          for fragment in ${GENERATION_DIR}/templates/${composite}/*end.ftl; do
+              addToArray "${composite}_array" "${fragment}"
+          done
+      done
+
+      info "Composite Array = ${id_array}"
+
+
+      # create the template composites
+      for composite in "${TEMPLATE_COMPOSITES[@]}"; do
+
+        info "Cache DIR ${CACHE_DIR}"
+
+          namedef_supported &&
+            declare -n composite_array="${composite}_array" ||
+            eval "declare composite_array=(\"\${${composite}_array[@]}\")"
+          debug "${composite^^}=${composite_array[*]}"
+          cat "${composite_array[@]}" > "${CACHE_DIR}/composite_${composite}.ftl"
+
+      done
+  fi
+
+  # Filename parts
+  local type_prefix="${type}-"
+
+  # Set up the level specific template information
+  local template_dir="${GENERATION_DIR}/templates"
+  local template="create${type^}Reference.ftl"
+  [[ ! -f "${template_dir}/${template}" ]] && template="create${type^}.ftl"
+  local template_composites=("POLICY" "ID" "NAME" "RESOURCE")
+
+  case "${type}" in
+    component)
+      cf_dir="${PRODUCT_INFRASTRUCTURE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
+      passes=("reference")
+
+      pass_level_prefix["reference"]="blueprint"
+      pass_description["reference"]="blueprint"
+      pass_suffix["reference"]=".md"
+      ;;
+
+    *)
+      fatalCantProceed "\"${LEVEL}\" is not one of the known stack levels."
+      ;;
+  esac
+
+  # Include the template composites
+  # Removal of drive letter (/?/) is specifically for MINGW
+  # It shouldn't affect other platforms as it won't be matched
+  for composite in "${template_composites[@]}"; do
+    composite_var="COMPOSITE_${composite^^}"
+    args+=("-r" "${composite,,}List=${!composite_var#/?/}")
+    info "${composite_var}"
+  done
+
+  args+=("-v" "blueprint=${COMPOSITE_BLUEPRINT}")
+  args+=("-v" "settings={}")
+  args+=("-v" "region=ap-southeast-2")
+
+  # Directory for temporary files
+  pushTempDir "create_template_XXXX"
+  local tmp_dir="$(getTopTempDir)"
+
+  # Perform each pass
+  for pass in "${passes[@]}"; do
+
+    local output_prefix="${pass_level_prefix[${pass}]}"
+
+    # Determine output file
+    info "Generating ${type} reference file ...\n"
+
+    local output_file="${output_dir}/${output_prefix}${pass_suffix[${pass}]}"
+    local template_result_file="${tmp_dir}/${output_prefix}${pass_alternative_prefix}${pass_suffix[${pass}]}"
+
+    pass_args=("${args[@]}")
+
+    ${GENERATION_DIR}/freemarker.sh \
+      -d "${template_dir}" -t "${template}" -o "${template_result_file}" "${pass_args[@]}" || return $?
+    
+    # Ignore whitespace only files
+    if [[ $(tr -d " \t\n\r\f" < "${template_result_file}" | wc -m) -eq 0 ]]; then
+      info "Ignoring empty ${file_description} file ...\n"
+
+      # Remove any previous version
+      [[ -f "${output_file}" ]] && rm "${output_file}"
+
+      continue
+    fi
+
+    # Check for exception strings in the output
+    grep "COTException:" < "${template_result_file}" > "${template_result_file}-exceptionstrings"
+    if [[ -s "${template_result_file}-exceptionstrings"  ]]; then
+      fatal "Exceptions occurred during template generation. Details follow...\n"
+      case "$(fileExtension "${template_result_file}")" in
+        json)
+          jq --indent 2 '.' < "${template_result_file}-exceptionstrings" >&2
+          ;;
+        *)
+          cat "${template_result_file}-exceptionstrings" >&2
+          ;;
+      esac
+      return 1
+    fi
+
+    case "$(fileExtension "${template_result_file}")" in
+      md)
+        info "${output_file}"
+        if [[ ! -f "${output_file}" ]]; then
+          
+          mkdir -p "${output_dir}"
+          # First generation - just format
+          cat "${template_result_file}"  > "${output_file}"
+        else
+          cat "${template_result_file}"  > "${output_file}"
+        fi
+
+        ;;
+    esac
+  done
+
+  return 0
+}
+
+function main() {
+
+  options "$@" || return $?
+
+  pushTempDir "create_template_XXXX"
+  tmp_dir="$(getTopTempDir)"
+  
+  info "Starting work on ${REFERENCE_TYPE} Reference"
+
+  process_template \
+    "${REFERENCE_TYPE}" \
+    "${REFERENCE_OUTPUT_DIR}"
+}
+
+main "$@"

--- a/aws/createReference.sh
+++ b/aws/createReference.sh
@@ -135,8 +135,8 @@ function process_template() {
       cf_dir="${PRODUCT_INFRASTRUCTURE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
       passes=("reference")
 
-      pass_level_prefix["reference"]="blueprint"
-      pass_description["reference"]="blueprint"
+      pass_level_prefix["reference"]="component-reference"
+      pass_description["reference"]="component-reference"
       pass_suffix["reference"]=".md"
       ;;
 
@@ -205,8 +205,6 @@ function process_template() {
 
     case "$(fileExtension "${template_result_file}")" in
       md)
-        npm install -g remark-cli
-
         info "${output_file}"
         if [[ ! -d "${output_dir}" ]]; then
           mkdir -p "${output_dir}"

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -403,7 +403,7 @@ behaviour.
                     "PopulateMissingChildren" : true
                 } ]
             [#if attribute?is_hash ]
-                [#local names = attribute.Names!attribute.Name!"COT:Missing" ]
+                [#local names = attribute.Names!"COT:Missing" ]
                 [#if (names?is_string) && (names == "COT:Missing") ]
                     [@cfException
                         mode=listMode

--- a/aws/templates/createBuildBlueprint.ftl
+++ b/aws/templates/createBuildBlueprint.ftl
@@ -1,11 +1,11 @@
 [#ftl]
 [#include "setContext.ftl" ]
 
-[#assign listMode = "blueprint"]
+[#assign listMode = "buildblueprint"]
 [#assign exceptionResources = []]
 [#assign debugResources = []]
 
-[#function getComponentBlueprint ]
+[#function getComponentBuildBlueprint ]
   [#local result={} ]
 
   [#list tiers as tier]
@@ -52,4 +52,6 @@
   [#return result ]
 [/#function]
 
-[@toJSON getComponentBlueprint() /]
+[#if deploymentSubsetRequired("buildblueprint", true)]
+    [@toJSON getComponentBuildBlueprint() /]
+[/#if]

--- a/aws/templates/createComponentReference.ftl
+++ b/aws/templates/createComponentReference.ftl
@@ -1,0 +1,343 @@
+[#ftl strip_text=true strip_whitespace=true ]
+[#include "setContext.ftl" ]
+
+[#assign listMode = "reference"]
+
+[#assign referenceTemplate = [] ]
+
+[#macro MDSection
+    title
+    content ]
+
+    [#assign referenceTemplate += [
+        "# " + title,
+        "\n"
+    ] +
+        asFlattenedArray(content) +
+    [ "\n",
+        "* * *"
+    ]]
+[/#macro]
+
+[#function getMDNotification content severity="info" ]
+    [#local result =  [
+        "!!! " + severity
+    ]]
+    
+    [#list content as line ]
+        [#local result += [
+            "    " + line
+        ]]
+    [/#list]
+    [#return result]
+[/#function]
+
+[#function getMDList content ordered=false level=0 ]
+    [#local result = []]
+
+    [#local spacing = (level == 0)?then("", (""?left_pad(level + 2, " ")))]
+    [#list asArray(content) as line ]
+        [#if ordered ]
+            [#local result += [
+                spacing + line?counter + ". " + line
+            ]]
+        [#else]
+            [#local result += [
+                spacing + "- " + line
+            ]]
+        [/#if]
+    [/#list]
+
+    [#return result]
+[/#function]
+
+[#function getMDHeading heading level=2 ]
+    [#return [
+        ""?left_pad(level, "#") + " " + heading,
+        "\n"
+    ]]
+[/#function]
+
+[#function getMDCodeBlock content language ]
+    [#local result = 
+        [
+            "\n",
+            "```" + language
+        ] + 
+            asArray(content) + 
+        [
+            "```",
+            "\n"
+        ]]
+    [#return result]
+[/#function]
+
+[#function getMDString value ]
+    [#local result = "" ]
+    [#if value?is_sequence ]
+        [#if value?has_content ]
+            [#local result = value?join(", ")]
+        [#else]
+            [#local result = "[]" ]
+        [/#if]
+    [#elseif value?is_hash ]
+        [#if value?has_content]
+            [#local result = getJSON("value")]
+        [#else]
+            [#local result = "\{}"]
+        [/#if]
+    [#elseif value?is_number || value?is_boolean ]
+        [#local result = value?c ]
+    [#else]
+        [#local result = value ]
+    [/#if]
+
+    [#if !result?has_content ]
+        [#local result = "null" ]
+    [/#if]
+
+    [#return result]
+[/#function]
+
+[#function getAttributeDetails attribute currentLevel ]
+    [#local result = [] ]
+    [#local headerLevel = currentLevel ]
+
+    [#if attribute?is_string ]
+        [#local attribute = {
+            "Name" : attribute
+        }]
+    [/#if]
+
+    [#if (attribute.Children![])?has_content ]
+    
+        [#local result = getMDList(
+                            "**" + (attribute.Name!"Unkown Name") + "**", 
+                            false,
+                            headerLevel)]
+        [#local headerLevel++ ]
+        [#list attribute.Children as childAttribute ]
+            [#local result += 
+                getAttributeDetails(childAttribute, headerLevel)]
+        [/#list]
+    
+    [#else]
+
+        [#list attribute as key,value ]
+            [#local name = [] ]
+            [#local details = []]
+            [#switch key ]
+                [#case "Name" ]
+                [#case "Names" ]    
+                    [#if value?is_sequence  ]
+                        [#if value?size > 1 ] 
+                            [#local name += 
+                                getMDList(
+                                    "**" + value[0] + "**", 
+                                    false, 
+                                    headerLevel 
+                                ) +
+                                getMDList(
+                                    "**Alternate Names** - " + value[1..]?join(", "), 
+                                    false,
+                                    (headerLevel + 2))
+                                ] 
+                        [#else]
+                            [#local name += 
+                                getMDList(
+                                    "**" + value[0] + "**", 
+                                    false, 
+                                    headerLevel 
+                                )]
+                        [/#if]
+                    [#else]
+                        [#local result += 
+                            getMDList(
+                                "**" + value + "**", 
+                                false,
+                                headerLevel )]
+                    [/#if]
+                    [#break]
+                [#case "Children" ]
+                    [#break]
+
+                [#case "Type"]
+                    [#if value?is_sequence ]
+                        [#local details += [
+                            getMDList( 
+                                "**" + key + "** - " + getMDString(value[0]) + " of " + getMDString(value[1]), 
+                                false,
+                                (headerLevel + 2)) ]]
+                        ]]
+                    [#else]
+                        [#local details += [
+                            getMDList( 
+                                "**" + key + "** - " + getMDString(value), 
+                                false,
+                                (headerLevel + 2)) ]]
+                    [/#if]
+                    [#break]
+                
+                [#default]
+                    [#local details += [
+                        getMDList( 
+                            "**" + key + "** - " + getMDString(value), 
+                            false,
+                            (headerLevel + 2)) ]]
+            [/#switch]
+
+            [#local result += 
+                        name + 
+                        details ]
+        [/#list]
+    [/#if]
+
+    [#return result]
+[/#function]
+
+[#function getMDCodeJSON obj depth=0 ]
+    [#local result = []]
+    [#local line = "" ]
+
+    [#if obj?is_hash]
+        [#local line += "{" ]]
+        [#local result += [ line ] ]
+        [#local line = "" ]
+    
+        [#local depth++ ]
+    
+        [#list obj as key,value]
+            [#local line = ""?left_pad(depth, "\t") +  "\"" + key  + "\" : " ]
+            [#if value?is_hash ]
+                [#local line += "\{" ]
+                [#local result += [ line ]]
+                [#local line = "" ]
+                [#local depth ++ ]
+                [#local result += getMDCodeBlock(value, depth ) ]
+            [#elseif value?is_sequence ]
+                [#local line += "[" ]
+                [#local result += [ line ]]
+                [#local line = "" ]
+                [#local depth ++ ]
+                [#local result += getMDCodeBlock(value, depth ) ]
+            [#elseif value?is_string ]
+                [#local line += ""?left_pad(depth, "\t") + "\"" + value + "\""]
+            [#else ]
+                [#local line += value?c ]
+            [/#if]
+            [#sep][#local line += "," ][/#sep]
+            [#local result += [ line ]]
+            [#local line = ""]
+        [/#list]
+        [#local result += [ "}"]]
+        [#local depth-- ]
+    [#else]
+        [#if obj?is_sequence]
+            [#list obj as entry]
+                [#local result += getMDCodeJSON(entry)]
+                [#sep][#local result += [ "," ]][/#sep]
+            [/#list]
+        [#else]
+            [#if obj?is_string]
+                [#local result = [ ""?left_pad(depth, "\t") + "\"" + obj + "\""]]
+            [#else]
+                [#local result = [ ""?left_pad(depth, "\t") + obj?c ]]
+            [/#if]
+        [/#if]
+    [/#if]
+    [#return result ]
+[/#function]
+
+[#list componentConfiguration as type,component ]
+
+    [#if component?is_hash ]
+        [#assign componentProperties = component.Properties![]]
+        [#assign componentAttributes = component.Attributes![]]
+        [#assign componentSubComponents = component.Components![]]
+
+        [#assign description = []]
+        [#assign deploymentProperties = [] ]
+        [#assign notes = []]
+        [#assign subComponents = []]
+        
+        [#assign attributeJson =
+            getMDHeading("Component Format", 2) +
+            getMDCodeBlock(
+                getMDCodeJSON(component.Attributes), 
+                "json" )]
+
+        [#assign attributes =
+            getMDHeading("Attribute Reference", 2)]
+        
+        [#list componentProperties as property ]
+            [#switch property.Type!"Description" ]
+
+                [#case "Description" ]
+                    [#assign description += 
+                        asArray(property.Value)]
+                    [#break]
+
+                [#case "Providers" ]
+                    [#assign deploymentProperties += 
+                            [ "**Available Providers** - " + getMDString(property.Value)  ]]
+                    [#break]
+
+                [#case "ComponentLevel" ]
+                    [#assign deploymentProperties += 
+                          [  "**Component Level** - " + getMDString(property.Value) ]]
+                    [#break]
+
+                [#case "Note" ]
+                    [#assign notes +=
+                        getMDNotification(
+                            asArray(property.Value),
+                            property.Severity!"info")]
+                    [#break]
+            [/#switch]
+        [/#list]
+
+        [#list componentAttributes as attribute ]
+            [#assign attributes +=
+                getAttributeDetails(attribute, 0)]
+        [/#list]
+
+        [#list componentSubComponents as subComponent ]
+            [#assign subComponents += 
+                getMDList( "[" + subComponent.Type + "](#" + getMDString(subComponent.Type) + ")" ) +
+                getMDList( "**Component Attribute** - " + getMDString(subComponent.Component), false, 1  ) + 
+                getMDList( "**Link Attribute** - " + getMDString(subComponent.Link) , false, 1)
+            ]
+        [/#list]
+
+        [#if notes?has_content ]
+            [#assign notes = getMDHeading("Notes", 2 ) + notes ]
+        [/#if]
+
+        [#if deploymentProperties?has_content ]
+            [#assign deploymentProperties = getMDHeading("Deployment Properties", 2) + getMDList(deploymentProperties) + [ "\n" ]] 
+        [/#if]
+
+        [#if subComponents?has_content ]
+            [#assign subComponents = getMDHeading("Sub Components", 2 ) + subComponents]
+        [/#if]
+
+        [@MDSection
+            title=type?lower_case 
+            content=
+                description +
+                deploymentProperties +
+                notes + 
+                subComponents + 
+                attributeJson + 
+                attributes
+        /]
+    [/#if]
+[/#list]
+
+[#list referenceTemplate as line]
+[#if line?is_string]
+${line}
+[#else]
+getJSON(line)
+[/#if]
+[/#list]

--- a/aws/templates/createComponentReference.ftl
+++ b/aws/templates/createComponentReference.ftl
@@ -200,7 +200,7 @@
     [#local line = "" ]
 
     [#if obj?is_hash]
-        [#local line += "{" ]]
+        [#local line += "\{" ]]
         [#local result += [ line ] ]
         [#local line = "" ]
     
@@ -214,17 +214,27 @@
                 [#local line = "" ]
                 [#local depth ++ ]
                 [#local result += getMDCodeBlock(value, depth ) ]
+            
             [#elseif value?is_sequence ]
+
                 [#local line += "[" ]
                 [#local result += [ line ]]
                 [#local line = "" ]
                 [#local depth ++ ]
                 [#local result += getMDCodeBlock(value, depth ) ]
-            [#elseif value?is_string ]
-                [#local line += ""?left_pad(depth, "\t") + "\"" + value + "\""]
+
+            [#elseif value?is_number || value?is_boolean ]
+                [#local line += "\"" + value?c + "\"" ]
+                [#local result += [ line ]]
+                [#local line = ""]
+
             [#else ]
-                [#local line += value?c ]
+                [#local line += "\"" + value + "\"" ]
+                [#local result += [ line ]]
+                [#local line = ""]
             [/#if]
+
+
             [#sep][#local line += "," ][/#sep]
             [#local result += [ line ]]
             [#local line = ""]
@@ -233,10 +243,14 @@
         [#local depth-- ]
     [#else]
         [#if obj?is_sequence]
+
+            [#local depth++ ]
             [#list obj as entry]
-                [#local result += getMDCodeJSON(entry)]
-                [#sep][#local result += [ "," ]][/#sep]
+                [#local line = ""?left_pad(depth, "\t") +  "\"" + entry  + "\""]
+                [#sep][#local line += [ "," ]][/#sep]
             [/#list]
+            [#local depth--]
+
         [#else]
             [#if obj?is_string]
                 [#local result = [ ""?left_pad(depth, "\t") + "\"" + obj + "\""]]

--- a/aws/templates/createComponentReference.ftl
+++ b/aws/templates/createComponentReference.ftl
@@ -74,6 +74,7 @@
 
 [#function getMDString value ]
     [#local result = "" ]
+
     [#if value?is_sequence ]
         [#if value?has_content ]
             [#local result = value?join(", ")]
@@ -95,7 +96,6 @@
     [#if !result?has_content ]
         [#local result = "null" ]
     [/#if]
-
     [#return result]
 [/#function]
 
@@ -178,11 +178,13 @@
                     [#break]
                 
                 [#default]
-                    [#local details += [
-                        getMDList( 
-                            "**" + key + "** - " + getMDString(value), 
-                            false,
-                            (headerLevel + 2)) ]]
+                    [#if value?has_content ]
+                        [#local details += [
+                            getMDList( 
+                                "**" + key + "** - " + getMDString(value), 
+                                false,
+                                (headerLevel + 2)) ]]
+                    [/#if]
             [/#switch]
 
             [#local result += 

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -32,118 +32,149 @@
 
 [#assign componentConfiguration +=
     {
-        APIGATEWAY_COMPONENT_TYPE : [
-            {
-                "Names" : ["Fragment", "Container"],
-                "Type" : STRING_TYPE,
-                "Default" : ""
-            },
-            {
-                "Name" : "Links",
-                "Subobjects" : true,
-                "Children" : linkChildrenConfiguration
-            },
-            {
-                "Name" : "WAF",
-                "Children" : wafChildConfiguration
-            },
-            {
-                "Name" : "EndpointType",
-                "Type" : STRING_TYPE,
-                "Values" : ["EDGE", "REGIONAL"],
-                "Default" : "EDGE"
-            },
-            {
-                "Name" : "IPAddressGroups",
-                "Type" : ARRAY_OF_STRING_TYPE,
-                "Default" : []
-            },
-            {
-                "Name" : "Authentication",
-                "Type" : STRING_TYPE,
-                "Values" : ["IP", "SIG4ORIP", "SIG4ANDIP"],
-                "Default" : "IP"
-            },
-            {
-                "Name" : "CloudFront",
-                "Children" : [
-                    {
-                        "Name" : "AssumeSNI",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "EnableLogging",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "CountryGroups",
-                        "Type" : ARRAY_OF_STRING_TYPE,
-                        "Default" : []
-                    },
-                    {
-                        "Name" : "CustomHeaders",
-                        "Type" : ARRAY_OF_ANY_TYPE,
-                        "Default" : []
-                    },
-                    {
-                        "Name" : "Mapping",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : false
-                    },
-                    {
-                        "Name" : "Compress",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    }
-                ]
-            },
-            {
-                "Name" : "Certificate",
-                "Children" : [
-                    {
-                        "Name" : "*"
-                    }
-                ]
-            },
-            {
-                "Name" : "Publish",
-                "Children" : [
-                    {
-                        "Name" : "DnsNamePrefix",
-                        "Type" : STRING_TYPE,
-                        "Default" : "docs"
-                    },
-                    {
-                        "Name" : "IPAddressGroups",
-                        "Type" : ARRAY_OF_STRING_TYPE,
-                        "Default" : []
-                    }
-                ]
-            },
-            {
-                "Name" : "Mapping",
-                "Children" : [
-                    {
-                        "Name" : "IncludeStage",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    }
-                ]
-            },
-            {
-                "Name" : "Profiles",
-                "Children" : [
-                    {
-                        "Name" : "SecurityProfile",
-                        "Type" : STRING_TYPE,
-                        "Default" : "default"
-                    }
-                ]
-            }
-        ],
-        APIGATEWAY_USAGEPLAN_COMPONENT_TYPE : [
+        APIGATEWAY_COMPONENT_TYPE : { 
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "Application level API proxy"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "application"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Names" : ["Fragment", "Container"],
+                    "Type" : STRING_TYPE,
+                    "Default" : ""
+                },
+                {
+                    "Name" : "Links",
+                    "Type" : OBJECT_TYPE,
+                    "Default" : {}
+                },
+                {
+                    "Name" : "WAF",
+                    "Children" : wafChildConfiguration
+                },
+                {
+                    "Name" : "EndpointType",
+                    "Type" : STRING_TYPE,
+                    "Values" : ["EDGE", "REGIONAL"],
+                    "Default" : "EDGE"
+                },
+                {
+                    "Name" : "IPAddressGroups",
+                    "Type" : ARRAY_OF_STRING_TYPE,
+                    "Default" : []
+                },
+                {
+                    "Name" : "Authentication",
+                    "Type" : STRING_TYPE,
+                    "Values" : ["IP", "SIG4ORIP", "SIG4ANDIP"],
+                    "Default" : "IP"
+                },
+                {
+                    "Name" : "CloudFront",
+                    "Children" : [
+                        {
+                            "Name" : "AssumeSNI",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "EnableLogging",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "CountryGroups",
+                            "Type" : ARRAY_OF_STRING_TYPE,
+                            "Default" : []
+                        },
+                        {
+                            "Name" : "CustomHeaders",
+                            "Type" : ARRAY_OF_ANY_TYPE,
+                            "Default" : []
+                        },
+                        {
+                            "Name" : "Mapping",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : false
+                        },
+                        {
+                            "Name" : "Compress",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        }
+                    ]
+                },
+                {
+                    "Name" : "Certificate",
+                    "Children" : [
+                        {
+                            "Name" : "*"
+                        }
+                    ]
+                },
+                {
+                    "Name" : "Publish",
+                    "Children" : [
+                        {
+                            "Name" : "DnsNamePrefix",
+                            "Type" : STRING_TYPE,
+                            "Default" : "docs"
+                        },
+                        {
+                            "Name" : "IPAddressGroups",
+                            "Type" : ARRAY_OF_STRING_TYPE,
+                            "Default" : []
+                        }
+                    ]
+                },
+                {
+                    "Name" : "Mapping",
+                    "Children" : [
+                        {
+                            "Name" : "IncludeStage",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        }
+                    ]
+                },
+                {
+                    "Name" : "Profiles",
+                    "Children" : [
+                        {
+                            "Name" : "SecurityProfile",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        }
+                    ]
+                }
+            ]
+        },
+        APIGATEWAY_USAGEPLAN_COMPONENT_TYPE : 
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "provides a metered link between an API gateway and an invoking client"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "application"
+                }
+            ],
+            "Attributes" : [
             {
                 "Name" : "Links",
                 "Subobjects" : true,

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -54,104 +54,104 @@
                     "Default" : ""
                 },
                 {
-                    "Name" : "Links",
+                    "Names" : "Links",
                     "Type" : OBJECT_TYPE,
                     "Default" : {}
                 },
                 {
-                    "Name" : "WAF",
+                    "Names" : "WAF",
                     "Children" : wafChildConfiguration
                 },
                 {
-                    "Name" : "EndpointType",
+                    "Names" : "EndpointType",
                     "Type" : STRING_TYPE,
                     "Values" : ["EDGE", "REGIONAL"],
                     "Default" : "EDGE"
                 },
                 {
-                    "Name" : "IPAddressGroups",
+                    "Names" : "IPAddressGroups",
                     "Type" : ARRAY_OF_STRING_TYPE,
                     "Default" : []
                 },
                 {
-                    "Name" : "Authentication",
+                    "Names" : "Authentication",
                     "Type" : STRING_TYPE,
                     "Values" : ["IP", "SIG4ORIP", "SIG4ANDIP"],
                     "Default" : "IP"
                 },
                 {
-                    "Name" : "CloudFront",
+                    "Names" : "CloudFront",
                     "Children" : [
                         {
-                            "Name" : "AssumeSNI",
+                            "Names" : "AssumeSNI",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "EnableLogging",
+                            "Names" : "EnableLogging",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "CountryGroups",
+                            "Names" : "CountryGroups",
                             "Type" : ARRAY_OF_STRING_TYPE,
                             "Default" : []
                         },
                         {
-                            "Name" : "CustomHeaders",
+                            "Names" : "CustomHeaders",
                             "Type" : ARRAY_OF_ANY_TYPE,
                             "Default" : []
                         },
                         {
-                            "Name" : "Mapping",
+                            "Names" : "Mapping",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : false
                         },
                         {
-                            "Name" : "Compress",
+                            "Names" : "Compress",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         }
                     ]
                 },
                 {
-                    "Name" : "Certificate",
+                    "Names" : "Certificate",
                     "Children" : [
                         {
-                            "Name" : "*"
+                            "Names" : "*"
                         }
                     ]
                 },
                 {
-                    "Name" : "Publish",
+                    "Names" : "Publish",
                     "Children" : [
                         {
-                            "Name" : "DnsNamePrefix",
+                            "Names" : "DnsNamePrefix",
                             "Type" : STRING_TYPE,
                             "Default" : "docs"
                         },
                         {
-                            "Name" : "IPAddressGroups",
+                            "Names" : "IPAddressGroups",
                             "Type" : ARRAY_OF_STRING_TYPE,
                             "Default" : []
                         }
                     ]
                 },
                 {
-                    "Name" : "Mapping",
+                    "Names" : "Mapping",
                     "Children" : [
                         {
-                            "Name" : "IncludeStage",
+                            "Names" : "IncludeStage",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         }
                     ]
                 },
                 {
-                    "Name" : "Profiles",
+                    "Names" : "Profiles",
                     "Children" : [
                         {
-                            "Name" : "SecurityProfile",
+                            "Names" : "SecurityProfile",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
                         }
@@ -176,7 +176,7 @@
             ],
             "Attributes" : [
             {
-                "Name" : "Links",
+                "Names" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration
             }

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -159,7 +159,7 @@
                 }
             ]
         },
-        APIGATEWAY_USAGEPLAN_COMPONENT_TYPE : 
+        APIGATEWAY_USAGEPLAN_COMPONENT_TYPE : {
             "Properties" : [
                 {
                     "Type" : "Description",
@@ -181,6 +181,7 @@
                 "Children" : linkChildrenConfiguration
             }
         ]
+        }
     }]
 
 [#function getAPIGatewayState occurrence]

--- a/aws/templates/id/id_cache.ftl
+++ b/aws/templates/id/id_cache.ftl
@@ -27,23 +27,23 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : "Engine",
+                    "Names" : "Engine",
                     "Type" : STRING_TYPE,
                     "Mandatory" : true
                 },
                 {
-                    "Name" : "EngineVersion",
+                    "Names" : "EngineVersion",
                     "Type" : STRING_TYPE
                 },
                 {
-                    "Name" : "Port",
+                    "Names" : "Port",
                     "Type" : STRING_TYPE
                 },
                 {
-                    "Name" : "Backup",
+                    "Names" : "Backup",
                     "Children" : [
                         {
-                            "Name" : "RetentionPeriod",
+                            "Names" : "RetentionPeriod",
                             "Type" : STRING_TYPE,
                             "Default" : ""
                         }

--- a/aws/templates/id/id_cache.ftl
+++ b/aws/templates/id/id_cache.ftl
@@ -10,31 +10,47 @@
 
 [#assign componentConfiguration +=
     {
-        CACHE_COMPONENT_TYPE : [
-            {
-                "Name" : "Engine",
-                "Type" : STRING_TYPE,
-                "Mandatory" : true
-            },
-            {
-                "Name" : "EngineVersion",
-                "Type" : STRING_TYPE
-            },
-            {
-                "Name" : "Port",
-                "Type" : STRING_TYPE
-            },
-            {
-                "Name" : "Backup",
-                "Children" : [
-                    {
-                        "Name" : "RetentionPeriod",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
-                    }
-                ]
-            }
-        ]
+        CACHE_COMPONENT_TYPE : {
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "Managed in-memory cache services"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : "Engine",
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
+                },
+                {
+                    "Name" : "EngineVersion",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Name" : "Port",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Name" : "Backup",
+                    "Children" : [
+                        {
+                            "Name" : "RetentionPeriod",
+                            "Type" : STRING_TYPE,
+                            "Default" : ""
+                        }
+                    ]
+                }
+            ]
+        }
 }]
 
 [#function getCacheState occurrence]

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -36,102 +36,102 @@
             ],
             "Attributes" : [
                 { 
-                    "Name" : "MFA",
+                    "Names" : "MFA",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
-                    "Name" : "AdminCreatesUser",
+                    "Names" : "AdminCreatesUser",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : true
                 },
                 {
-                    "Name" : "UnusedAccountTimeout",
+                    "Names" : "UnusedAccountTimeout",
                     "Type" : NUMBER_TYPE,
                     "Default" : 7
                 },
                 {
-                    "Name" : "VerifyEmail",
+                    "Names" : "VerifyEmail",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : true
                 },
                 {
-                    "Name" : "VerifyPhone",
+                    "Names" : "VerifyPhone",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
-                    "Name" : "LoginAliases",
+                    "Names" : "LoginAliases",
                     "Type" : ARRAY_OF_STRING_TYPE,
                     "Default" : ["email"]
                 },
                 {
-                    "Name" : "ClientGenerateSecret",
+                    "Names" : "ClientGenerateSecret",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
-                    "Name" : "ClientTokenValidity",
+                    "Names" : "ClientTokenValidity",
                     "Type" : NUMBER_TYPE,
                     "Default" : 30
                 },
                 {
-                    "Name" : "AllowUnauthenticatedIds",
+                    "Names" : "AllowUnauthenticatedIds",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
-                    "Name" : "AuthorizationHeader",
+                    "Names" : "AuthorizationHeader",
                     "Type" : STRING_TYPE,
                     "Default" : "Authorization"
                 },
                 {
-                    "Name" : "OAuth",
+                    "Names" : "OAuth",
                     "Children" : [
                         {
-                            "Name" : "Scopes",
+                            "Names" : "Scopes",
                             "Type" : ARRAY_OF_STRING_TYPE,
                             "Default" : [ "openid" ]
                         },
                         {
-                            "Name" : "Flows",
+                            "Names" : "Flows",
                             "Type" : ARRAY_OF_STRING_TYPE,
                             "Default" : [ "code" ]
                         }
                     ]
                 },
                 {
-                    "Name" : "PasswordPolicy",
+                    "Names" : "PasswordPolicy",
                     "Children" : [
                         {
-                            "Name" : "MinimumLength",
+                            "Names" : "MinimumLength",
                             "Type" : NUMBER_TYPE,
                             "Default" : 10
                         },
                         {
-                            "Name" : "Lowercase",
+                            "Names" : "Lowercase",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "Uppercase",
+                            "Names" : "Uppercase",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "Numbers",
+                            "Names" : "Numbers",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "SpecialCharacters",
+                            "Names" : "SpecialCharacters",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         }
                     ] 
                 },
                 {
-                    "Name" : "Links",
+                    "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
                 }

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -14,108 +14,129 @@
 
 [#assign componentConfiguration +=
     {
-        USERPOOL_COMPONENT_TYPE : [
-            { 
-                "Name" : "MFA",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
-            },
-            {
-                "Name" : "AdminCreatesUser",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : true
-            },
-            {
-                "Name" : "UnusedAccountTimeout",
-                "Type" : NUMBER_TYPE,
-                "Default" : 7
-            },
-            {
-                "Name" : "VerifyEmail",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : true
-            },
-            {
-                "Name" : "VerifyPhone",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
-            },
-            {
-                "Name" : "LoginAliases",
-                "Type" : ARRAY_OF_STRING_TYPE,
-                "Default" : ["email"]
-            },
-            {
-                "Name" : "ClientGenerateSecret",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
-            },
-            {
-                "Name" : "ClientTokenValidity",
-                "Type" : NUMBER_TYPE,
-                "Default" : 30
-            },
-            {
-                "Name" : "AllowUnauthenticatedIds",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
-            },
-            {
-                "Name" : "AuthorizationHeader",
-                "Type" : STRING_TYPE,
-                "Default" : "Authorization"
-            },
-            {
-                "Name" : "OAuth",
-                "Children" : [
-                    {
-                        "Name" : "Scopes",
-                        "Type" : ARRAY_OF_STRING_TYPE,
-                        "Default" : [ "openid" ]
-                    },
-                    {
-                        "Name" : "Flows",
-                        "Type" : ARRAY_OF_STRING_TYPE,
-                        "Default" : [ "code" ]
-                    }
-                ]
-            },
-            {
-                "Name" : "PasswordPolicy",
-                "Children" : [
-                    {
-                        "Name" : "MinimumLength",
-                        "Type" : NUMBER_TYPE,
-                        "Default" : 10
-                    },
-                    {
-                        "Name" : "Lowercase",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "Uppercase",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "Numbers",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "SpecialCharacters",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    }
-                ] 
-            },
-            {
-                "Name" : "Links",
-                "Subobjects" : true,
-                "Children" : linkChildrenConfiguration
-            }
-        ]
+        USERPOOL_COMPONENT_TYPE : {
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "Managed identity service"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                },
+                {
+                    "Type" : "Note",
+                    "Value" : "Requires second deployment to complete configuration",
+                    "Severity" : "warning"
+                }
+            ],
+            "Attributes" : [
+                { 
+                    "Name" : "MFA",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Name" : "AdminCreatesUser",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Name" : "UnusedAccountTimeout",
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 7
+                },
+                {
+                    "Name" : "VerifyEmail",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Name" : "VerifyPhone",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Name" : "LoginAliases",
+                    "Type" : ARRAY_OF_STRING_TYPE,
+                    "Default" : ["email"]
+                },
+                {
+                    "Name" : "ClientGenerateSecret",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Name" : "ClientTokenValidity",
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 30
+                },
+                {
+                    "Name" : "AllowUnauthenticatedIds",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Name" : "AuthorizationHeader",
+                    "Type" : STRING_TYPE,
+                    "Default" : "Authorization"
+                },
+                {
+                    "Name" : "OAuth",
+                    "Children" : [
+                        {
+                            "Name" : "Scopes",
+                            "Type" : ARRAY_OF_STRING_TYPE,
+                            "Default" : [ "openid" ]
+                        },
+                        {
+                            "Name" : "Flows",
+                            "Type" : ARRAY_OF_STRING_TYPE,
+                            "Default" : [ "code" ]
+                        }
+                    ]
+                },
+                {
+                    "Name" : "PasswordPolicy",
+                    "Children" : [
+                        {
+                            "Name" : "MinimumLength",
+                            "Type" : NUMBER_TYPE,
+                            "Default" : 10
+                        },
+                        {
+                            "Name" : "Lowercase",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "Uppercase",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "Numbers",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "SpecialCharacters",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        }
+                    ] 
+                },
+                {
+                    "Name" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                }
+            ]
+        }
     }]
     
 [#function getUserPoolState occurrence]

--- a/aws/templates/id/id_computecluster.ftl
+++ b/aws/templates/id/id_computecluster.ftl
@@ -3,47 +3,63 @@
 
 [#assign componentConfiguration +=
     {
-        COMPUTECLUSTER_COMPONENT_TYPE : [
-            {
-                "Name" : ["Fragment", "Container"],
-                "Type" : STRING_TYPE,
-                "Default" : ""
-            },
-            {
-                "Name" : "Links",
-                "Subobjects" : true,
-                "Children" : linkChildrenConfiguration
-            },
-            {
-                "Name" : "UseInitAsService",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
-            },
-            {
-                "Name" : "AutoScaling",
-                "Children" : autoScalingChildConfiguration
-            },
-            {
-                "Name" : "DockerHost",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
-            },
-            {
-                "Name" : "Ports",
-                "Subobjects" : true,
-                "Children" : [
-                    {
-                        "Name" : "IPAddressGroups",
-                        "Type" : ARRAY_OF_STRING_TYPE,
-                        "Default" : []
-                    },
-                    {
-                        "Name" : "LB",
-                        "Children" : lbChildConfiguration
-                    }
-                ]
-            }
-        ]
+        COMPUTECLUSTER_COMPONENT_TYPE : { 
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "Auto-Scaling IaaS with code deployment"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "application"
+                }
+            ],
+            "Attributes" :  [
+                {
+                    "Name" : ["Fragment", "Container"],
+                    "Type" : STRING_TYPE,
+                    "Default" : ""
+                },
+                {
+                    "Name" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                },
+                {
+                    "Name" : "UseInitAsService",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Name" : "AutoScaling",
+                    "Children" : autoScalingChildConfiguration
+                },
+                {
+                    "Name" : "DockerHost",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Name" : "Ports",
+                    "Subobjects" : true,
+                    "Children" : [
+                        {
+                            "Name" : "IPAddressGroups",
+                            "Type" : ARRAY_OF_STRING_TYPE,
+                            "Default" : []
+                        },
+                        {
+                            "Name" : "LB",
+                            "Children" : lbChildConfiguration
+                        }
+                    ]
+                }
+            ]
+        }
     }]
 
 [#function getComputeClusterState occurrence]

--- a/aws/templates/id/id_computecluster.ftl
+++ b/aws/templates/id/id_computecluster.ftl
@@ -20,40 +20,40 @@
             ],
             "Attributes" :  [
                 {
-                    "Name" : ["Fragment", "Container"],
+                    "Names" : ["Fragment", "Container"],
                     "Type" : STRING_TYPE,
                     "Default" : ""
                 },
                 {
-                    "Name" : "Links",
+                    "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
                 },
                 {
-                    "Name" : "UseInitAsService",
+                    "Names" : "UseInitAsService",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
-                    "Name" : "AutoScaling",
+                    "Names" : "AutoScaling",
                     "Children" : autoScalingChildConfiguration
                 },
                 {
-                    "Name" : "DockerHost",
+                    "Names" : "DockerHost",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
-                    "Name" : "Ports",
+                    "Names" : "Ports",
                     "Subobjects" : true,
                     "Children" : [
                         {
-                            "Name" : "IPAddressGroups",
+                            "Names" : "IPAddressGroups",
                             "Type" : ARRAY_OF_STRING_TYPE,
                             "Default" : []
                         },
                         {
-                            "Name" : "LB",
+                            "Names" : "LB",
                             "Children" : lbChildConfiguration
                         }
                     ]

--- a/aws/templates/id/id_contenthub.ftl
+++ b/aws/templates/id/id_contenthub.ftl
@@ -9,24 +9,44 @@
 
 [#assign componentConfiguration +=
     {
-        CONTENTHUB_HUB_COMPONENT_TYPE : [
-            "Prefix",
-            {
-                "Name" : "Engine",
-                "Type" : STRING_TYPE,
-                "Default" : "github"
-            },
-            {
-                "Name" : "Branch",
-                "Type" : STRING_TYPE,
-                "Default" : "master"
-            },
-            {
-                "Name" : "Repository",
-                "Type" : STRING_TYPE,
-                "Default" : ""
-            }
-        ]
+        CONTENTHUB_HUB_COMPONENT_TYPE : { 
+            "Properties" : [
+                {
+                    "Name" : "Description",
+                    "Value" : "Hub for decentralised content hosting with centralised publishing"
+                },
+                {
+                    "Name" : "Providers",
+                    "Value" : [ "github" ]
+                },
+                {
+                    "Name" : "ComponentLevel",
+                    "Value" : "application"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : "Prefix",
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
+                },
+                {
+                    "Name" : "Engine",
+                    "Type" : STRING_TYPE,
+                    "Default" : "github"
+                },
+                {
+                    "Name" : "Branch",
+                    "Type" : STRING_TYPE,
+                    "Default" : "master"
+                },
+                {
+                    "Name" : "Repository",
+                    "Type" : STRING_TYPE,
+                    "Default" : ""
+                }
+            ]
+        }
     }]
 
 [#function getContentHubState occurrence]
@@ -58,78 +78,95 @@
 
 [#assign componentConfiguration +=
     {
-        CONTENTHUB_NODE_COMPONENT_TYPE : [
-            {
-                "Name" : "Path",
-                "Children" : [
-                    {
-                        "Name" : "Host",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
-                    },
-                    {
-                        "Name" : "Style",
-                        "Type" : STRING_TYPE,
-                        "Default" : "single"
-                    },
-                    {
-                        "Name" : "IncludeInPath",
-                        "Children" : [
+        CONTENTHUB_NODE_COMPONENT_TYPE : { 
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "Node for decentralised content hosting with centralised publishing"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "github" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "application"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : "Path",
+                    "Children" : [
+                        {
+                            "Name" : "Host",
+                            "Type" : STRING_TYPE,
+                            "Default" : ""
+                        },
+                        {
+                            "Name" : "Style",
+                            "Type" : STRING_TYPE,
+                            "Default" : "single"
+                        },
+                        {
+                            "Name" : "IncludeInPath",
+                            "Children" : [
 
-                            {
-                                "Name" : "Product",
-                                "Type" : BOOLEAN_TYPE,
-                                "Default" : true
-                            },
-                            {
-                                "Name" : "Environment",
-                                "Type" : BOOLEAN_TYPE,
-                                "Default" : false
-                            },
-                            {
-                                "Name" : "Solution",
-                                "Type" : BOOLEAN_TYPE,
-                                "Default" : false
-                            },
-                            {
-                                "Name" : "Segment",
-                                "Type" : BOOLEAN_TYPE,
-                                "Default" : true
-                            },
-                            {
-                                "Name" : "Tier",
-                                "Type" : BOOLEAN_TYPE,
-                                "Default": false
-                            },
-                            {
-                                "Name" : "Component",
-                                "Type" : BOOLEAN_TYPE,
-                                "Default" : false
-                            },
-                            {
-                                "Name" : "Instance",
-                                "Type" : BOOLEAN_TYPE,
-                                "Default" : false
-                            },
-                            {
-                                "Name" : "Version",
-                                "Type" : BOOLEAN_TYPE,
-                                "Default" : false
-                            },
-                            {
-                                "Name" : "Host",
-                                "Type" : BOOLEAN_TYPE,
-                                "Default": false
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "Name" : "Links",
-                "Default" : {}
-            }
-        ]
+                                {
+                                    "Name" : "Product",
+                                    "Type" : BOOLEAN_TYPE,
+                                    "Default" : true
+                                },
+                                {
+                                    "Name" : "Environment",
+                                    "Type" : BOOLEAN_TYPE,
+                                    "Default" : false
+                                },
+                                {
+                                    "Name" : "Solution",
+                                    "Type" : BOOLEAN_TYPE,
+                                    "Default" : false
+                                },
+                                {
+                                    "Name" : "Segment",
+                                    "Type" : BOOLEAN_TYPE,
+                                    "Default" : true
+                                },
+                                {
+                                    "Name" : "Tier",
+                                    "Type" : BOOLEAN_TYPE,
+                                    "Default": false
+                                },
+                                {
+                                    "Name" : "Component",
+                                    "Type" : BOOLEAN_TYPE,
+                                    "Default" : false
+                                },
+                                {
+                                    "Name" : "Instance",
+                                    "Type" : BOOLEAN_TYPE,
+                                    "Default" : false
+                                },
+                                {
+                                    "Name" : "Version",
+                                    "Type" : BOOLEAN_TYPE,
+                                    "Default" : false
+                                },
+                                {
+                                    "Name" : "Host",
+                                    "Type" : BOOLEAN_TYPE,
+                                    "Default": false
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "Name" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                }
+            ]
+        }
     }]
 
 [#function getContentNodeState occurrence]

--- a/aws/templates/id/id_contenthub.ftl
+++ b/aws/templates/id/id_contenthub.ftl
@@ -12,36 +12,36 @@
         CONTENTHUB_HUB_COMPONENT_TYPE : { 
             "Properties" : [
                 {
-                    "Name" : "Description",
+                    "Type" : "Description",
                     "Value" : "Hub for decentralised content hosting with centralised publishing"
                 },
                 {
-                    "Name" : "Providers",
+                    "Type" : "Providers",
                     "Value" : [ "github" ]
                 },
                 {
-                    "Name" : "ComponentLevel",
+                    "Type" : "ComponentLevel",
                     "Value" : "application"
                 }
             ],
             "Attributes" : [
                 {
-                    "Name" : "Prefix",
+                    "Names" : "Prefix",
                     "Type" : STRING_TYPE,
                     "Mandatory" : true
                 },
                 {
-                    "Name" : "Engine",
+                    "Names" : "Engine",
                     "Type" : STRING_TYPE,
                     "Default" : "github"
                 },
                 {
-                    "Name" : "Branch",
+                    "Names" : "Branch",
                     "Type" : STRING_TYPE,
                     "Default" : "master"
                 },
                 {
-                    "Name" : "Repository",
+                    "Names" : "Repository",
                     "Type" : STRING_TYPE,
                     "Default" : ""
                 }
@@ -95,64 +95,64 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : "Path",
+                    "Names" : "Path",
                     "Children" : [
                         {
-                            "Name" : "Host",
+                            "Names" : "Host",
                             "Type" : STRING_TYPE,
                             "Default" : ""
                         },
                         {
-                            "Name" : "Style",
+                            "Names" : "Style",
                             "Type" : STRING_TYPE,
                             "Default" : "single"
                         },
                         {
-                            "Name" : "IncludeInPath",
+                            "Names" : "IncludeInPath",
                             "Children" : [
 
                                 {
-                                    "Name" : "Product",
+                                    "Names" : "Product",
                                     "Type" : BOOLEAN_TYPE,
                                     "Default" : true
                                 },
                                 {
-                                    "Name" : "Environment",
+                                    "Names" : "Environment",
                                     "Type" : BOOLEAN_TYPE,
                                     "Default" : false
                                 },
                                 {
-                                    "Name" : "Solution",
+                                    "Names" : "Solution",
                                     "Type" : BOOLEAN_TYPE,
                                     "Default" : false
                                 },
                                 {
-                                    "Name" : "Segment",
+                                    "Names" : "Segment",
                                     "Type" : BOOLEAN_TYPE,
                                     "Default" : true
                                 },
                                 {
-                                    "Name" : "Tier",
+                                    "Names" : "Tier",
                                     "Type" : BOOLEAN_TYPE,
                                     "Default": false
                                 },
                                 {
-                                    "Name" : "Component",
+                                    "Names" : "Component",
                                     "Type" : BOOLEAN_TYPE,
                                     "Default" : false
                                 },
                                 {
-                                    "Name" : "Instance",
+                                    "Names" : "Instance",
                                     "Type" : BOOLEAN_TYPE,
                                     "Default" : false
                                 },
                                 {
-                                    "Name" : "Version",
+                                    "Names" : "Version",
                                     "Type" : BOOLEAN_TYPE,
                                     "Default" : false
                                 },
                                 {
-                                    "Name" : "Host",
+                                    "Names" : "Host",
                                     "Type" : BOOLEAN_TYPE,
                                     "Default": false
                                 }
@@ -161,7 +161,7 @@
                     ]
                 },
                 {
-                    "Name" : "Links",
+                    "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
                 }

--- a/aws/templates/id/id_datapipeline.ftl
+++ b/aws/templates/id/id_datapipeline.ftl
@@ -25,37 +25,37 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : ["Fragment", "Container"],
+                    "Names" : ["Fragment", "Container"],
                     "Type" : STRING_TYPE,
                     "Default" : ""
                 },
                 {
-                    "Name" : "Permissions",
+                    "Names" : "Permissions",
                     "Children" : [
                         {
-                            "Name" : "Decrypt",
+                            "Names" : "Decrypt",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "AsFile",
+                            "Names" : "AsFile",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "AppData",
+                            "Names" : "AppData",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "AppPublic",
+                            "Names" : "AppPublic",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         }
                     ]
                 },
                 {
-                    "Name" : "Links",
+                    "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
                 }

--- a/aws/templates/id/id_datapipeline.ftl
+++ b/aws/templates/id/id_datapipeline.ftl
@@ -8,43 +8,59 @@
 
 [#assign componentConfiguration +=
     {
-        DATAPIPELINE_COMPONENT_TYPE : [
-            {
-                "Name" : ["Fragment", "Container"],
-                "Type" : STRING_TYPE,
-                "Default" : ""
-            },
-            {
-                "Name" : "Permissions",
-                "Children" : [
-                    {
-                        "Name" : "Decrypt",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "AsFile",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "AppData",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "AppPublic",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    }
-                ]
-            },
-            {
-                "Name" : "Links",
-                "Subobjects" : true,
-                "Children" : linkChildrenConfiguration
-            }
-        ]
+        DATAPIPELINE_COMPONENT_TYPE : {
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "Managed Data ETL Processing"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "application"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : ["Fragment", "Container"],
+                    "Type" : STRING_TYPE,
+                    "Default" : ""
+                },
+                {
+                    "Name" : "Permissions",
+                    "Children" : [
+                        {
+                            "Name" : "Decrypt",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "AsFile",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "AppData",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "AppPublic",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        }
+                    ]
+                },
+                {
+                    "Name" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                }
+            ]
+        }
     }]
 
 [#function getDataPipelineState occurrence]

--- a/aws/templates/id/id_dataset.ftl
+++ b/aws/templates/id/id_dataset.ftl
@@ -5,25 +5,40 @@
 
 [#assign componentConfiguration +=
     {
-        DATASET_COMPONENT_TYPE : [
-            {
-                "Name" : "Engine",
-                "Type" : STRING_TYPE,
-                "Values" : ["s3", "rdsSnapshot"],
-                "Default" : "",
-                "Mandatory" : true
-            }
-            {
-                "Name" : "Links",
-                "Subobjects" : true,
-                "Children" : linkChildrenConfiguration
-            },
-            {
-                "Name" : "Prefix",
-                "Type" : STRING_TYPE,
-                "Default" : ""
-            }
-        ]
+        DATASET_COMPONENT_TYPE : {
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "A data aretefact that is managed in a similar way to a code unit"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "application"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : "Engine",
+                    "Type" : STRING_TYPE,
+                    "Values" : ["s3", "rdsSnapshot"],
+                    "Mandatory" : true
+                }
+                {
+                    "Name" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                },
+                {
+                    "Name" : "Prefix",
+                    "Type" : STRING_TYPE,
+                    "Default" : ""
+                }
+            ]
+        }
     }]
 
 [#function getDataSetState occurrence]

--- a/aws/templates/id/id_dataset.ftl
+++ b/aws/templates/id/id_dataset.ftl
@@ -22,18 +22,18 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : "Engine",
+                    "Names" : "Engine",
                     "Type" : STRING_TYPE,
                     "Values" : ["s3", "rdsSnapshot"],
                     "Mandatory" : true
-                }
+                },
                 {
-                    "Name" : "Links",
+                    "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
                 },
                 {
-                    "Name" : "Prefix",
+                    "Names" : "Prefix",
                     "Type" : STRING_TYPE,
                     "Default" : ""
                 }

--- a/aws/templates/id/id_ec2.ftl
+++ b/aws/templates/id/id_ec2.ftl
@@ -96,36 +96,36 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : "FixedIP",
+                    "Names" : "FixedIP",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
-                    "Name" : "DockerHost",
+                    "Names" : "DockerHost",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
-                    "Name" : ["Fragment", "Container"],
+                    "Names" : ["Fragment", "Container"],
                     "Type" : "string",
                     "Default" : ""
                 },
                 {
-                    "Name" : "Links",
+                    "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
                 },
                 {
-                    "Name" : "Ports",
+                    "Names" : "Ports",
                     "Subobjects" : true,
                     "Children" : [
                         {
-                            "Name" : "IPAddressGroups",
+                            "Names" : "IPAddressGroups",
                             "Type" : ARRAY_OF_STRING_TYPE,
                             "Default" : []
                         },
                         {
-                            "Name" : "LB",
+                            "Names" : "LB",
                             "Children" : lbChildConfiguration
                         }
                     ]

--- a/aws/templates/id/id_ec2.ftl
+++ b/aws/templates/id/id_ec2.ftl
@@ -79,43 +79,59 @@
 
 [#assign componentConfiguration +=
     {
-        EC2_COMPONENT_TYPE : [
-            {
-                "Name" : "FixedIP",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
-            },
-            {
-                "Name" : "DockerHost",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
-            },
-            {
-                "Name" : ["Fragment", "Container"],
-                "Type" : "string",
-                "Default" : ""
-            },
-            {
-                "Name" : "Links",
-                "Subobjects" : true,
-                "Children" : linkChildrenConfiguration
-            },
-            {
-                "Name" : "Ports",
-                "Subobjects" : true,
-                "Children" : [
-                    {
-                        "Name" : "IPAddressGroups",
-                        "Type" : ARRAY_OF_STRING_TYPE,
-                        "Default" : []
-                    },
-                    {
-                        "Name" : "LB",
-                        "Children" : lbChildConfiguration
-                    }
-                ]
-            }
-        ]
+        EC2_COMPONENT_TYPE : {
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "A single virtual machine with no code deployment "
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : "FixedIP",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Name" : "DockerHost",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Name" : ["Fragment", "Container"],
+                    "Type" : "string",
+                    "Default" : ""
+                },
+                {
+                    "Name" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                },
+                {
+                    "Name" : "Ports",
+                    "Subobjects" : true,
+                    "Children" : [
+                        {
+                            "Name" : "IPAddressGroups",
+                            "Type" : ARRAY_OF_STRING_TYPE,
+                            "Default" : []
+                        },
+                        {
+                            "Name" : "LB",
+                            "Children" : lbChildConfiguration
+                        }
+                    ]
+                }
+            ]
+        }
     }]
 
 [#function getEC2State occurrence]

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -95,6 +95,20 @@
 [#assign componentConfiguration +=
     {
         ECS_COMPONENT_TYPE : {
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "An autoscaling container host cluster"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                }
+            ],
             "Attributes" : [
                 {
                     "Name" : ["Fragment", "Container"],
@@ -155,111 +169,143 @@
                 }
             ]
         },
-        ECS_SERVICE_COMPONENT_TYPE : [
-            {
-                "Name" : "Containers",
-                "Subobjects" : true,
-                "Children" : containerChildrenConfiguration
-            },
-            {
-                "Name" : "DesiredCount",
-                "Type" : NUMBER_TYPE,
-                "Default" : -1
-            },
-            {
-                "Name" : "UseTaskRole",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : true
-            },
-            {
-                "Name" : "Permissions",
-                "Children" : [
-                    {
-                        "Name" : "Decrypt",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "AsFile",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "AppData",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "AppPublic",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    }
-                ]
-            },
-            {
-                "Name" : "TaskLogGroup",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : true
-            },
-            {
-                "Name" : "NetworkMode",
-                "Type" : STRING_TYPE,
-                "Values" : ["none", "bridge", "awsvpc", "host"],
-                "Default" : ""
-            },
-            {
-                "Name" : "ContainerNetworkLinks",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
-            }
-        ],
-        ECS_TASK_COMPONENT_TYPE : [
-            {
-                "Name" : "Containers",
-                "Subobjects" : true,
-                "Children" : containerChildrenConfiguration
-            },
-            {
-                "Name" : "UseTaskRole",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : true
-            },
-            {
-                "Name" : "Permissions",
-                "Children" : [
-                    {
-                        "Name" : "Decrypt",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "AsFile",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "AppData",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "AppPublic",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    }
-                ]
-            },
-            {
-                "Name" : "TaskLogGroup",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : true
-            },
-            {
-                "Name" : "FixedName",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
-            }
-        ]
+        ECS_SERVICE_COMPONENT_TYPE : {
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "An orchestrated container with always on scheduling"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "application"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : "Containers",
+                    "Subobjects" : true,
+                    "Children" : containerChildrenConfiguration
+                },
+                {
+                    "Name" : "DesiredCount",
+                    "Type" : NUMBER_TYPE,
+                    "Default" : -1
+                },
+                {
+                    "Name" : "UseTaskRole",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Name" : "Permissions",
+                    "Children" : [
+                        {
+                            "Name" : "Decrypt",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "AsFile",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "AppData",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "AppPublic",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        }
+                    ]
+                },
+                {
+                    "Name" : "TaskLogGroup",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Name" : "NetworkMode",
+                    "Type" : STRING_TYPE,
+                    "Values" : ["none", "bridge", "awsvpc", "host"],
+                    "Default" : ""
+                },
+                {
+                    "Name" : "ContainerNetworkLinks",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                }
+            ]
+        },
+        ECS_TASK_COMPONENT_TYPE : {
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "A container defintion which is invoked on demand"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "application"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : "Containers",
+                    "Subobjects" : true,
+                    "Children" : containerChildrenConfiguration
+                },
+                {
+                    "Name" : "UseTaskRole",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Name" : "Permissions",
+                    "Children" : [
+                        {
+                            "Name" : "Decrypt",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "AsFile",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "AppData",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "AppPublic",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        }
+                    ]
+                },
+                {
+                    "Name" : "TaskLogGroup",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Name" : "FixedName",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                }
+            ]
+        }
     } ]
 
 

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -13,79 +13,79 @@
 [#assign
     containerChildrenConfiguration = [
         {
-            "Name" : "Cpu",
+            "Names" : "Cpu",
             "Type" : NUMBER_TYPE,
             "Default" : ""
         },
         {
-            "Name" : "Links",
+            "Names" : "Links",
             "Subobjects" : true,
             "Children" : linkChildrenConfiguration
         },
         {
-            "Name" : "LocalLogging",
+            "Names" : "LocalLogging",
             "Type" : BOOLEAN_TYPE,
             "Default" : false
         },
         {
-            "Name" : "LogDriver",
+            "Names" : "LogDriver",
             "Type" : STRING_TYPE,
             "Values" : ["awslogs", "json-file", "fluentd"],
             "Default" : "awslogs"
         },
         {
-            "Name" : "ContainerLogGroup",
+            "Names" : "ContainerLogGroup",
             "Type" : BOOLEAN_TYPE,
             "Default" : false
         },
         {
-            "Name" : "RunCapabilities",
+            "Names" : "RunCapabilities",
             "Type" : ARRAY_OF_STRING_TYPE,
             "Default" : []
         },
         {
-            "Name" : "Privileged",
+            "Names" : "Privileged",
             "Type" : BOOLEAN_TYPE,
             "Default" : false
         },
         {
-            "Name" : ["MaximumMemory", "MemoryMaximum", "MaxMemory"],
+            "Names" : ["MaximumMemory", "MemoryMaximum", "MaxMemory"],
             "Types" : NUMBER_TYPE,
             "Description" : "Set to 0 to not set a maximum"
         },
         {
-            "Name" : ["MemoryReservation", "Memory", "ReservedMemory"],
+            "Names" : ["MemoryReservation", "Memory", "ReservedMemory"],
             "Type" : NUMBER_TYPE,
             "Mandatory" : true
         },
         {
-            "Name" : "Ports",
+            "Names" : "Ports",
             "Subobjects" : true,
             "Children" : [
                 "Container",
                 {
-                    "Name" : "DynamicHostPort",
+                    "Names" : "DynamicHostPort",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 }
                 {
-                    "Name" : "LB",
+                    "Names" : "LB",
                     "Children" : lbChildConfiguration
                 },
                 {
-                    "Name" : "IPAddressGroups",
+                    "Names" : "IPAddressGroups",
                     "Type" : ARRAY_OF_STRING_TYPE,
                     "Default" : []
                 }
             ]
         },
         {
-            "Name" : "Version",
+            "Names" : "Version",
             "Type" : STRING_TYPE,
             "Default" : ""
         },
         {
-            "Name" : "ContainerNetworkLinks",
+            "Names" : "ContainerNetworkLinks",
             "Type" : ARRAY_OF_STRING_TYPE,
             "Default" : []
         }
@@ -111,45 +111,45 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : ["Fragment", "Container"],
+                    "Names" : ["Fragment", "Container"],
                     "Type" : "string",
                     "Default" : ""
                 },
                 {
-                    "Name" : "FixedIP",
+                    "Names" : "FixedIP",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
-                    "Name" : "LogDriver",
+                    "Names" : "LogDriver",
                     "Type" : STRING_TYPE,
                     "Values" : ["awslogs", "json-file", "fluentd"],
                     "Default" : "awslogs"
                 },
                 {
-                    "Name" : "ClusterLogGroup",
+                    "Names" : "ClusterLogGroup",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : true
                 },
                 {
-                    "Name" : "Links",
+                    "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
                 },
                 {
-                    "Name" : "AutoScaling",
+                    "Names" : "AutoScaling",
                     "Children" : autoScalingChildConfiguration
                 },
                 {
-                    "Name" : "DockerUsers",
+                    "Names" : "DockerUsers",
                     "Subobjects" : true,
                     "Children" : [
                         {
-                            "Name" : "UserName",
+                            "Names" : "UserName",
                             "Type" : STRING_TYPE
                         },
                         {
-                            "Name" : "UID",
+                            "Names" : "UID",
                             "Type" : NUMBER_TYPE,
                             "Mandatory" : true
                         }
@@ -186,58 +186,58 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : "Containers",
+                    "Names" : "Containers",
                     "Subobjects" : true,
                     "Children" : containerChildrenConfiguration
                 },
                 {
-                    "Name" : "DesiredCount",
+                    "Names" : "DesiredCount",
                     "Type" : NUMBER_TYPE,
                     "Default" : -1
                 },
                 {
-                    "Name" : "UseTaskRole",
+                    "Names" : "UseTaskRole",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : true
                 },
                 {
-                    "Name" : "Permissions",
+                    "Names" : "Permissions",
                     "Children" : [
                         {
-                            "Name" : "Decrypt",
+                            "Names" : "Decrypt",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "AsFile",
+                            "Names" : "AsFile",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "AppData",
+                            "Names" : "AppData",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "AppPublic",
+                            "Names" : "AppPublic",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         }
                     ]
                 },
                 {
-                    "Name" : "TaskLogGroup",
+                    "Names" : "TaskLogGroup",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : true
                 },
                 {
-                    "Name" : "NetworkMode",
+                    "Names" : "NetworkMode",
                     "Type" : STRING_TYPE,
                     "Values" : ["none", "bridge", "awsvpc", "host"],
                     "Default" : ""
                 },
                 {
-                    "Name" : "ContainerNetworkLinks",
+                    "Names" : "ContainerNetworkLinks",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 }
@@ -260,47 +260,47 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : "Containers",
+                    "Names" : "Containers",
                     "Subobjects" : true,
                     "Children" : containerChildrenConfiguration
                 },
                 {
-                    "Name" : "UseTaskRole",
+                    "Names" : "UseTaskRole",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : true
                 },
                 {
-                    "Name" : "Permissions",
+                    "Names" : "Permissions",
                     "Children" : [
                         {
-                            "Name" : "Decrypt",
+                            "Names" : "Decrypt",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "AsFile",
+                            "Names" : "AsFile",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "AppData",
+                            "Names" : "AppData",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "AppPublic",
+                            "Names" : "AppPublic",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         }
                     ]
                 },
                 {
-                    "Name" : "TaskLogGroup",
+                    "Names" : "TaskLogGroup",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : true
                 },
                 {
-                    "Name" : "FixedName",
+                    "Names" : "FixedName",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 }

--- a/aws/templates/id/id_efs.ftl
+++ b/aws/templates/id/id_efs.ftl
@@ -27,6 +27,20 @@
 [#assign componentConfiguration +=
     {
         EFS_COMPONENT_TYPE  : {
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "A managed network attached file share"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                }
+            ],
             "Attributes" : [
                 {
                     "Name" : "Encrypted",
@@ -42,13 +56,29 @@
                 }
             ]
         },
-        EFS_MOUNT_COMPONENT_TYPE : [
-            {
-                "Name" : "Directory",
-                "Type" : STRING_TYPE,
-                "Mandatory" : true
-            }
-        ]
+        EFS_MOUNT_COMPONENT_TYPE : {
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "A specific directory on the share for OS mounting"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : "Directory",
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
+                }
+            ]
+        }
     }]
 
 [#function getEFSState occurrence]

--- a/aws/templates/id/id_efs.ftl
+++ b/aws/templates/id/id_efs.ftl
@@ -43,7 +43,7 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : "Encrypted",
+                    "Names" : "Encrypted",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : true
                 }
@@ -73,7 +73,7 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : "Directory",
+                    "Names" : "Directory",
                     "Type" : STRING_TYPE,
                     "Mandatory" : true
                 }

--- a/aws/templates/id/id_es.ftl
+++ b/aws/templates/id/id_es.ftl
@@ -34,43 +34,43 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : "Authentication",
+                    "Names" : "Authentication",
                     "Type" : STRING_TYPE,
                     "Values" : ["IP", "SIG4ORIP", "SIG4ANDIP"],
                     "Default" : "IP"
                 },
                 {
-                    "Name" : "IPAddressGroups",
+                    "Names" : "IPAddressGroups",
                     "Type" : ARRAY_OF_STRING_TYPE,
                     "Mandatory" : true
                 },
                 {
-                    "Name" : "AdvancedOptions",
+                    "Names" : "AdvancedOptions",
                     "Type" : ARRAY_OF_STRING_TYPE,
                     "Default" : []
                 },
                 {
-                    "Name" : "Version",
+                    "Names" : "Version",
                     "Type" : STRING_TYPE,
                     "Default" : "2.3"
                 },
                 {
-                    "Name" : "Encrypted",
+                    "Names" : "Encrypted",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
-                    "Name" : "Snapshot",
+                    "Names" : "Snapshot",
                     "Children" : [
                         {
-                            "Name" : "Hour",
+                            "Names" : "Hour",
                             "Type" : STRING_TYPE,
                             "Default" : ""
                         }
                     ]
                 },
                 {
-                    "Name" : "Links",
+                    "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
                 }

--- a/aws/templates/id/id_es.ftl
+++ b/aws/templates/id/id_es.ftl
@@ -17,49 +17,65 @@
 
 [#assign componentConfiguration +=
     {
-        ES_COMPONENT_TYPE : [
-            {
-                "Name" : "Authentication",
-                "Type" : STRING_TYPE,
-                "Values" : ["IP", "SIG4ORIP", "SIG4ANDIP"],
-                "Default" : "IP"
-            },
-            {
-                "Name" : "IPAddressGroups",
-                "Type" : ARRAY_OF_STRING_TYPE,
-                "Mandatory" : true
-            },
-            {
-                "Name" : "AdvancedOptions",
-                "Type" : ARRAY_OF_STRING_TYPE,
-                "Default" : []
-            },
-            {
-                "Name" : "Version",
-                "Type" : STRING_TYPE,
-                "Default" : "2.3"
-            },
-            {
-                "Name" : "Encrypted",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
-            },
-            {
-                "Name" : "Snapshot",
-                "Children" : [
-                    {
-                        "Name" : "Hour",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
-                    }
-                ]
-            },
-            {
-                "Name" : "Links",
-                "Subobjects" : true,
-                "Children" : linkChildrenConfiguration
-            }
-        ]
+        ES_COMPONENT_TYPE : {
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "A managed ElasticSearch instance"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : "Authentication",
+                    "Type" : STRING_TYPE,
+                    "Values" : ["IP", "SIG4ORIP", "SIG4ANDIP"],
+                    "Default" : "IP"
+                },
+                {
+                    "Name" : "IPAddressGroups",
+                    "Type" : ARRAY_OF_STRING_TYPE,
+                    "Mandatory" : true
+                },
+                {
+                    "Name" : "AdvancedOptions",
+                    "Type" : ARRAY_OF_STRING_TYPE,
+                    "Default" : []
+                },
+                {
+                    "Name" : "Version",
+                    "Type" : STRING_TYPE,
+                    "Default" : "2.3"
+                },
+                {
+                    "Name" : "Encrypted",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Name" : "Snapshot",
+                    "Children" : [
+                        {
+                            "Name" : "Hour",
+                            "Type" : STRING_TYPE,
+                            "Default" : ""
+                        }
+                    ]
+                },
+                {
+                    "Name" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                }
+            ]
+        }
     }]
 
 [#function getESState occurrence]

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -74,114 +74,114 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : ["Fragment", "Container"],
+                    "Names" : ["Fragment", "Container"],
                     "Type" : STRING_TYPE,
                     "Default" : ""
                 },
                 {
-                    "Name" : "Handler",
+                    "Names" : "Handler",
                     "Type" : STRING_TYPE,
                     "Mandatory" : true
                 },
                 {
-                    "Name" : "Links",
+                    "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
                 },
                 {
-                    "Name" : "LogMetrics",
+                    "Names" : "LogMetrics",
                     "Subobjects" : true,
                     "Children" : logMetricChildrenConfiguration
                 },
                 {
-                    "Name" : "LogWatchers",
+                    "Names" : "LogWatchers",
                     "Subobjects" : true,
                     "Children" : logWatcherChildrenConfiguration
                 },
                 {
-                    "Name" : "Alerts",
+                    "Names" : "Alerts",
                     "Subobjects" : true,
                     "Children" : alertChildrenConfiguration
                 },
                 {
-                    "Name" : ["Memory", "MemorySize"],
+                    "Names" : ["Memory", "MemorySize"],
                     "Type" : NUMBER_TYPE,
                     "Default" : 0
                 },
                 {
-                    "Name" : "RunTime",
+                    "Names" : "RunTime",
                     "Type" : STRING_TYPE,
                     "Values" : ["nodejs", "nodejs4.3", "nodejs6.10", "nodejs8.10", "java8", "python2.7", "python3.6", "dotnetcore1.0", "dotnetcore2.0", "dotnetcore2.1", "nodejs4.3-edge", "go1.x"],
                     "Mandatory" : true
                 },
                 {
-                    "Name" : "Schedules",
+                    "Names" : "Schedules",
                     "Subobjects" : true,
                     "Children" : [
                         {
-                            "Name" : "Expression",
+                            "Names" : "Expression",
                             "Type" : STRING_TYPE,
                             "Default" : "rate(6 minutes)"
                         },
                         {
-                            "Name" : "InputPath",
+                            "Names" : "InputPath",
                             "Type" : STRING_TYPE,
                             "Default" : "/healthcheck"
                         },
                         {
-                            "Name" : "Input",
+                            "Names" : "Input",
                             "Type" : OBJECT_TYPE,
                             "Default" : {}
                         }
                     ]
                 },
                 {
-                    "Name" : "Timeout",
+                    "Names" : "Timeout",
                     "Type" : NUMBER_TYPE,
                     "Default" : 0
                 },
                 {
-                    "Name" : "VPCAccess",
+                    "Names" : "VPCAccess",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : true
                 },
                 {
-                    "Name" : "UseSegmentKey",
+                    "Names" : "UseSegmentKey",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
-                    "Name" : "Permissions",
+                    "Names" : "Permissions",
                     "Children" : [
                         {
-                            "Name" : "Decrypt",
+                            "Names" : "Decrypt",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "AsFile",
+                            "Names" : "AsFile",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "AppData",
+                            "Names" : "AppData",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "AppPublic",
+                            "Names" : "AppPublic",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         }
                     ]
                 },
                 {
-                    "Name" : "PredefineLogGroup",
+                    "Names" : "PredefineLogGroup",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
-                    "Name" : "Environment",
+                    "Names" : "Environment",
                     "Children" : settingsChildConfiguration
                 }
             ]

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -34,6 +34,20 @@
 [#assign componentConfiguration +=
     {
         LAMBDA_COMPONENT_TYPE : {
+            "Properties" : [
+                {
+                    "Type"  : "Description",
+                    "Value" : "Container for a Function as a Service deployment"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "application"
+                }
+            ],
             "Attributes" : [],
             "Components" : [
                 {
@@ -43,119 +57,135 @@
                 }
             ]
         },
-        LAMBDA_FUNCTION_COMPONENT_TYPE : [
-            {
-                "Name" : ["Fragment", "Container"],
-                "Type" : STRING_TYPE,
-                "Default" : ""
-            },
-            {
-                "Name" : "Handler",
-                "Type" : STRING_TYPE,
-                "Mandatory" : true
-            },
-            {
-                "Name" : "Links",
-                "Subobjects" : true,
-                "Children" : linkChildrenConfiguration
-            },
-            {
-                "Name" : "LogMetrics",
-                "Subobjects" : true,
-                "Children" : logMetricChildrenConfiguration
-            },
-            {
-                "Name" : "LogWatchers",
-                "Subobjects" : true,
-                "Children" : logWatcherChildrenConfiguration
-            },
-            {
-                "Name" : "Alerts",
-                "Subobjects" : true,
-                "Children" : alertChildrenConfiguration
-            },
-            {
-                "Name" : ["Memory", "MemorySize"],
-                "Type" : NUMBER_TYPE,
-                "Default" : 0
-            },
-            {
-                "Name" : "RunTime",
-                "Type" : STRING_TYPE,
-                "Values" : ["nodejs", "nodejs4.3", "nodejs6.10", "nodejs8.10", "java8", "python2.7", "python3.6", "dotnetcore1.0", "dotnetcore2.0", "dotnetcore2.1", "nodejs4.3-edge", "go1.x"],
-                "Mandatory" : true
-            },
-            {
-                "Name" : "Schedules",
-                "Subobjects" : true,
-                "Children" : [
-                    {
-                        "Name" : "Expression",
-                        "Type" : STRING_TYPE,
-                        "Default" : "rate(6 minutes)"
-                    },
-                    {
-                        "Name" : "InputPath",
-                        "Type" : STRING_TYPE,
-                        "Default" : "/healthcheck"
-                    },
-                    {
-                        "Name" : "Input",
-                        "Type" : OBJECT_TYPE,
-                        "Default" : {}
-                    }
-                ]
-            },
-            {
-                "Name" : "Timeout",
-                "Type" : NUMBER_TYPE,
-                "Default" : 0
-            },
-            {
-                "Name" : "VPCAccess",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : true
-            },
-            {
-                "Name" : "UseSegmentKey",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
-            },
-            {
-                "Name" : "Permissions",
-                "Children" : [
-                    {
-                        "Name" : "Decrypt",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "AsFile",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "AppData",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "AppPublic",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    }
-                ]
-            },
-            {
-                "Name" : "PredefineLogGroup",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
-            },
-            {
-                "Name" : "Environment",
-                "Children" : settingsChildConfiguration
-            }
-        ]
+        LAMBDA_FUNCTION_COMPONENT_TYPE : {
+            "Properties" : [
+                {
+                    "Type"  : "Description",
+                    "Value" : "A specific entry point for the lambda deployment"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "application"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : ["Fragment", "Container"],
+                    "Type" : STRING_TYPE,
+                    "Default" : ""
+                },
+                {
+                    "Name" : "Handler",
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
+                },
+                {
+                    "Name" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                },
+                {
+                    "Name" : "LogMetrics",
+                    "Subobjects" : true,
+                    "Children" : logMetricChildrenConfiguration
+                },
+                {
+                    "Name" : "LogWatchers",
+                    "Subobjects" : true,
+                    "Children" : logWatcherChildrenConfiguration
+                },
+                {
+                    "Name" : "Alerts",
+                    "Subobjects" : true,
+                    "Children" : alertChildrenConfiguration
+                },
+                {
+                    "Name" : ["Memory", "MemorySize"],
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 0
+                },
+                {
+                    "Name" : "RunTime",
+                    "Type" : STRING_TYPE,
+                    "Values" : ["nodejs", "nodejs4.3", "nodejs6.10", "nodejs8.10", "java8", "python2.7", "python3.6", "dotnetcore1.0", "dotnetcore2.0", "dotnetcore2.1", "nodejs4.3-edge", "go1.x"],
+                    "Mandatory" : true
+                },
+                {
+                    "Name" : "Schedules",
+                    "Subobjects" : true,
+                    "Children" : [
+                        {
+                            "Name" : "Expression",
+                            "Type" : STRING_TYPE,
+                            "Default" : "rate(6 minutes)"
+                        },
+                        {
+                            "Name" : "InputPath",
+                            "Type" : STRING_TYPE,
+                            "Default" : "/healthcheck"
+                        },
+                        {
+                            "Name" : "Input",
+                            "Type" : OBJECT_TYPE,
+                            "Default" : {}
+                        }
+                    ]
+                },
+                {
+                    "Name" : "Timeout",
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 0
+                },
+                {
+                    "Name" : "VPCAccess",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Name" : "UseSegmentKey",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Name" : "Permissions",
+                    "Children" : [
+                        {
+                            "Name" : "Decrypt",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "AsFile",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "AppData",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "AppPublic",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        }
+                    ]
+                },
+                {
+                    "Name" : "PredefineLogGroup",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Name" : "Environment",
+                    "Children" : settingsChildConfiguration
+                }
+            ]
+        }
     }
 ]
     

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -39,33 +39,33 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : "Logs",
+                    "Names" : "Logs",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
-                    "Name" : "Engine",
+                    "Names" : "Engine",
                     "Type" : STRING_TYPE,
                     "Values" : ["application", "network", "classic"],
                     "Default" : "application"
                 },
                 {
-                    "Name" : "Profiles",
+                    "Names" : "Profiles",
                     "Children" : [
                         {
-                            "Name" : "SecurityProfile",
+                            "Names" : "SecurityProfile",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
                         }
                     ]
                 },
                 {
-                    "Name" : "IdleTimeout", 
+                    "Names" : "IdleTimeout", 
                     "Type" : NUMBER_TYPE,
                     "Default" : 60
                 }
                 {
-                    "Name" : "HealthCheckPort",
+                    "Names" : "HealthCheckPort",
                     "Type" : STRING_TYPE,
                     "Default" : ""
                 }
@@ -95,131 +95,131 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : "IPAddressGroups",
+                    "Names" : "IPAddressGroups",
                     "Type" : ARRAY_OF_STRING_TYPE,
                     "Default" : []
                 },
                 {
-                    "Name" : "Certificate",
+                    "Names" : "Certificate",
                     "Type" : OBJECT_TYPE,
                     "Default" : {}
                 },
                 {
-                    "Name" : "HostFilter",
+                    "Names" : "HostFilter",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
-                    "Name" : "Mapping",
+                    "Names" : "Mapping",
                     "Type" : STRING_TYPE
                 },
                 {
-                    "Name" : "Path",
+                    "Names" : "Path",
                     "Type" : STRING_TYPE,
                     "Default" : "default"
                 },
                 {
-                    "Name" : "Priority",
+                    "Names" : "Priority",
                     "Type" : NUMBER_TYPE,
                     "Default" : 100
                 },
                 {
-                    "Name" : "Links",
+                    "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
                 },
                 {
-                    "Name" : "Authentication",
+                    "Names" : "Authentication",
                     "Children" : [
                         {
-                            "Name" : "SessionCookieName",
+                            "Names" : "SessionCookieName",
                             "Type" : STRING_TYPE,
                             "Default" : "AWSELBAuthSessionCookie"
                         },
                         {
-                            "Name" : "SessionTimeout",
+                            "Names" : "SessionTimeout",
                             "Type" : NUMBER_TYPE,
                             "Default" : 604800
                         }
                     ]
                 },
                 {
-                    "Name" : "Redirect",
+                    "Names" : "Redirect",
                     "Children" : [
                         {
-                            "Name" : "Protocol",
+                            "Names" : "Protocol",
                             "Type" : STRING_TYPE,
                             "Values" : ["HTTPS", "#\{protocol}" ],
                             "Default" : "HTTPS"
                         },
                         {
-                            "Name" : "Port",
+                            "Names" : "Port",
                             "Type" : STRING_TYPE,
                             "Default" : "443"
                         },
                         {
-                            "Name" : "Host",
+                            "Names" : "Host",
                             "Type" : STRING_TYPE,
                             "Default" : "#\{host}"
                         },
                         {
-                            "Name" : "Path",
+                            "Names" : "Path",
                             "Type" : STRING_TYPE,
                             "Default" : "/#\{path}"
                         },
                         {
-                            "Name" : "Query",
+                            "Names" : "Query",
                             "Type" : STRING_TYPE,
                             "Default" : "#\{query}"
                         },
                         {
-                            "Name" : "Permanent",
+                            "Names" : "Permanent",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         }
                     ]
                 },
                 {
-                    "Name" : "Fixed",
+                    "Names" : "Fixed",
                     "Children" : [
                         {
-                            "Name" : "Message",
+                            "Names" : "Message",
                             "Type" : STRING_TYPE,
                             "Default" : "This application is currently unavailable. Please try again later."
                         },
                         {
-                            "Name" : "ContentType",
+                            "Names" : "ContentType",
                             "Type" : STRING_TYPE,
                             "Default" : "text/plain"
                         },
                         {
-                            "Name" : "StatusCode",
+                            "Names" : "StatusCode",
                             "Type" : STRING_TYPE,
                             "Default" : "404"
                         }
                     ]
                 },
                 {
-                    "Name" : "Forward",
+                    "Names" : "Forward",
                     "Children" : [
                         {
-                            "Name" : "TargetType",
+                            "Names" : "TargetType",
                             "Type" : STRING_TYPE,
                             "Values" : ["instance", "ip"],
                             "Default" : "instance"
                         },
                         {
-                            "Name" : "SlowStartTime",
+                            "Names" : "SlowStartTime",
                             "Type" : NUMBER_TYPE,
                             "Default" : -1
                         },
                         {
-                            "Name" : "StickinessTime",
+                            "Names" : "StickinessTime",
                             "Type" : NUMBER_TYPE,
                             "Default" : -1
                         },
                         {
-                            "Name" : "DeregistrationTimeout",
+                            "Names" : "DeregistrationTimeout",
                             "Type" : NUMBER_TYPE,
                             "Default" : 30
                         }

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -18,6 +18,25 @@
 [#assign componentConfiguration +=
     {
         LB_COMPONENT_TYPE   : {
+            "Properties"  : [
+                {
+                    "Type"  : "Description",
+                    "Value" : "A load balancer for virtual network based components"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                },
+                {
+                    "Type" : "Note",
+                    "Value" : "Requires second deployment to complete configuration",
+                    "Severity" : "warning"
+                }
+            ],
             "Attributes" : [
                 {
                     "Name" : "Logs",
@@ -59,139 +78,155 @@
                 }
             ]
         },
-        LB_PORT_COMPONENT_TYPE : [
-            {
-                "Name" : "IPAddressGroups",
-                "Type" : ARRAY_OF_STRING_TYPE,
-                "Default" : []
-            },
-            {
-                "Name" : "Certificate",
-                "Type" : OBJECT_TYPE,
-                "Default" : {}
-            },
-            {
-                "Name" : "HostFilter",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
-            },
-            {
-                "Name" : "Mapping",
-                "Type" : STRING_TYPE
-            },
-            {
-                "Name" : "Path",
-                "Type" : STRING_TYPE,
-                "Default" : "default"
-            },
-            {
-                "Name" : "Priority",
-                "Type" : NUMBER_TYPE,
-                "Default" : 100
-            },
-            {
-                "Name" : "Links",
-                "Subobjects" : true,
-                "Children" : linkChildrenConfiguration
-            },
-            {
-                "Name" : "Authentication",
-                "Children" : [
-                    {
-                        "Name" : "SessionCookieName",
-                        "Type" : STRING_TYPE,
-                        "Default" : "AWSELBAuthSessionCookie"
-                    },
-                    {
-                        "Name" : "SessionTimeout",
-                        "Type" : NUMBER_TYPE,
-                        "Default" : 604800
-                    }
-                ]
-            },
-            {
-                "Name" : "Redirect",
-                "Children" : [
-                    {
-                        "Name" : "Protocol",
-                        "Type" : STRING_TYPE,
-                        "Values" : ["HTTPS", "#\{protocol}" ],
-                        "Default" : "HTTPS"
-                    },
-                    {
-                        "Name" : "Port",
-                        "Type" : STRING_TYPE,
-                        "Default" : "443"
-                    },
-                    {
-                        "Name" : "Host",
-                        "Type" : STRING_TYPE,
-                        "Default" : "#\{host}"
-                    },
-                    {
-                        "Name" : "Path",
-                        "Type" : STRING_TYPE,
-                        "Default" : "/#\{path}"
-                    },
-                    {
-                        "Name" : "Query",
-                        "Type" : STRING_TYPE,
-                        "Default" : "#\{query}"
-                    },
-                    {
-                        "Name" : "Permanent",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    }
-                ]
-            },
-            {
-                "Name" : "Fixed",
-                "Children" : [
-                    {
-                        "Name" : "Message",
-                        "Type" : STRING_TYPE,
-                        "Default" : "This application is currently unavailable. Please try again later."
-                    },
-                    {
-                        "Name" : "ContentType",
-                        "Type" : STRING_TYPE,
-                        "Default" : "text/plain"
-                    },
-                    {
-                        "Name" : "StatusCode",
-                        "Type" : STRING_TYPE,
-                        "Default" : "404"
-                    }
-                ]
-            },
-            {
-                "Name" : "Forward",
-                "Children" : [
-                    {
-                        "Name" : "TargetType",
-                        "Type" : STRING_TYPE,
-                        "Values" : ["instance", "ip"],
-                        "Default" : "instance"
-                    },
-                    {
-                        "Name" : "SlowStartTime",
-                        "Type" : NUMBER_TYPE,
-                        "Default" : -1
-                    },
-                    {
-                        "Name" : "StickinessTime",
-                        "Type" : NUMBER_TYPE,
-                        "Default" : -1
-                    },
-                    {
-                        "Name" : "DeregistrationTimeout",
-                        "Type" : NUMBER_TYPE,
-                        "Default" : 30
-                    }
-                ]
-            }
-        ]
+        LB_PORT_COMPONENT_TYPE : {
+            "Properties"  : [
+                {
+                    "Type"  : "Description",
+                    "Value" : "A specifc listener based on the client side network port"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : "IPAddressGroups",
+                    "Type" : ARRAY_OF_STRING_TYPE,
+                    "Default" : []
+                },
+                {
+                    "Name" : "Certificate",
+                    "Type" : OBJECT_TYPE,
+                    "Default" : {}
+                },
+                {
+                    "Name" : "HostFilter",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Name" : "Mapping",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Name" : "Path",
+                    "Type" : STRING_TYPE,
+                    "Default" : "default"
+                },
+                {
+                    "Name" : "Priority",
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 100
+                },
+                {
+                    "Name" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                },
+                {
+                    "Name" : "Authentication",
+                    "Children" : [
+                        {
+                            "Name" : "SessionCookieName",
+                            "Type" : STRING_TYPE,
+                            "Default" : "AWSELBAuthSessionCookie"
+                        },
+                        {
+                            "Name" : "SessionTimeout",
+                            "Type" : NUMBER_TYPE,
+                            "Default" : 604800
+                        }
+                    ]
+                },
+                {
+                    "Name" : "Redirect",
+                    "Children" : [
+                        {
+                            "Name" : "Protocol",
+                            "Type" : STRING_TYPE,
+                            "Values" : ["HTTPS", "#\{protocol}" ],
+                            "Default" : "HTTPS"
+                        },
+                        {
+                            "Name" : "Port",
+                            "Type" : STRING_TYPE,
+                            "Default" : "443"
+                        },
+                        {
+                            "Name" : "Host",
+                            "Type" : STRING_TYPE,
+                            "Default" : "#\{host}"
+                        },
+                        {
+                            "Name" : "Path",
+                            "Type" : STRING_TYPE,
+                            "Default" : "/#\{path}"
+                        },
+                        {
+                            "Name" : "Query",
+                            "Type" : STRING_TYPE,
+                            "Default" : "#\{query}"
+                        },
+                        {
+                            "Name" : "Permanent",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        }
+                    ]
+                },
+                {
+                    "Name" : "Fixed",
+                    "Children" : [
+                        {
+                            "Name" : "Message",
+                            "Type" : STRING_TYPE,
+                            "Default" : "This application is currently unavailable. Please try again later."
+                        },
+                        {
+                            "Name" : "ContentType",
+                            "Type" : STRING_TYPE,
+                            "Default" : "text/plain"
+                        },
+                        {
+                            "Name" : "StatusCode",
+                            "Type" : STRING_TYPE,
+                            "Default" : "404"
+                        }
+                    ]
+                },
+                {
+                    "Name" : "Forward",
+                    "Children" : [
+                        {
+                            "Name" : "TargetType",
+                            "Type" : STRING_TYPE,
+                            "Values" : ["instance", "ip"],
+                            "Default" : "instance"
+                        },
+                        {
+                            "Name" : "SlowStartTime",
+                            "Type" : NUMBER_TYPE,
+                            "Default" : -1
+                        },
+                        {
+                            "Name" : "StickinessTime",
+                            "Type" : NUMBER_TYPE,
+                            "Default" : -1
+                        },
+                        {
+                            "Name" : "DeregistrationTimeout",
+                            "Type" : NUMBER_TYPE,
+                            "Default" : 30
+                        }
+                    ]
+                }
+            ]
+        }
     }]
 
 [#function getLBState occurrence]

--- a/aws/templates/id/id_mobilenotifier.ftl
+++ b/aws/templates/id/id_mobilenotifier.ftl
@@ -25,20 +25,20 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : "Links",
+                    "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
                 },
                 {
-                    "Name" : "SuccessSampleRate",
+                    "Names" : "SuccessSampleRate",
                     "Type" : STRING_TYPE,
                     "Default" : "100"
                 },
                 {
-                    "Name" : "Credentials",
+                    "Names" : "Credentials",
                     "Children" : [
                         {
-                            "Name" : "EncryptionScheme",
+                            "Names" : "EncryptionScheme",
                             "Type" : STRING_TYPE,
                             "Values" : ["base64"],
                             "Default" : "base64"
@@ -81,30 +81,30 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : "Engine",
+                    "Names" : "Engine",
                     "Type" : STRING_TYPE
                 },
                 {
-                    "Name" : "SuccessSampleRate",
+                    "Names" : "SuccessSampleRate",
                     "Type" : STRING_TYPE
                 },
                 {
-                    "Name" : "Credentials",
+                    "Names" : "Credentials",
                     "Children" : [
                         {
-                            "Name" : "EncryptionScheme",
+                            "Names" : "EncryptionScheme",
                             "Type" : STRING_TYPE,
                             "Values" : ["base64"]
                         }
                     ]
                 },
                 { 
-                    "Name" : "Links",
+                    "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
                 },
                 {
-                    "Name" : "LogMetrics",
+                    "Names" : "LogMetrics",
                     "Subobjects" : true,
                     "Children" : logMetricChildrenConfiguration
                 }

--- a/aws/templates/id/id_mobilenotifier.ftl
+++ b/aws/templates/id/id_mobilenotifier.ftl
@@ -9,6 +9,20 @@
 [#assign componentConfiguration +=
     {
         MOBILENOTIFIER_COMPONENT_TYPE : {
+            "Properties"  : [
+                {
+                    "Type"  : "Description",
+                    "Value" : "A managed mobile notification proxy"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                }
+            ],
             "Attributes" : [
                 {
                     "Name" : "Links",
@@ -40,36 +54,62 @@
                 }
             ]
         },
-        MOBILENOTIFIER_PLATFORM_COMPONENT_TYPE : [
-            {
-                "Name" : "Engine",
-                "Type" : STRING_TYPE
-            },
-            {
-                "Name" : "SuccessSampleRate",
-                "Type" : STRING_TYPE
-            },
-            {
-                "Name" : "Credentials",
-                "Children" : [
-                    {
-                        "Name" : "EncryptionScheme",
-                        "Type" : STRING_TYPE,
-                        "Values" : ["base64"]
-                    }
-                ]
-            },
-            {
-                "Name" : "Links",
-                "Subobjects" : true,
-                "Children" : linkChildrenConfiguration
-            },
-            {
-                "Name" : "LogMetrics",
-                "Subobjects" : true,
-                "Children" : logMetricChildrenConfiguration
-            }
-        ]
+        MOBILENOTIFIER_PLATFORM_COMPONENT_TYPE : {
+            "Properties"  : [
+                {
+                    "Type"  : "Description",
+                    "Value" : "A specific mobile platform notification proxy"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                },
+                {
+                    "Type" : "Note",
+                    "Value" : "SMS Engine requires account level configuration for AWS provider",
+                    "Severity" : "warning"
+                },
+                {
+                    "Type" : "Note",
+                    "Value" : "Platform specific credentials are required and must be provided as credentials",
+                    "Severity" : "info"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : "Engine",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Name" : "SuccessSampleRate",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Name" : "Credentials",
+                    "Children" : [
+                        {
+                            "Name" : "EncryptionScheme",
+                            "Type" : STRING_TYPE,
+                            "Values" : ["base64"]
+                        }
+                    ]
+                },
+                { 
+                    "Name" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                },
+                {
+                    "Name" : "LogMetrics",
+                    "Subobjects" : true,
+                    "Children" : logMetricChildrenConfiguration
+                }
+            ]
+        }
     }]
 
 [#function getMobileNotifierState occurrence]

--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -43,42 +43,42 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : "Engine",
+                    "Names" : "Engine",
                     "Mandatory" : true
                 },
                 {
-                    "Name" : "EngineVersion",
+                    "Names" : "EngineVersion",
                     "Type" : STRING_TYPE
                 },
                 {
-                    "Name" : "Port",
+                    "Names" : "Port",
                     "Type" : STRING_TYPE
                 },
                 {
-                    "Name" : "Encrypted",
+                    "Names" : "Encrypted",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
-                    "Name" : "GenerateCredentials",
+                    "Names" : "GenerateCredentials",
                     "Children" : [
                         {
-                            "Name" : "Enabled",
+                            "Names" : "Enabled",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : false
                         },
                         {
-                            "Name" : "MasterUserName",
+                            "Names" : "MasterUserName",
                             "Type" : STRING_TYPE,
                             "Default" : "root"
                         },
                         {
-                            "Name" : "CharacterLength",
+                            "Names" : "CharacterLength",
                             "Type" : NUMBER_TYPE,
                             "Default" : 20
                         },
                         {
-                            "Name" : "EncryptionScheme",
+                            "Names" : "EncryptionScheme",
                             "Type" : STRING_TYPE,
                             "Values" : ["base64"],
                             "Default" : ""
@@ -86,35 +86,35 @@
                     ]
                 },
                 {
-                    "Name" : "Size",
+                    "Names" : "Size",
                     "Type" : NUMBER_TYPE,
                     "Default" : 20
                 },
                 {
-                    "Name" : "Backup",
+                    "Names" : "Backup",
                     "Children" : [
                         {
-                            "Name" : "RetentionPeriod",
+                            "Names" : "RetentionPeriod",
                             "Type" : NUMBER_TYPE,
                             "Default" : 35
                         },
                         {
-                            "Name" : "SnapshotOnDeploy",
+                            "Names" : "SnapshotOnDeploy",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         }
                     ]
                 },
                 {
-                    "Name" : "AutoMinorVersionUpgrade",
+                    "Names" : "AutoMinorVersionUpgrade",
                     "Type" : BOOLEAN_TYPE
                 },
                 {
-                    "Name" : "DatabaseName",
+                    "Names" : "DatabaseName",
                     "Type" : STRING_TYPE
                 },
                 {
-                    "Name" : "DBParameters",
+                    "Names" : "DBParameters",
                     "Type" : OBJECT_TYPE,
                     "Default" : {}
                 }

--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -26,84 +26,100 @@
 
 [#assign componentConfiguration +=
     {
-        RDS_COMPONENT_TYPE : [
-            {
-                "Name" : "Engine",
-                "Mandatory" : true
-            },
-            {
-                "Name" : "EngineVersion",
-                "Type" : STRING_TYPE
-            },
-            {
-                "Name" : "Port",
-                "Type" : STRING_TYPE
-            },
-            {
-                "Name" : "Encrypted",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
-            },
-            {
-                "Name" : "GenerateCredentials",
-                "Children" : [
-                    {
-                        "Name" : "Enabled",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : false
-                    },
-                    {
-                        "Name" : "MasterUserName",
-                        "Type" : STRING_TYPE,
-                        "Default" : "root"
-                    },
-                    {
-                        "Name" : "CharacterLength",
-                        "Type" : NUMBER_TYPE,
-                        "Default" : 20
-                    },
-                    {
-                        "Name" : "EncryptionScheme",
-                        "Type" : STRING_TYPE,
-                        "Values" : ["base64"],
-                        "Default" : ""
-                    }
-                ]
-            },
-            {
-                "Name" : "Size",
-                "Type" : NUMBER_TYPE,
-                "Default" : 20
-            },
-            {
-                "Name" : "Backup",
-                "Children" : [
-                    {
-                        "Name" : "RetentionPeriod",
-                        "Type" : NUMBER_TYPE,
-                        "Default" : 35
-                    },
-                    {
-                        "Name" : "SnapshotOnDeploy",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    }
-                ]
-            },
-            {
-                "Name" : "AutoMinorVersionUpgrade",
-                "Type" : BOOLEAN_TYPE
-            },
-            {
-                "Name" : "DatabaseName",
-                "Type" : STRING_TYPE
-            },
-            {
-                "Name" : "DBParameters",
-                "Type" : OBJECT_TYPE,
-                "Default" : {}
-            }
-        ]
+        RDS_COMPONENT_TYPE : {
+            "Properties"  : [
+                {
+                    "Type"  : "Description",
+                    "Value" : "A managed SQL database instance"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : "Engine",
+                    "Mandatory" : true
+                },
+                {
+                    "Name" : "EngineVersion",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Name" : "Port",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Name" : "Encrypted",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Name" : "GenerateCredentials",
+                    "Children" : [
+                        {
+                            "Name" : "Enabled",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : false
+                        },
+                        {
+                            "Name" : "MasterUserName",
+                            "Type" : STRING_TYPE,
+                            "Default" : "root"
+                        },
+                        {
+                            "Name" : "CharacterLength",
+                            "Type" : NUMBER_TYPE,
+                            "Default" : 20
+                        },
+                        {
+                            "Name" : "EncryptionScheme",
+                            "Type" : STRING_TYPE,
+                            "Values" : ["base64"],
+                            "Default" : ""
+                        }
+                    ]
+                },
+                {
+                    "Name" : "Size",
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 20
+                },
+                {
+                    "Name" : "Backup",
+                    "Children" : [
+                        {
+                            "Name" : "RetentionPeriod",
+                            "Type" : NUMBER_TYPE,
+                            "Default" : 35
+                        },
+                        {
+                            "Name" : "SnapshotOnDeploy",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        }
+                    ]
+                },
+                {
+                    "Name" : "AutoMinorVersionUpgrade",
+                    "Type" : BOOLEAN_TYPE
+                },
+                {
+                    "Name" : "DatabaseName",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Name" : "DBParameters",
+                    "Type" : OBJECT_TYPE,
+                    "Default" : {}
+                }
+            ]
+    }
 }]
 
 [#function getRDSState occurrence]

--- a/aws/templates/id/id_s3.ftl
+++ b/aws/templates/id/id_s3.ftl
@@ -90,77 +90,77 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : "Lifecycle",
+                    "Names" : "Lifecycle",
                     "Children" : [
                         {
-                            "Name" : "Expiration",
+                            "Names" : "Expiration",
                             "Types" : [STRING_TYPE, NUMBER_TYPE],
                             "Description" : "Provide either a date or a number of days"
                         },
                         {
-                            "Name" : "Offline",
+                            "Names" : "Offline",
                             "Types" : [STRING_TYPE, NUMBER_TYPE],
                             "Description" : "Provide either a date or a number of days"
                         },
                         {
-                            "Name" : "Versioning",
+                            "Names" : "Versioning",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : false
                         }
                     ]
                 },
                 { 
-                    "Name" : "Website",
+                    "Names" : "Website",
                     "Children" : [
                         {
-                            "Name": "Index",
+                            "Names": "Index",
                             "Type" : STRING_TYPE,
                             "Default": "index.html"
                         },
                         {
-                            "Name": "Error",
+                            "Names": "Error",
                             "Type" : STRING_TYPE,
                             "Default": ""
                         }
                     ]
                 },
                 {
-                    "Name" : "PublicAccess",
+                    "Names" : "PublicAccess",
                     "Children" : [
                         {
-                            "Name" : "Enabled",
+                            "Names" : "Enabled",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : false
                         },
                         {
-                            "Name" : "Permissions",
+                            "Names" : "Permissions",
                             "Type" : STRING_TYPE,
                             "Values" : ["ro", "wo", "rw"],
                             "Default" : "ro"
                         },
                         {
-                            "Name" : "IPAddressGroups",
+                            "Names" : "IPAddressGroups",
                             "Type" : ARRAY_OF_STRING_TYPE,
                             "Default" : [ "_localnet" ]
                         },
                         {
-                            "Name" : "Prefix",
+                            "Names" : "Prefix",
                             "Type" : STRING_TYPE,
                             "Default" : ""
                         }
                     ]
                 },
                 {
-                    "Name" : "Style",
+                    "Names" : "Style",
                     "Type" : STRING_TYPE,
                     "Description" : "TODO(mfl): Think this can be removed"
                 },
                 {
-                    "Name" : "Notifications",
+                    "Names" : "Notifications",
                     "Type" : OBJECT_TYPE
                 },
                 {
-                    "Name" : "CORSBehaviours",
+                    "Names" : "CORSBehaviours",
                     "Type" : ARRAY_OF_STRING_TYPE,
                     "Default" : []
                 }

--- a/aws/templates/id/id_s3.ftl
+++ b/aws/templates/id/id_s3.ftl
@@ -73,83 +73,99 @@
 
 [#assign componentConfiguration +=
     {
-        S3_COMPONENT_TYPE : [
-            {
-                "Name" : "Lifecycle",
-                "Children" : [
-                    {
-                        "Name" : "Expiration",
-                        "Types" : [STRING_TYPE, NUMBER_TYPE],
-                        "Description" : "Provide either a date or a number of days"
-                    },
-                    {
-                        "Name" : "Offline",
-                        "Types" : [STRING_TYPE, NUMBER_TYPE],
-                        "Description" : "Provide either a date or a number of days"
-                    },
-                    {
-                        "Name" : "Versioning",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : false
-                    }
-                ]
-            },
-            { 
-                "Name" : "Website",
-                "Children" : [
-                    {
-                        "Name": "Index",
-                        "Type" : STRING_TYPE,
-                        "Default": "index.html"
-                    },
-                    {
-                        "Name": "Error",
-                        "Type" : STRING_TYPE,
-                        "Default": ""
-                    }
-                ]
-            },
-            {
-                "Name" : "PublicAccess",
-                "Children" : [
-                    {
-                        "Name" : "Enabled",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : false
-                    },
-                    {
-                        "Name" : "Permissions",
-                        "Type" : STRING_TYPE,
-                        "Values" : ["ro", "wo", "rw"],
-                        "Default" : "ro"
-                    },
-                    {
-                        "Name" : "IPAddressGroups",
-                        "Type" : ARRAY_OF_STRING_TYPE,
-                        "Default" : [ "_localnet" ]
-                    },
-                    {
-                        "Name" : "Prefix",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
-                    }
-                ]
-            },
-            {
-                "Name" : "Style",
-                "Type" : STRING_TYPE,
-                "Description" : "TODO(mfl): Think this can be removed"
-            },
-            {
-                "Name" : "Notifications",
-                "Type" : OBJECT_TYPE
-            },
-            {
-                "Name" : "CORSBehaviours",
-                "Type" : ARRAY_OF_STRING_TYPE,
-                "Default" : []
-            }
-        ]
+        S3_COMPONENT_TYPE : {
+            "Properties"  : [
+                {
+                    "Type"  : "Description",
+                    "Value" : "HTTP based object storage service"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : "Lifecycle",
+                    "Children" : [
+                        {
+                            "Name" : "Expiration",
+                            "Types" : [STRING_TYPE, NUMBER_TYPE],
+                            "Description" : "Provide either a date or a number of days"
+                        },
+                        {
+                            "Name" : "Offline",
+                            "Types" : [STRING_TYPE, NUMBER_TYPE],
+                            "Description" : "Provide either a date or a number of days"
+                        },
+                        {
+                            "Name" : "Versioning",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : false
+                        }
+                    ]
+                },
+                { 
+                    "Name" : "Website",
+                    "Children" : [
+                        {
+                            "Name": "Index",
+                            "Type" : STRING_TYPE,
+                            "Default": "index.html"
+                        },
+                        {
+                            "Name": "Error",
+                            "Type" : STRING_TYPE,
+                            "Default": ""
+                        }
+                    ]
+                },
+                {
+                    "Name" : "PublicAccess",
+                    "Children" : [
+                        {
+                            "Name" : "Enabled",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : false
+                        },
+                        {
+                            "Name" : "Permissions",
+                            "Type" : STRING_TYPE,
+                            "Values" : ["ro", "wo", "rw"],
+                            "Default" : "ro"
+                        },
+                        {
+                            "Name" : "IPAddressGroups",
+                            "Type" : ARRAY_OF_STRING_TYPE,
+                            "Default" : [ "_localnet" ]
+                        },
+                        {
+                            "Name" : "Prefix",
+                            "Type" : STRING_TYPE,
+                            "Default" : ""
+                        }
+                    ]
+                },
+                {
+                    "Name" : "Style",
+                    "Type" : STRING_TYPE,
+                    "Description" : "TODO(mfl): Think this can be removed"
+                },
+                {
+                    "Name" : "Notifications",
+                    "Type" : OBJECT_TYPE
+                },
+                {
+                    "Name" : "CORSBehaviours",
+                    "Type" : ARRAY_OF_STRING_TYPE,
+                    "Default" : []
+                }
+            ]
+        }
     }]
     
 [#function getS3State occurrence]

--- a/aws/templates/id/id_spa.ftl
+++ b/aws/templates/id/id_spa.ftl
@@ -5,100 +5,116 @@
 
 [#assign componentConfiguration +=
     {
-        SPA_COMPONENT_TYPE : [
-            {
-                "Name" : ["Fragment", "Container"],
-                "Type" : STRING_TYPE,
-                "Default" : ""
-            },
-            {
-                "Name" : "Links",
-                "Type" : OBJECT_TYPE,
-                "Default" : {}
-            },
-            {
-                "Name" : "WAF",
-                "Children" : wafChildConfiguration
-            },
-            {
-                "Name" : "CloudFront",
-                "Children" : [
-                    {
-                        "Name" : "AssumeSNI",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "EnableLogging",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Name" : "CountryGroups",
-                        "Type" : ARRAY_OF_STRING_TYPE,
-                        "Default" : []
-                    },
-                    {
-                        "Name" : "ErrorPage",
-                        "Type" : STRING_TYPE,
-                        "Default" : "/index.html"
-                    },
-                    {
-                        "Name" : "DeniedPage",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
-                    },
-                    {
-                        "Name" : "NotFoundPage",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
-                    },
-                    {
-                        "Name" : "CachingTTL",
-                        "Children" : [
-                            {
-                                "Name" : "Default",
-                                "Type" : NUMBER_TYPE,
-                                "Default" : 600
-                            },
-                            {
-                                "Name" : "Maximum",
-                                "Type" : NUMBER_TYPE,
-                                "Default" : 31536000
-                            },
-                            {
-                                "Name" : "Minimum",
-                                "Type" : NUMBER_TYPE,
-                                "Default" : 0
-                            }
-                        ]
-                    },
-                    {
-                        "Name" : "Compress",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    }
-                ]
-            },
-            {
-                "Name" : "Certificate",
-                "Children" : [
-                    {
-                        "Name" : "*"
-                    }
-                ]
-            },
-            {
-                "Name" : "Profiles",
-                "Children" : [
-                    {
-                        "Name" : "SecurityProfile",
-                        "Type" : STRING_TYPE,
-                        "Default" : "default"
-                    }
-                ]
-            }
-        ]
+        SPA_COMPONENT_TYPE : {
+            "Properties"  : [
+                {
+                    "Type"  : "Description",
+                    "Value" : "Object stored hosted web application with content distribution management"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "application"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : ["Fragment", "Container"],
+                    "Type" : STRING_TYPE,
+                    "Default" : ""
+                },
+                {
+                    "Name" : "Links",
+                    "Type" : OBJECT_TYPE,
+                    "Default" : {}
+                },
+                {
+                    "Name" : "WAF",
+                    "Children" : wafChildConfiguration
+                },
+                {
+                    "Name" : "CloudFront",
+                    "Children" : [
+                        {
+                            "Name" : "AssumeSNI",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "EnableLogging",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Name" : "CountryGroups",
+                            "Type" : ARRAY_OF_STRING_TYPE,
+                            "Default" : []
+                        },
+                        {
+                            "Name" : "ErrorPage",
+                            "Type" : STRING_TYPE,
+                            "Default" : "/index.html"
+                        },
+                        {
+                            "Name" : "DeniedPage",
+                            "Type" : STRING_TYPE,
+                            "Default" : ""
+                        },
+                        {
+                            "Name" : "NotFoundPage",
+                            "Type" : STRING_TYPE,
+                            "Default" : ""
+                        },
+                        {
+                            "Name" : "CachingTTL",
+                            "Children" : [
+                                {
+                                    "Name" : "Default",
+                                    "Type" : NUMBER_TYPE,
+                                    "Default" : 600
+                                },
+                                {
+                                    "Name" : "Maximum",
+                                    "Type" : NUMBER_TYPE,
+                                    "Default" : 31536000
+                                },
+                                {
+                                    "Name" : "Minimum",
+                                    "Type" : NUMBER_TYPE,
+                                    "Default" : 0
+                                }
+                            ]
+                        },
+                        {
+                            "Name" : "Compress",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        }
+                    ]
+                },
+                {
+                    "Name" : "Certificate",
+                    "Children" : [
+                        {
+                            "Name" : "*"
+                        }
+                    ]
+                },
+                {
+                    "Name" : "Profiles",
+                    "Children" : [
+                        {
+                            "Name" : "SecurityProfile",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        }
+                    ]
+                }
+            ]
+        }
     }]
     
 [#function getSPAState occurrence]

--- a/aws/templates/id/id_spa.ftl
+++ b/aws/templates/id/id_spa.ftl
@@ -22,92 +22,92 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : ["Fragment", "Container"],
+                    "Names" : ["Fragment", "Container"],
                     "Type" : STRING_TYPE,
                     "Default" : ""
                 },
                 {
-                    "Name" : "Links",
+                    "Names" : "Links",
                     "Type" : OBJECT_TYPE,
                     "Default" : {}
                 },
                 {
-                    "Name" : "WAF",
+                    "Names" : "WAF",
                     "Children" : wafChildConfiguration
                 },
                 {
-                    "Name" : "CloudFront",
+                    "Names" : "CloudFront",
                     "Children" : [
                         {
-                            "Name" : "AssumeSNI",
+                            "Names" : "AssumeSNI",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "EnableLogging",
+                            "Names" : "EnableLogging",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "CountryGroups",
+                            "Names" : "CountryGroups",
                             "Type" : ARRAY_OF_STRING_TYPE,
                             "Default" : []
                         },
                         {
-                            "Name" : "ErrorPage",
+                            "Names" : "ErrorPage",
                             "Type" : STRING_TYPE,
                             "Default" : "/index.html"
                         },
                         {
-                            "Name" : "DeniedPage",
+                            "Names" : "DeniedPage",
                             "Type" : STRING_TYPE,
                             "Default" : ""
                         },
                         {
-                            "Name" : "NotFoundPage",
+                            "Names" : "NotFoundPage",
                             "Type" : STRING_TYPE,
                             "Default" : ""
                         },
                         {
-                            "Name" : "CachingTTL",
+                            "Names" : "CachingTTL",
                             "Children" : [
                                 {
-                                    "Name" : "Default",
+                                    "Names" : "Default",
                                     "Type" : NUMBER_TYPE,
                                     "Default" : 600
                                 },
                                 {
-                                    "Name" : "Maximum",
+                                    "Names" : "Maximum",
                                     "Type" : NUMBER_TYPE,
                                     "Default" : 31536000
                                 },
                                 {
-                                    "Name" : "Minimum",
+                                    "Names" : "Minimum",
                                     "Type" : NUMBER_TYPE,
                                     "Default" : 0
                                 }
                             ]
                         },
                         {
-                            "Name" : "Compress",
+                            "Names" : "Compress",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         }
                     ]
                 },
                 {
-                    "Name" : "Certificate",
+                    "Names" : "Certificate",
                     "Children" : [
                         {
-                            "Name" : "*"
+                            "Names" : "*"
                         }
                     ]
                 },
                 {
-                    "Name" : "Profiles",
+                    "Names" : "Profiles",
                     "Children" : [
                         {
-                            "Name" : "SecurityProfile",
+                            "Names" : "SecurityProfile",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
                         }

--- a/aws/templates/id/id_sqs.ftl
+++ b/aws/templates/id/id_sqs.ftl
@@ -8,38 +8,54 @@
 
 [#assign componentConfiguration +=
     {
-        SQS_COMPONENT_TYPE : [
-            {
-                "Name" : "DelaySeconds",
-                "Type" : NUMBER_TYPE
-            },
-            {
-                "Name" : "MaximumMessageSize",
-                "Type" : NUMBER_TYPE
-            },
-            {
-                "Name" : "MessageRetentionPeriod",
-                "Type" : NUMBER_TYPE
-            },
-            {
-                "Name" : "ReceiveMessageWaitTimeSeconds",
-                "Type" : NUMBER_TYPE
-            },
-            {
-                "Name" : "DeadLetterQueue",
-                "Children" : [
-                    {
-                        "Name" : "MaxReceives",
-                        "Type" : NUMBER_TYPE,
-                        "Default" : 0
-                    }
-                ]
-            },
-            {
-                "Name" : "VisibilityTimeout",
-                "Type" : NUMBER_TYPE
-            }
-        ]
+        SQS_COMPONENT_TYPE : {
+            "Properties"  : [
+                {
+                    "Type"  : "Description",
+                    "Value" : "Managed worker queue engine"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Name" : "DelaySeconds",
+                    "Type" : NUMBER_TYPE
+                },
+                {
+                    "Name" : "MaximumMessageSize",
+                    "Type" : NUMBER_TYPE
+                },
+                {
+                    "Name" : "MessageRetentionPeriod",
+                    "Type" : NUMBER_TYPE
+                },
+                {
+                    "Name" : "ReceiveMessageWaitTimeSeconds",
+                    "Type" : NUMBER_TYPE
+                },
+                {
+                    "Name" : "DeadLetterQueue",
+                    "Children" : [
+                        {
+                            "Name" : "MaxReceives",
+                            "Type" : NUMBER_TYPE,
+                            "Default" : 0
+                        }
+                    ]
+                },
+                {
+                    "Name" : "VisibilityTimeout",
+                    "Type" : NUMBER_TYPE
+                }
+            ]
+        }
     }]
     
 [#function getSQSState occurrence baseState]

--- a/aws/templates/id/id_sqs.ftl
+++ b/aws/templates/id/id_sqs.ftl
@@ -25,33 +25,33 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : "DelaySeconds",
+                    "Names" : "DelaySeconds",
                     "Type" : NUMBER_TYPE
                 },
                 {
-                    "Name" : "MaximumMessageSize",
+                    "Names" : "MaximumMessageSize",
                     "Type" : NUMBER_TYPE
                 },
                 {
-                    "Name" : "MessageRetentionPeriod",
+                    "Names" : "MessageRetentionPeriod",
                     "Type" : NUMBER_TYPE
                 },
                 {
-                    "Name" : "ReceiveMessageWaitTimeSeconds",
+                    "Names" : "ReceiveMessageWaitTimeSeconds",
                     "Type" : NUMBER_TYPE
                 },
                 {
-                    "Name" : "DeadLetterQueue",
+                    "Names" : "DeadLetterQueue",
                     "Children" : [
                         {
-                            "Name" : "MaxReceives",
+                            "Names" : "MaxReceives",
                             "Type" : NUMBER_TYPE,
                             "Default" : 0
                         }
                     ]
                 },
                 {
-                    "Name" : "VisibilityTimeout",
+                    "Names" : "VisibilityTimeout",
                     "Type" : NUMBER_TYPE
                 }
             ]

--- a/aws/templates/id/id_user.ftl
+++ b/aws/templates/id/id_user.ftl
@@ -6,6 +6,20 @@
 [#assign componentConfiguration +=
     {
         USER_COMPONENT_TYPE : {
+            "Properties"  : [
+                {
+                    "Type"  : "Description",
+                    "Value" : "A user with permissions on components deployed in the solution"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "application"
+                }
+            ],
             "Attributes" : [
                 {
                     "Name" : ["Fragment", "Container"],

--- a/aws/templates/id/id_user.ftl
+++ b/aws/templates/id/id_user.ftl
@@ -22,57 +22,57 @@
             ],
             "Attributes" : [
                 {
-                    "Name" : ["Fragment", "Container"],
+                    "Names" : ["Fragment", "Container"],
                     "Type" : STRING_TYPE,
                     "Default" : ""
                 },
                 { 
-                    "Name" : "Links",
+                    "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
                 },
                 {
-                    "Name" : "GenerateCredentials",
+                    "Names" : "GenerateCredentials",
                     "Children" : [
                         {
-                            "Name" : "Formats",
+                            "Names" : "Formats",
                             "Type" : ARRAY_OF_STRING_TYPE,
                             "Values" : ["system", "console"],
                             "Default"  : [ "system" ]
                         }
                         {
-                            "Name" : "EncryptionScheme",
+                            "Names" : "EncryptionScheme",
                             "Type" : STRING_TYPE,
                             "Values" : ["base64"],
                             "Default" : ""
                         },
                         {
-                            "Name" : "CharacterLength",
+                            "Names" : "CharacterLength",
                             "Type" : NUMBER_TYPE,
                             "Default" : 20
                         }
                     ]
                 },
                 {
-                "Name" : "Permissions",
+                "Names" : "Permissions",
                 "Children" : [
                         {
-                            "Name" : "Decrypt",
+                            "Names" : "Decrypt",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "AsFile",
+                            "Names" : "AsFile",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "AppData",
+                            "Names" : "AppData",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         },
                         {
-                            "Name" : "AppPublic",
+                            "Names" : "AppPublic",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         }

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -7,65 +7,65 @@
 [#assign
     filterChildrenConfiguration = [
         {
-            "Name" : "Any",
+            "Names" : "Any",
             "Type" : STRING_TYPE
         },
         {
-            "Name" : "Tenant",
+            "Names" : "Tenant",
             "Type" : STRING_TYPE
         },
         {
-            "Name" : "Product",
+            "Names" : "Product",
             "Type" : STRING_TYPE
         },
         {
-            "Name" : "Environment",
+            "Names" : "Environment",
             "Type" : STRING_TYPE
         },
         {
-            "Name" : "Segment",
+            "Names" : "Segment",
             "Type" : STRING_TYPE
         },
         {
-            "Name" : "Tier",
+            "Names" : "Tier",
             "Type" : STRING_TYPE,
             "Mandatory" : true
         },
         {
-            "Name" : "Component",
+            "Names" : "Component",
             "Type" : STRING_TYPE,
             "Mandatory" : true
         },
         {
-            "Name" : ["Function"],
+            "Names" : ["Function"],
             "Type" : STRING_TYPE
         },
         {
-            "Name" : ["Service"],
+            "Names" : ["Service"],
             "Type" : STRING_TYPE
         },
         {
-            "Name" : ["Task"],
+            "Names" : ["Task"],
             "Type" : STRING_TYPE
         },
         {
-            "Name" : ["PortMapping", "Port"],
+            "Names" : ["PortMapping", "Port"],
             "Type" : STRING_TYPE
         },
         {
-            "Name" : ["Mount"],
+            "Names" : ["Mount"],
             "Type" : STRING_TYPE
         },
         {
-            "Name" : ["Platform"],
+            "Names" : ["Platform"],
             "Type" : STRING_TYPE
         },
         {
-            "Name" : "Instance",
-            "Type" : STRING_TYPE
+            "Names" : "Instance",
+            "Types" : STRING_TYPE
         },
         {
-            "Name" : "Version",
+            "Names" : "Version",
             "Type" : STRING_TYPE
         }
     ]
@@ -76,11 +76,11 @@
         filterChildrenConfiguration +
         [
             {
-                "Name" : "Role",
+                "Names" : "Role",
                 "Type" : STRING_TYPE
             },
             {
-                "Name" : "Direction",
+                "Names" : "Direction",
                 "Type" : STRING_TYPE
             },
             {
@@ -93,12 +93,12 @@
 [#assign
     logWatcherChildrenConfiguration = [
         {
-            "Name" : "LogFilter",
+            "Names" : "LogFilter",
             "Type" : STRING_TYPE,
             "Mandatory" : true
         },
         {
-            "Name" : "Links",
+            "Names" : "Links",
             "Subobjects" : true,
             "Children" : linkChildrenConfiguration
         }
@@ -108,7 +108,7 @@
 [#assign
     logMetricChildrenConfiguration = [
         {
-            "Name" : "LogFilter",
+            "Names" : "LogFilter",
             "Type" : STRING_TYPE,
             "Mandatory" : true
         }
@@ -119,72 +119,72 @@
     alertChildrenConfiguration = [
         "Description",
         {
-            "Name" : "Name",
+            "Names" : "Name",
             "Type" : STRING_TYPE,
             "Mandatory" : true
         },
         {
-            "Name" : "Metric",
+            "Names" : "Metric",
             "Children" : [
                 {
-                    "Name" : "Name",
+                    "Names" : "Name",
                     "Type" : STRING_TYPE,
                     "Mandatory" : true
                 },
                 {
-                    "Name" : "Type",
+                    "Names" : "Type",
                     "Type" : STRING_TYPE,
                     "Mandatory" : true
                 }
             ]
         },
         {
-            "Name" : "Threshold",
+            "Names" : "Threshold",
             "Type" : NUMBER_TYPE,
             "Default" : 1
         },
         {
-            "Name" : "Severity",
+            "Names" : "Severity",
             "Type" : STRING_TYPE,
             "Default" : "Info"
         },
         {
-            "Name" : "Namespace",
+            "Names" : "Namespace",
             "Type" : STRING_TYPE,
             "Default" : ""
         },
         {
-            "Name" : "Comparison",
+            "Names" : "Comparison",
             "Type" : STRING_TYPE,
             "Default" : "Threshold"
         },
         {
-            "Name" : "Operator",
+            "Names" : "Operator",
             "Type" : STRING_TYPE,
             "Default" : "GreaterThanOrEqualToThreshold"
         },
         {
-            "Name" : "Time",
+            "Names" : "Time",
             "Type" : NUMBER_TYPE,
             "Default" : 300
         },
         {
-            "Name" : "Periods",
+            "Names" : "Periods",
             "Type" : NUMBER_TYPE,
             "Default" : 1
         },
         {
-            "Name" : "Statistic",
+            "Names" : "Statistic",
             "Type" : STRING_TYPE,
             "Default" : "Sum"
         },
         {
-            "Name" : "ReportOk",
+            "Names" : "ReportOk",
             "Type" : BOOLEAN_TYPE,
             "Default" : false
         },
         {
-            "Name" : "MissingData",
+            "Names" : "MissingData",
             "Type" : STRING_TYPE,
             "Default" : "notBreaching"
         }
@@ -193,30 +193,30 @@
 
 [#assign lbChildConfiguration = [
         {
-            "Name" : "Tier",
+            "Names" : "Tier",
             "Type" : STRING_TYPE,
             "Mandatory" : true
         },
         {
-            "Name" : "Component",
+            "Names" : "Component",
             "Type" : STRING_TYPE,
             "Mandatory" : true
         },
         {
-            "Name" : "LinkName",
+            "Names" : "LinkName",
             "Type" : STRING_TYPE,
             "Default" : "lb"
         },
         {
-            "Name" : "Instance",
+            "Names" : "Instance",
             "Type" : STRING_TYPE
         },
         {
-            "Name" : "Version",
+            "Names" : "Version",
             "Type" : STRING_TYPE
         },
         {
-            "Name" : ["PortMapping", "Port"],
+            "Names" : ["PortMapping", "Port"],
             "Type" : STRING_TYPE,
             "Default" : ""
         }
@@ -225,18 +225,18 @@
 
 [#assign wafChildConfiguration = [
         {
-            "Name" : "IPAddressGroups",
+            "Names" : "IPAddressGroups",
             "Type" : ARRAY_OF_STRING_TYPE,
             "Mandatory" : true
         },
         {
-            "Name" : "Default",
+            "Names" : "Default",
             "Type" : STRING_TYPE,
             "Values" : ["ALLOW", "BLOCK"],
             "Default" : "BLOCK"
         },
         {
-            "Name" : "RuleDefault",
+            "Names" : "RuleDefault",
             "Type" : STRING_TYPE,
             "Values" : ["ALLOW", "BLOCK"],
             "Default" : "ALLOW"
@@ -246,20 +246,20 @@
 
 [#assign settingsChildConfiguration = [
         {
-            "Name" : "AsFile",
+            "Names" : "AsFile",
             "Type" : BOOLEAN_TYPE,
             "Default" : false
         },
         {
-            "Name" : "Json",
+            "Names" : "Json",
             "Children" : [
                 {
-                    "Name" : "Escaped",
+                    "Names" : "Escaped",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : true
                 },
                 {
-                    "Name" : "Prefix",
+                    "Names" : "Prefix",
                     "Type" : STRING_TYPE,
                     "Values" : ["json", ""],
                     "Default" : "json"

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -735,4 +735,3 @@
 [#include "commonApplication.ftl"]
 
 
-

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -84,7 +84,7 @@
                 "Type" : STRING_TYPE
             },
             {
-                "Name" : "Type",
+                "Names" : "Type",
                 "Type" : STRING_TYPE
             }
         ]
@@ -271,43 +271,43 @@
 
 [#assign autoScalingChildConfiguration = [
     {
-        "Name" : "WaitForSignal",
+        "Names" : "WaitForSignal",
         "Type" : BOOLEAN_TYPE,
         "Default" : true,
         "Description" : "Wait for a cfn-signal before treating the instances as alive"
     },
     {
-        "Name" : "MinUpdateInstances",
+        "Names" : "MinUpdateInstances",
         "Type" : NUMBER_TYPE,
         "Default" : 1,
         "Description" : "The minimum number of instances which must be available during an update"
     },
     {
-        "Name" : "ReplaceCluster",
+        "Names" : "ReplaceCluster",
         "Type" : BOOLEAN_TYPE,
         "Default" : false,
         "Description" : "When set to true a brand new cluster will be built, if false the instances in the current cluster will be replaced"
     },
     {
-        "Name" : "UpdatePauseTime",
+        "Names" : "UpdatePauseTime",
         "Type" : STRING_TYPE,
         "Default" : "5M",
         "Description" : "How long to pause betweeen updates of instances"
     },
     {
-        "Name" : "StartupTimeout",
+        "Names" : "StartupTimeout",
         "Type" : STRING_TYPE,
         "Default" : "15M",
         "Description" : "How long to wait for a cfn-signal to be received from a host"
     },
     {
-        "Name" : "AlwaysReplaceOnUpdate",
+        "Names" : "AlwaysReplaceOnUpdate",
         "Type" : BOOLEAN_TYPE,
         "Default" : false,
         "Description" : "Replace instances on every update action" 
     },
     {
-        "Name" : "ActivityCooldown",
+        "Names" : "ActivityCooldown",
         "Type" : NUMBER_TYPE,
         "Default" : 30
     }


### PR DESCRIPTION
- Adds support for generate a markdown based reference document based on the component configuration defined in the *id.ftl files. 
- Adds a properties section to the component configuration objects which adds documentation or immutable attributes for a component 
Properties have the following types
    - Description - A description of the component and what it does  
    - Note - A informational note. Severity can also be set on a Note property to highlight the note appropriately 
    - Providers - The providers that support the component 
    - ComponentLevel - The level ( segment, solution, application, etc ) that the component is deployed with 
- Updated all Attribute name properties to **Names** instead of **Name**.  Single string is still accepted and will be converted to a single item list during processing
- Running createReference.sh requires the npm package remark-cli ( https://www.npmjs.com/package/remark-cli ) Which cleans up the markdown file and makes it happy for mkdocs to process 

To generate a reference you just need the GENERATION_DIR no cmdb is required 
```
${GENERATION_DIR}/createReference.sh -t component
``` 

The file will then be available in `${GENERATION_BASE_DIR}/dist/reference/component-reference.md`

An example of reference is available here 
https://codeontap.readthedocs.io/en/latest/reference/component-reference/ 

More documentation needs to be added but this provides the foundations