### PR TITLE
Context references now use _context

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -38,7 +38,7 @@
             contentIfContent(solution.Fragment, getComponentId(component)) ]
 
         [#assign contextLinks = getLinkTargets(occurrence) ]
-        [#assign context =
+        [#assign _context =
             {
                 "Id" : fragment,
                 "Name" : fragment,
@@ -57,12 +57,12 @@
         [#-- Add in fragment specifics including override of defaults --]
         [#if solution.Fragment?has_content ]
             [#assign fragmentListMode = "model"]
-            [#assign fragmentId = formatFragmentId(context)]
+            [#assign fragmentId = formatFragmentId(_context)]
             [#assign containerId = fragmentId]
             [#include fragmentList?ensure_starts_with("/")]
         [/#if]
 
-        [#assign stageVariables += getFinalEnvironment(occurrence, context).Environment ]
+        [#assign stageVariables += getFinalEnvironment(occurrence, _context).Environment ]
 
         [#assign cognitoPools = {} ]
 
@@ -185,7 +185,7 @@
         [#assign docsS3BucketName       = resources["docs"].Name]
         [#assign docsS3BucketPolicyId   = resources["docspolicy"].Id ]
 
-        [#assign apiPolicyStatements    = context.Policy ]
+        [#assign apiPolicyStatements    = _context.Policy ]
         [#assign apiPolicyAuth          = solution.Authentication?upper_case ]
 
         [#assign apiPolicyCidr          = getGroupCIDRs(solution.IPAddressGroups) ]

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -84,7 +84,7 @@
             contentIfContent(solution.Fragment, getComponentId(component)) ]
 
         [#assign contextLinks = getLinkTargets(occurrence, links) ]
-        [#assign context =
+        [#assign _context =
             {
                 "Id" : fragment,
                 "Name" : fragment,
@@ -105,15 +105,15 @@
 
         [#-- Add in fragment specifics including override of defaults --]
         [#assign fragmentListMode = "model"]
-        [#assign fragmentId = formatFragmentId(context)]
+        [#assign fragmentId = formatFragmentId(_context)]
         [#assign containerId = fragmentId]
         [#include fragmentList?ensure_starts_with("/")]
 
-        [#assign environmentVariables += getFinalEnvironment(occurrence, context).Environment ]
+        [#assign environmentVariables += getFinalEnvironment(occurrence, _context).Environment ]
 
-        [#assign configSets +=  
+        [#assign configSets +=
             getInitConfigEnvFacts(environmentVariables, false) +
-            getInitConfigDirsFiles(context.Files, context.Directories) ]
+            getInitConfigDirsFiles(_context.Files, _context.Directories) ]
 
         [#list bootstrapProfile.BootStraps as bootstrapName ]
             [#assign bootstrap = bootstraps[bootstrapName]]
@@ -141,7 +141,7 @@
                             s3WritePermission(operationsBucket, "Backups") +
                             cwLogsProducePermission(computeClusterLogGroupName),
                             "basic")
-                    ] + 
+                    ] +
                     targetGroupPermission?then(
                         [
                             getPolicyDocument(
@@ -151,10 +151,10 @@
                         []
                     ) +
                     arrayIfContent(
-                        [getPolicyDocument(context.Policy, "fragment")],
-                        context.Policy) 
+                        [getPolicyDocument(_context.Policy, "fragment")],
+                        _context.Policy)
                 managedArns=
-                    context.ManagedPolicy
+                    _context.ManagedPolicy
             /]
 
         [/#if]
@@ -181,7 +181,7 @@
                     [#assign targetGroupPermission = true]
                     [#assign destinationPort = linkTargetAttributes["DESTINATION_PORT"]]
 
-                    [#switch linkTargetAttributes["ENGINE"] ] 
+                    [#switch linkTargetAttributes["ENGINE"] ]
                         [#case "application" ]
                         [#case "classic"]
                             [#assign sourceSecurityGroupIds += [ linkTargetResources["sg"].Id ] ]
@@ -216,11 +216,11 @@
                     [#break]
             [/#switch]
 
-            [#if deploymentSubsetRequired(COMPUTECLUSTER_COMPONENT_TYPE, true)] 
+            [#if deploymentSubsetRequired(COMPUTECLUSTER_COMPONENT_TYPE, true)]
 
                 [#assign securityGroupCIDRs = getGroupCIDRs(sourceIPAddressGroups)]
                 [#list securityGroupCIDRs as cidr ]
-                    
+
                     [@createSecurityGroupIngress
                         mode=listMode
                         id=
@@ -256,7 +256,7 @@
         [#assign configSets += getInitConfigScriptsDeployment(scriptsFile, environmentVariables, solution.UseInitAsService, false)]
 
         [#if deploymentSubsetRequired("lg", true) && isPartOfCurrentDeploymentUnit(computeClusterLogGroupId) ]
-            [@createLogGroup 
+            [@createLogGroup
                 mode=listMode
                 id=computeClusterLogGroupId
                 name=computeClusterLogGroupName /]

--- a/aws/templates/application/application_datapipeline.ftl
+++ b/aws/templates/application/application_datapipeline.ftl
@@ -60,7 +60,7 @@
         [#-- Add in container specifics including override of defaults --]
         [#-- Allows for explicit policy or managed ARN's to be assigned to the user --]
         [#assign contextLinks = getLinkTargets(occurrence) ]
-        [#assign context =
+        [#assign _context =
             {
                 "Id" : fragment,
                 "Name" : fragment,
@@ -77,12 +77,12 @@
         
         [#if solution.Fragment?has_content ]
             [#assign fragmentListMode = "model"]
-            [#assign fragmentId = formatFragmentId(context)]
+            [#assign fragmentId = formatFragmentId(_context)]
             [#include fragmentList?ensure_starts_with("/")]
         [/#if]
 
-        [#assign context += getFinalEnvironment(occurrence, context) ]
-        [#assign parameterValues += context.Environment ]
+        [#assign _context += getFinalEnvironment(occurrence, _context) ]
+        [#assign parameterValues += _context.Environment ]
 
         [#assign myParameterValues = {}]
         [#list parameterValues as key,value ]
@@ -160,18 +160,18 @@
                     outputs={}
                 /]
 
-                [#if context.Policy?has_content]
+                [#if _context.Policy?has_content]
                     [#assign policyId = formatDependentPolicyId(pipelineId)]
                     [@createPolicy
                         mode=listMode
                         id=policyId
-                        name=context.Name
-                        statements=context.Policy
+                        name=_context.Name
+                        statements=_context.Policy
                         roles=resourceRoleId
                     /]
                 [/#if]
 
-                [#assign linkPolicies = getLinkTargetsOutboundRoles(context.Links) ]
+                [#assign linkPolicies = getLinkTargetsOutboundRoles(_context.Links) ]
 
                 [#if linkPolicies?has_content]
                     [#assign policyId = formatDependentPolicyId(pipelineId, "links")]

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -23,7 +23,7 @@
                 contentIfContent(solution.Fragment, getComponentId(core.Component)) ]
 
             [#assign contextLinks = getLinkTargets(fn) ]
-            [#assign context =
+            [#assign _context =
                 {
                     "Id" : fragment,
                     "Name" : fragment,
@@ -49,7 +49,7 @@
             ]
 
             [#if deploymentSubsetRequired("lambda", true)]
-                [#list context.Links as linkName,linkTarget]
+                [#list _context.Links as linkName,linkTarget]
 
                     [#assign linkTargetCore = linkTarget.Core ]
                     [#assign linkTargetConfiguration = linkTarget.Configuration ]
@@ -107,13 +107,13 @@
 
             [#-- Add in fragment specifics including override of defaults --]
             [#assign fragmentListMode = "model"]
-            [#assign fragmentId = formatFragmentId(context)]
+            [#assign fragmentId = formatFragmentId(_context)]
             [#assign containerId = fragmentId]
             [#include fragmentList?ensure_starts_with("/")]
 
-            [#assign finalEnvironment = getFinalEnvironment(fn, context, solution.Environment) ]
-            [#assign finalAsFileEnvironment = getFinalEnvironment(fn, context, solution.Environment + {"AsFile" : false}) ]
-            [#assign context += finalEnvironment ]
+            [#assign finalEnvironment = getFinalEnvironment(fn, _context, solution.Environment) ]
+            [#assign finalAsFileEnvironment = getFinalEnvironment(fn, _context, solution.Environment + {"AsFile" : false}) ]
+            [#assign _context += finalEnvironment ]
 
             [#assign roleId = formatDependentRoleId(fnId)]
             [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(roleId)]
@@ -122,7 +122,7 @@
                             ["arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"],
                             ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
                         ) +
-                        context.ManagedPolicy ]
+                        _context.ManagedPolicy ]
 
                 [#-- Create a role under which the function will run and attach required policies --]
                 [#-- The role is mandatory though there may be no policies attached to it --]
@@ -134,18 +134,18 @@
 
                 /]
 
-                [#if context.Policy?has_content]
+                [#if _context.Policy?has_content]
                     [#assign policyId = formatDependentPolicyId(fnId)]
                     [@createPolicy
                         mode=listMode
                         id=policyId
-                        name=context.Name
-                        statements=context.Policy
+                        name=_context.Name
+                        statements=_context.Policy
                         roles=roleId
                     /]
                 [/#if]
 
-                [#assign linkPolicies = getLinkTargetsOutboundRoles(context.Links) ]
+                [#assign linkPolicies = getLinkTargetsOutboundRoles(_context.Links) ]
 
                 [#if linkPolicies?has_content]
                     [#assign policyId = formatDependentPolicyId(fnId, "links")]
@@ -200,7 +200,7 @@
                 [@createLambdaFunction
                     mode=listMode
                     id=fnId
-                    settings=context +
+                    settings=_context +
                         {
                             "Handler" : solution.Handler,
                             "RunTime" : solution.RunTime,

--- a/aws/templates/application/application_spa.ftl
+++ b/aws/templates/application/application_spa.ftl
@@ -17,7 +17,7 @@
             contentIfContent(solution.Fragment, getComponentId(component)) ]
 
         [#assign contextLinks = getLinkTargets(occurrence) ]
-        [#assign context =
+        [#assign _context =
             {
                 "Id" : fragment,
                 "Name" : fragment,
@@ -34,16 +34,16 @@
 
         [#-- Add in container specifics including override of defaults --]
         [#assign fragmentListMode = "model"]
-        [#assign fragmentId = formatFragmentId(context)]
+        [#assign fragmentId = formatFragmentId(_context)]
         [#assign containerId = fragmentId]
         [#include fragmentList?ensure_starts_with("/")]
 
-        [#assign context += getFinalEnvironment(occurrence, context) ]
+        [#assign _context += getFinalEnvironment(occurrence, _context) ]
 
         [#if deploymentSubsetRequired("config", false)]
             [@cfConfig
                 mode=listMode
-                content=context.Environment
+                content=_context.Environment
             /]
         [/#if]
         [#if deploymentSubsetRequired("prologue", false)]

--- a/aws/templates/application/application_user.ftl
+++ b/aws/templates/application/application_user.ftl
@@ -44,7 +44,7 @@
         [#-- Add in container specifics including override of defaults --]
         [#-- Allows for explicit policy or managed ARN's to be assigned to the user --]
         [#assign contextLinks = getLinkTargets(occurrence) ]
-        [#assign context =
+        [#assign _context =
             {
                 "Id" : fragment,
                 "Name" : fragment,
@@ -62,25 +62,25 @@
         
         [#if solution.Fragment?has_content ]
             [#assign fragmentListMode = "model"]
-            [#assign fragmentId = formatFragmentId(context)]
+            [#assign fragmentId = formatFragmentId(_context)]
             [#assign containerId = fragmentId]
             [#include fragmentList?ensure_starts_with("/")]
         [/#if]
 
         [#if deploymentSubsetRequired(USER_COMPONENT_TYPE, true)]
 
-            [#if context.Policy?has_content]
+            [#if _context.Policy?has_content]
                 [#assign policyId = formatDependentPolicyId(userId)]
                 [@createPolicy
                     mode=listMode
                     id=policyId
-                    name=context.Name
-                    statements=context.Policy
+                    name=_context.Name
+                    statements=_context.Policy
                     users=userId
                 /]
             [/#if]
 
-            [#assign linkPolicies = getLinkTargetsOutboundRoles(context.Links) ]
+            [#assign linkPolicies = getLinkTargetsOutboundRoles(_context.Links) ]
 
             [#if linkPolicies?has_content]
                 [#assign policyId = formatDependentPolicyId(userId, "links")]
@@ -103,7 +103,7 @@
                     } + 
                     attributeIfContent(
                         "ManagedPolicyArns",
-                        context.ManagedPolicy![]
+                        _context.ManagedPolicy![]
                     ) 
                 outputs=USER_OUTPUT_MAPPINGS
             /]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -67,7 +67,7 @@
                 )
             ) ]
     [#else]
-        [#return context.Environment["APPDATA_PREFIX"] ]
+        [#return _context.Environment["APPDATA_PREFIX"] ]
     [/#if]
 [/#function]
 
@@ -92,7 +92,7 @@
                     )
                 ) ]
         [#else]
-            [#return context.Environment["APPDATA_PUBLIC_PREFIX"] ]
+            [#return _context.Environment["APPDATA_PUBLIC_PREFIX"] ]
         [/#if]
     [#else]
         [#return ""]
@@ -103,7 +103,7 @@
     [#if occurrence?has_content ]
         [#return formatRelativePath("backups", occurrence.Core.FullRelativePath) ]
     [#else]
-        [#return context.Environment["BACKUPS_PREFIX"] ]
+        [#return _context.Environment["BACKUPS_PREFIX"] ]
     [/#if]
 [/#function]
 
@@ -115,7 +115,7 @@
     [#if occurrence?has_content ]
         [#return getSettingsFilePrefix(occurrence) ]
     [#else]
-        [#return context.Environment["SETTINGS_PREFIX"] ]
+        [#return _context.Environment["SETTINGS_PREFIX"] ]
     [/#if]
 [/#function]
 
@@ -123,7 +123,7 @@
     [#if occurrence?has_content]
         [#return getSettingsFilePrefix(occurrence) ]
     [#else]
-        [#return context.Environment["SETTINGS_PREFIX"] ]
+        [#return _context.Environment["SETTINGS_PREFIX"] ]
     [/#if]
 [/#function]
 
@@ -408,7 +408,7 @@ behaviour.
                     [@cfException
                         mode=listMode
                         description="Attribute must have a \"Name\" attribute"
-                        context= attribute
+                        context=attribute
                     /]
                 [/#if]
                 [#local normalisedAttribute =

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -42,7 +42,7 @@
 
 [#macro Attributes name="" image="" version="" essential=true]
     [#if (fragmentListMode!"") == "model"]
-        [#assign context +=
+        [#assign _context +=
             {
                 "Essential" : essential
             } +
@@ -64,12 +64,12 @@
 
 [#macro Variable name value]
     [#if (fragmentListMode!"") == "model"]
-        [#assign context = addVariableToContext(context, name, value) ]
+        [#assign _context = addVariableToContext(_context, name, value) ]
     [/#if]
 [/#macro]
 
 [#function getLinkResourceId link alias]
-    [#return (context.Links[link].State.Resources[alias].Id)!"" ]
+    [#return (_context.Links[link].State.Resources[alias].Id)!"" ]
 [/#function]
 
 [#function addLinkVariablesToContext context name link attributes rawName=false ignoreIfNotDefined=false]
@@ -106,9 +106,9 @@
 
 [#macro Link name link="" attributes=[] rawName=false ignoreIfNotDefined=false]
     [#if (fragmentListMode!"") == "model"]
-        [#assign context =
+        [#assign _context =
             addLinkVariablesToContext(
-                context,
+                _context,
                 name,
                 contentIfContent(link, name),
                 attributes,
@@ -119,19 +119,19 @@
 
 [#macro DefaultLinkVariables enabled=true ]
     [#if (fragmentListMode!"") == "model"]
-        [#assign context += { "DefaultLinkVariables" : enabled } ]
+        [#assign _context += { "DefaultLinkVariables" : enabled } ]
     [/#if]
 [/#macro]
 
 [#macro DefaultCoreVariables enabled=true ]
     [#if (fragmentListMode!"") == "model"]
-        [#assign context += { "DefaultCoreVariables" : enabled } ]
+        [#assign _context += { "DefaultCoreVariables" : enabled } ]
     [/#if]
 [/#macro]
 
 [#macro DefaultEnvironmentVariables enabled=true ]
     [#if (fragmentListMode!"") == "model"]
-        [#assign context += { "DefaultEnvironmentVariables" : enabled } ]
+        [#assign _context += { "DefaultEnvironmentVariables" : enabled } ]
     [/#if]
 [/#macro]
 
@@ -140,7 +140,7 @@
         [#local name = contentIfContent(value.Setting!"", key) ]
 
         [#if (value.IgnoreIfMissing!false) &&
-            (!((context.DefaultEnvironment[formatSettingName(name)])??)) ]
+            (!((_context.DefaultEnvironment[formatSettingName(name)])??)) ]
                 [#return valueIfTrue(false, asBoolean, "") ]
         [/#if]
     [#else]
@@ -154,7 +154,7 @@
         valueIfTrue(
             true,
             asBoolean,
-            context.DefaultEnvironment[formatSettingName(name)]!
+            _context.DefaultEnvironment[formatSettingName(name)]!
                 "COTException: Variable " + name + " not found"
         ) ]
 [/#function]
@@ -193,9 +193,9 @@
 
 [#macro Host name value]
     [#if (fragmentListMode!"") == "model"]
-        [#assign context +=
+        [#assign _context +=
             {
-                "Hosts" : (context.Hosts!{}) + { name : value }
+                "Hosts" : (_context.Hosts!{}) + { name : value }
             }
         ]
     [/#if]
@@ -203,9 +203,9 @@
 
 [#macro Hosts hosts]
     [#if ((fragmentListMode!"") == "model") && hosts?is_hash]
-        [#assign context +=
+        [#assign _context +=
             {
-                "Hosts" : (context.Hosts!{}) + hosts
+                "Hosts" : (_context.Hosts!{}) + hosts
             }
         ]
     [/#if]
@@ -213,7 +213,7 @@
 
 [#macro WorkingDirectory workingDirectory ]
         [#if ((fragmentListMode!"") == "model")]
-        [#assign context +=
+        [#assign _context +=
             {
                 "WorkingDirectory" : workingDirectory
             }
@@ -223,10 +223,10 @@
 
 [#macro Volume name containerPath hostPath="" readOnly=false]
     [#if (fragmentListMode!"") == "model"]
-        [#assign context +=
+        [#assign _context +=
             {
                 "Volumes" :
-                    (context.Volumes!{}) +
+                    (_context.Volumes!{}) +
                     {
                         name : {
                             "ContainerPath" : containerPath,
@@ -241,9 +241,9 @@
 
 [#macro Volumes volumes]
     [#if ((fragmentListMode!"") == "model") && volumes?is_hash]
-        [#assign context +=
+        [#assign _context +=
             {
-                "Volumes" : (context.Volumes!{}) + volumes
+                "Volumes" : (_context.Volumes!{}) + volumes
             }
         ]
     [/#if]
@@ -251,7 +251,7 @@
 
 [#macro EntryPoint entrypoint ]
     [#if ((fragmentListMode!"") == "model") ]
-        [#assign context +=
+        [#assign _context +=
             {
                 "EntryPoint" : entrypoint?is_string?then(
                     entrypoint?split(" "),
@@ -264,7 +264,7 @@
 
 [#macro Command command ]
     [#if ((fragmentListMode!"") == "model") ]
-        [#assign context +=
+        [#assign _context +=
             {
                 "Command" : command?is_string?then(
                     [ command ],
@@ -277,9 +277,9 @@
 
 [#macro Policy statements...]
     [#if (fragmentListMode!"") == "model"]
-        [#assign context +=
+        [#assign _context +=
             {
-                "Policy" : (context.Policy![]) + asFlattenedArray(statements)
+                "Policy" : (_context.Policy![]) + asFlattenedArray(statements)
             }
         ]
     [/#if]
@@ -287,9 +287,9 @@
 
 [#macro ManagedPolicy arns...]
     [#if (fragmentListMode!"") == "model"]
-        [#assign context +=
+        [#assign _context +=
             {
-                "ManagedPolicy" : (context.ManagedPolicy![]) + asFlattenedArray(arns)
+                "ManagedPolicy" : (_context.ManagedPolicy![]) + asFlattenedArray(arns)
             }
         ]
     [/#if]
@@ -298,9 +298,9 @@
 [#-- Compute instance fragment macros --]
 [#macro File path mode="644" owner="root" group="root" content=[] ]
     [#if (fragmentListMode!"") == "model"]
-        [#assign context +=
+        [#assign _context +=
             {
-                "Files" : (context.Files!{}) + {
+                "Files" : (_context.Files!{}) + {
                     path : {
                         "mode" : mode,
                         "owner" : owner,
@@ -314,9 +314,9 @@
 
 [#macro Directory path mode="755" owner="root" group="root" ]
     [#if (fragmentListMode!"") == "model"]
-        [#assign context +=
+        [#assign _context +=
             {
-                "Directories" : (context.Directories!{}) + {
+                "Directories" : (_context.Directories!{}) + {
                     path : {
                         "mode" : mode,
                         "owner" : owner,
@@ -545,7 +545,7 @@
             )]
 
         [#assign contextLinks = getLinkTargets(task, containerLinks) ]
-        [#assign context =
+        [#assign _context =
             {
                 "Id" : getContainerId(container),
                 "Name" : getContainerName(container),
@@ -602,13 +602,13 @@
 
         [#-- Add in fragment specifics including override of defaults --]
         [#assign fragmentListMode = "model"]
-        [#assign fragmentId = formatFragmentId(context)]
+        [#assign fragmentId = formatFragmentId(_context)]
         [#assign containerId = fragmentId]
         [#include fragmentList]
 
-        [#assign context += getFinalEnvironment(task, context) ]
+        [#assign _context += getFinalEnvironment(task, _context) ]
 
-        [#local containers += [context] ]
+        [#local containers += [_context] ]
     [/#list]
 
     [#return containers]

--- a/aws/templates/createSwaggerExtensions.ftl
+++ b/aws/templates/createSwaggerExtensions.ftl
@@ -4,14 +4,14 @@
 
 [#assign swaggerObject = swagger?eval ]
 [#assign integrationsObject = integrations?eval ]
-[#assign context =
+[#assign _context =
     {
         "Account" : account,
         "Region" : region
     } ]
 
 [#-- Determine the Cognito User Pools --]
-[#assign context += {"CognitoPools" : getLegacyCognitoPools(context, integrationsObject)} ]
+[#assign _context += {"CognitoPools" : getLegacyCognitoPools(context, integrationsObject)} ]
 
-[@toJSON extendSwaggerDefinition(swaggerObject, integrationsObject, context) /]
+[@toJSON extendSwaggerDefinition(swaggerObject, integrationsObject, _context) /]
 

--- a/aws/templates/fragment/fragment_codeontap.ftl
+++ b/aws/templates/fragment/fragment_codeontap.ftl
@@ -1,7 +1,7 @@
 [#case "codeontap"]
 [#case "_codeontap"]
 
-    [#assign settings = context.DefaultEnvironment]
+    [#assign settings = _context.DefaultEnvironment]
 
     [#assign dockerStageDir = settings["DOCKER_STAGE_DIR"]!"/tmp" ]
     [#assign dockerHostDaemon = settings["DOCKER_HOST_DAEMON"]!"/var/run/docker.sock" ]

--- a/aws/templates/fragment/fragment_jenkins.ftl
+++ b/aws/templates/fragment/fragment_jenkins.ftl
@@ -3,7 +3,7 @@
 
     [@Attributes image="jenkins-master" /]
    
-    [#assign settings = context.DefaultEnvironment]
+    [#assign settings = _context.DefaultEnvironment]
 
     [@Settings {
             "ECS_ARN" :  getExistingReference(ecsId),

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -72,7 +72,7 @@
             contentIfContent(solution.Fragment, getComponentId(component)) ]
 
         [#assign contextLinks = getLinkTargets(occurrence, links) ]
-        [#assign context =
+        [#assign _context =
             {
                 "Id" : fragment,
                 "Name" : fragment,
@@ -93,14 +93,14 @@
 
         [#-- Add in fragment specifics including override of defaults --]
         [#assign fragmentListMode = "model"]
-        [#assign fragmentId = formatFragmentId(context)]
+        [#assign fragmentId = formatFragmentId(_context)]
         [#include fragmentList?ensure_starts_with("/")]
 
-        [#assign environmentVariables += getFinalEnvironment(occurrence, context).Environment ]
+        [#assign environmentVariables += getFinalEnvironment(occurrence, _context).Environment ]
 
         [#assign configSets +=  
             getInitConfigEnvFacts(environmentVariables, false) +
-            getInitConfigDirsFiles(context.Files, context.Directories) ]
+            getInitConfigDirsFiles(_context.Files, _context.Directories) ]
 
         [#list bootstrapProfile.BootStraps as bootstrapName ]
             [#assign bootstrap = bootstraps[bootstrapName]]
@@ -206,14 +206,14 @@
         [#if deploymentSubsetRequired("iam", true) &&
                 isPartOfCurrentDeploymentUnit(ec2RoleId)]
 
-            [#assign linkPolicies = getLinkTargetsOutboundRoles(context.Links) ]
+            [#assign linkPolicies = getLinkTargetsOutboundRoles(_context.Links) ]
 
             [@createRole
                 mode=listMode
                 id=ec2RoleId
                 trustedServices=["ec2.amazonaws.com" ]
                 managedArns=
-                    context.ManagedPolicy
+                    _context.ManagedPolicy
                 policies=
                     [
                         getPolicyDocument(
@@ -236,8 +236,8 @@
                         [getPolicyDocument(linkPolicies, "links")],
                         linkPolicies) +
                     arrayIfContent(
-                        [getPolicyDocument(context.Policy, "fragment")],
-                        context.Policy)
+                        [getPolicyDocument(_context.Policy, "fragment")],
+                        _context.Policy)
             /]
         [/#if]
 

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -44,7 +44,7 @@
             contentIfContent(solution.Fragment, getComponentId(component)) ]
 
         [#assign contextLinks = getLinkTargets(occurrence) ]
-        [#assign context =
+        [#assign _context =
             {
                 "Id" : fragment,
                 "Name" : fragment,
@@ -65,14 +65,14 @@
 
         [#-- Add in fragment specifics including override of defaults --]
         [#assign fragmentListMode = "model"]
-        [#assign fragmentId = formatFragmentId(context)]
+        [#assign fragmentId = formatFragmentId(_context)]
         [#include fragmentList?ensure_starts_with("/")]
 
-        [#assign environmentVariables += getFinalEnvironment(occurrence, context).Environment ]
+        [#assign environmentVariables += getFinalEnvironment(occurrence, _context).Environment ]
 
         [#assign configSets += 
             getInitConfigEnvFacts(environmentVariables, false) +
-            getInitConfigDirsFiles(context.Files, context.Directories) ]
+            getInitConfigDirsFiles(_context.Files, _context.Directories) ]
         
         [#list bootstrapProfile.BootStraps as bootstrapName ]
             [#assign bootstrap = bootstraps[bootstrapName]]
@@ -82,7 +82,7 @@
             
         [#if deploymentSubsetRequired("iam", true) &&
                 isPartOfCurrentDeploymentUnit(ecsRoleId)]
-            [#assign linkPolicies = getLinkTargetsOutboundRoles(context.Links) ]
+            [#assign linkPolicies = getLinkTargetsOutboundRoles(_context.Links) ]
 
             [@createRole
                 mode=listMode
@@ -90,7 +90,7 @@
                 trustedServices=["ec2.amazonaws.com" ]
                 managedArns=
                     ["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"] +
-                    context.ManagedPolicy
+                    _context.ManagedPolicy
                 policies=
                     [
                         getPolicyDocument(
@@ -108,8 +108,8 @@
                             "docker")
                     ] +
                     arrayIfContent(
-                        [getPolicyDocument(context.Policy, "fragment")],
-                        context.Policy) +
+                        [getPolicyDocument(_context.Policy, "fragment")],
+                        _context.Policy) +
                     arrayIfContent(
                         [getPolicyDocument(linkPolicies, "links")],
                         linkPolicies)
@@ -148,7 +148,7 @@
 
         [#if deploymentSubsetRequired("ecs", true)]
 
-            [#list context.Links as linkId,linkTarget]
+            [#list _context.Links as linkId,linkTarget]
                 [#assign linkTargetCore = linkTarget.Core ]
                 [#assign linkTargetConfiguration = linkTarget.Configuration ]
                 [#assign linkTargetResources = linkTarget.State.Resources ]


### PR DESCRIPTION
Align context references to the standard of identifying framework
related values by starting them with an underscore.