### PR TITLE
Add control over the ordering of host name parts

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1428,7 +1428,7 @@
       "Product": false,
       "Segment": false,
       "Tier": false
-    }
+    },
     "HostParts" : ["Host", "Tier", "Component", "Instance", "Version", "Segment", "Environment", "Product"],
     "Qualifiers": {
       "prod": {

--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1426,14 +1426,10 @@
     "Wildcard": true,
     "IncludeInHost": {
       "Product": false,
-      "Environment": true,
       "Segment": false,
-      "Tier": false,
-      "Component": true,
-      "Instance": true,
-      "Version": true,
-      "Host": true
-    },
+      "Tier": false
+    }
+    "HostParts" : ["Host", "Tier", "Component", "Instance", "Version", "Segment", "Environment", "Product"],
     "Qualifiers": {
       "prod": {
         "IncludeInHost": {

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1847,6 +1847,7 @@ behaviour.
                     "Name" : "Host",
                     "Default" : ""
                 },
+                "HostParts",
                 {
                     "Name" : "IncludeInHost",
                     "Children" : [
@@ -1882,22 +1883,45 @@ behaviour.
 [#function getHostName certificateObject occurrence]
 
     [#local core = occurrence.Core ]
-    [#local includes = certificateObject.IncludeInHost ]
+    [#local includes = certificateObject.IncludeInHost!{} ]
+    [#local hostParts = certificateObject.HostParts ]
+    [#local parts = [] ]
 
+    [#list hostParts as part]
+        [#if includes[part]!true]
+            [#switch part]
+                [#case "Host"]
+                    [#local parts += [certificateObject.Host!""] ]
+                    [#break]
+                [#case "Tier"]
+                    [#local parts += [getTierName(core.Tier)] ]
+                    [#break]
+                [#case "Component"]
+                    [#local parts += [getComponentName(core.Component)] ]
+                    [#break]
+                [#case "Instance"]
+                    [#local parts += [core.Instance.Name!""] ]
+                    [#break]
+                [#case "Version"]
+                    [#local parts += [core.Version.Name!""] ]
+                    [#break]
+                [#case "Segment"]
+                    [#local parts += [segmentName!""] ]
+                    [#break]
+                [#case "Environment"]
+                    [#local parts += [environmentName!""] ]
+                    [#break]
+                [#case "Product"]
+                    [#local parts += [productName!""] ]
+                    [#break]
+            [/#switch]
+        [/#if]
+    [/#list]
     [#return
         valueIfTrue(
             certificateObject.Host,
             certificateObject.Host?has_content && (!(includes.Host)),
-            formatName(
-                valueIfTrue(certificateObject.Host, includes.Host),
-                valueIfTrue(getTierName(core.Tier), includes.Tier),
-                valueIfTrue(getComponentName(core.Component), includes.Component),
-                valueIfTrue(core.Instance.Name!"", includes.Instance),
-                valueIfTrue(core.Version.Name!"", includes.Version),
-                valueIfTrue(segmentName!"", includes.Segment),
-                valueIfTrue(environmentName!"", includes.Environment),
-                valueIfTrue(productName!"", includes.Product)
-            )
+            formatName(parts)
         )
     ]
 ]


### PR DESCRIPTION
A certificate or certificate behaviour object can now have a HostParts
array, listing the parts to be considered for a host name.

This list is used to drive the candidate parts considered, so anything
not in this list will not be included.

In addition, the booleans in IncludeInHost continue to apply for those
parts in the HostParts array. However, if the boolean is not present, is
it considered to have a value of true.

It is thus possible to override the host structure either via the
HostParts array or via controlling the flags for each part. By default,
the flags are used to not provide the Environment in the host name in
production environments.