### PR TITLE
Add support for usage plans

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -1,6 +1,6 @@
 [#-- API Gateway --]
 
-[#if (componentType == "apigateway")]
+[#if (componentType == APIGATEWAY_COMPONENT_TYPE)]
     [#list requiredOccurrences(
             getOccurrences(tier, component),
             deploymentUnit) as occurrence]
@@ -436,21 +436,16 @@
                         wafAclId,
                         wafPresent)
                 /]
-                [@cfResource
+                [@createAPIUsagePlan
                     mode=listMode
                     id=usagePlanId
-                    type="AWS::ApiGateway::UsagePlan"
-                    properties=
+                    name=usagePlanName
+                    stages=[
                         {
-                            "ApiStages" : [
-                                {
-                                  "ApiId" : getReference(apiId),
-                                  "Stage" : stageName
-                                }
-                            ],
-                            "UsagePlanName" : usagePlanName
+                          "ApiId" : getReference(apiId),
+                          "Stage" : stageName
                         }
-                    outputs={}
+                    ]
                     dependencies=stageId
                 /]
 

--- a/aws/templates/application/application_apiusageplan.ftl
+++ b/aws/templates/application/application_apiusageplan.ftl
@@ -1,0 +1,61 @@
+[#-- API Gateway --]
+
+[#if (componentType == APIGATEWAY_USAGEPLAN_COMPONENT_TYPE)]
+    [#list requiredOccurrences(
+            getOccurrences(tier, component),
+            deploymentUnit) as occurrence]
+
+        [@cfDebug listMode occurrence false /]
+
+        [#assign core = occurrence.Core ]
+        [#assign solution = occurrence.Configuration.Solution ]
+        [#assign resources = occurrence.State.Resources ]
+        [#assign attributes = occurrence.State.Attributes ]
+        [#assign roles = occurrence.State.Roles]
+
+        [#assign planId   = resources["apiusageplan"].Id]
+        [#assign planName = resources["apiusageplan"].Name]
+
+        [#assign stages = [] ]
+
+        [#list solution.Links?values as link]
+            [#if link?is_hash]
+                [#assign linkTarget = getLinkTarget(occurrence, link) ]
+
+                [@cfDebug listMode linkTarget false /]
+
+                [#if !linkTarget?has_content]
+                    [#continue]
+                [/#if]
+
+                [#assign linkTargetCore = linkTarget.Core ]
+                [#assign linkTargetConfiguration = linkTarget.Configuration ]
+                [#assign linkTargetResources = linkTarget.State.Resources ]
+                [#assign linkTargetAttributes = linkTarget.State.Attributes ]
+
+                [#switch linkTargetCore.Type]
+                    [#case APIGATEWAY_COMPONENT_TYPE ]
+                        [#assign stages +=
+                            [
+                                {
+                                    "ApiId" : getReference(linkTargetResources["apigateway"].Id),
+                                    "Stage" : linkTargetResources["apistage"].Name
+                                }
+                            ]
+                        ]
+                        [#break]
+                [/#switch]
+            [/#if]
+        [/#list]
+
+        [#if deploymentSubsetRequired("apiusageplan", true)]
+            [@createAPIUsagePlan
+                mode=listMode
+                id=planId
+                name=planName
+                stages=stages
+            /]
+        [/#if]
+
+    [/#list]
+[/#if]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -776,8 +776,12 @@ behaviour.
                 [#local result = getLBPortState(occurrence, parentOccurrence)]
                 [#break]
 
-            [#case "apigateway"]
+            [#case APIGATEWAY_COMPONENT_TYPE]
                 [#local result = getAPIGatewayState(occurrence)]
+                [#break]
+
+            [#case APIGATEWAY_USAGEPLAN_COMPONENT_TYPE]
+                [#local result = getAPIGatewayUsagePlanState(occurrence)]
                 [#break]
 
             [#case "cache"]

--- a/aws/templates/id/id_user.ftl
+++ b/aws/templates/id/id_user.ftl
@@ -86,6 +86,11 @@
                     "Id" : userId,
                     "Name" : core.ShortFullName,
                     "Type" : AWS_IAM_USER_RESOURCE_TYPE
+                },
+                "apikey" : {
+                    "Id" : formatDependentResourceId(AWS_APIGATEWAY_APIKEY_RESOURCE_TYPE, userId),
+                    "Name" : core.ShortFullName,
+                    "Type" : AWS_APIGATEWAY_APIKEY_RESOURCE_TYPE
                 }
             },
             "Attributes" : {

--- a/aws/templates/resource/resource_apigateway.ftl
+++ b/aws/templates/resource/resource_apigateway.ftl
@@ -10,9 +10,25 @@
         }
     }
 ]
+[#assign APIGATEWAY_USAGEPLAN_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+[#assign APIGATEWAY_APIKEY_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
 [#assign outputMappings +=
     {
-        AWS_APIGATEWAY_RESOURCE_TYPE : APIGATEWAY_OUTPUT_MAPPINGS
+        AWS_APIGATEWAY_RESOURCE_TYPE : APIGATEWAY_OUTPUT_MAPPINGS,
+        AWS_APIGATEWAY_USAGEPLAN_RESOURCE_TYPE : APIGATEWAY_USAGEPLAN_OUTPUT_MAPPINGS,
+        AWS_APIGATEWAY_APIKEY_RESOURCE_TYPE : APIGATEWAY_APIKEY_OUTPUT_MAPPINGS
     }
 ]
 
@@ -28,3 +44,52 @@
         )
     ]
 [/#function]
+
+[#macro createAPIUsagePlan mode id name stages=[] dependencies="" ]
+    [@cfResource
+        mode=mode
+        id=id
+        type="AWS::ApiGateway::UsagePlan"
+        properties=
+            {
+                "ApiStages" : stages,
+                "UsagePlanName" : name
+            }
+        outputs=APIGATEWAY_USAGEPLAN_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]
+
+[#macro createAPIKey mode id name enabled=true distinctId=false description="" dependencies="" ]
+    [@cfResource
+        mode=mode
+        id=id
+        type="AWS::ApiGateway::ApiKey"
+        properties=
+            {
+                "Enabled" : enabled,
+                "GenerateDistinctId" : distinctId,
+                "Name" : name
+            } +
+            attributeIfContent("Description", description)
+        outputs=APIGATEWAY_APIKEY_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]
+
+[#macro createAPIUsagePlanMember mode id planId apikeyId dependencies="" ]
+    [@cfResource
+        mode=mode
+        id=id
+        type="AWS::ApiGateway::UsagePlanKey"
+        properties=
+            {
+                "KeyId" : getReference(apikeyId),
+                "KeyType" : "API_KEY",
+                "UsagePlanId" : getReference(planId)
+            }
+        outputs={}
+        dependencies=dependencies
+    /]
+[/#macro]
+


### PR DESCRIPTION
Allow the creation of a usage plan that can then be linked to from users.

Create an API key for the user to be included into any usage plans to which they are linked.

Move creation of some API Gateway resources to macros as they now occur in multiple places.

A user is given permission to invoke any api to which the usage plan is linked.