### PR TITLE
Add AutoScale Update Controls 

### DIFF
--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -26,6 +26,16 @@
 
         [#assign logFileProfile = getLogFileProfile(tier, component, "ComputeCluster")]
         [#assign bootstrapProfile = getBootstrapProfile(tier, component, "ComputeCluster")]
+        [#assign storageProfile = getStorage(tier, component, "ComputeCluster")]
+        [#assign processorProfile = getProcessor(tier, component, "ComputeCluster")]
+
+        [#assign computeAutoScaleGroupTags =                     
+                getCfTemplateCoreTags(
+                        computeClusterAutoScaleGroupName,
+                        tier,
+                        component,
+                        "",
+                        true)]
 
         [#assign targetGroupPermission = false ]
         [#assign targetGroups = [] ]
@@ -288,23 +298,6 @@
                         groupId=computeClusterSecurityGroupId /]
             [/#list]
 
-            [#assign processorProfile = getProcessor(tier, component, "ComputeCluster")]
-
-            [#assign maxSize = processorProfile.MaxPerZone]
-            [#if multiAZ]
-                [#assign maxSize = maxSize * zones?size]
-            [/#if]
-            [#if maxSize <= solution.MinUpdateInstances ]
-                [#assign maxSize = maxSize + solution.MinUpdateInstances ]
-            [/#if]
-
-            [#assign storageProfile = getStorage(tier, component, "ComputeCluster")]
-
-            [#assign desiredCapacity = multiAZ?then(
-                processorProfile.DesiredPerZone * zones?size,
-                processorProfile.DesiredPerZone
-            )]
-
             [@cfResource
                 mode=listMode
                 id=computeClusterInstanceProfileId
@@ -317,77 +310,24 @@
                 outputs={}
             /]
 
-            [@cfResource
+            [@createEc2AutoScaleGroup 
                 mode=listMode
                 id=computeClusterAutoScaleGroupId
-                type="AWS::AutoScaling::AutoScalingGroup"
-                metadata=getInitConfig(configSetName, configSets )
-                properties=
-                    {
-                        "Cooldown" : "30",
-                        "LaunchConfigurationName": getReference(computeClusterLaunchConfigId),
-                        "MetricsCollection" : [
-                            {
-                                "Granularity" : "1Minute"
-                            }
-                        ]
-                    } +
-                    multiAZ?then(
-                        {
-                            "MinSize": processorProfile.MinPerZone * zones?size,
-                            "MaxSize": maxSize,
-                            "DesiredCapacity": desiredCapacity,
-                            "VPCZoneIdentifier": getSubnets(tier)
-                        },
-                        {
-                            "MinSize": processorProfile.MinPerZone,
-                            "MaxSize": maxSize,
-                            "DesiredCapacity": desiredCapacity,
-                            "VPCZoneIdentifier" : getSubnets(tier)[0..0]
-                        }
-                    ) +
-                    attributeIfContent(
-                        "LoadBalancerNames",
-                        loadBalancers,
-                        loadBalancers
-                    ) +
-                    attributeIfContent(
-                        "TargetGroupARNs",
-                        targetGroups,
-                        targetGroups
-                    )
-                tags=
-                    getCfTemplateCoreTags(
-                        computeClusterAutoScaleGroupName,
-                        tier,
-                        component,
-                        "",
-                        true)
-                outputs={}
-                updatePolicy=solution.ReplaceOnUpdate?then(
-                    {
-                        "AutoScalingReplacingUpdate" : {
-                            "WillReplace" : true
-                        }
-                    },
-                    {
-                        "AutoScalingRollingUpdate" : {
-                            "WaitOnResourceSignals" : (solution.UseInitAsService != true),
-                            "MinInstancesInService" : solution.MinUpdateInstances,
-                            "PauseTime" : "PT" + solution.UpdatePauseTime
-                        }
-                    }
-                )
-                creationPolicy=
-                    (solution.UseInitAsService != true )?then(
-                        {
-                            "ResourceSignal" : {
-                                "Count" : desiredCapacity,
-                                "Timeout" : "PT" + solution.StartupTimeout
-                            }
-                        },
-                        {}
-                    )
+                tier=tier
+                configSetName=configSetName
+                configSets=configSets
+                launchConfigId=computeClusterLaunchConfigId
+                processorProfile=processorProfile
+                minUpdateInstances=solution.AutoScaling.MinUpdateInstances
+                replaceOnUpdate=solution.AutoScaling.ReplaceCluster
+                waitOnSignal=solution.UseInitAsService
+                startupTimeout=solution.AutoScaling.StartupTimeout
+                updatePauseTime=solution.AutoScaling.UpdatePauseTime
+                activityCooldown=solution.AutoScaling.ActivityCooldown
+                multiAZ=multiAZ
+                targetGroups=targetGroups
+                loadBalancers=loadBalancers
+                tags=computeAutoScaleGroupTags
             /]
 
             [#assign imageId = dockerHost?then(

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -320,7 +320,7 @@
                 processorProfile=processorProfile
                 minUpdateInstances=solution.AutoScaling.MinUpdateInstances
                 replaceOnUpdate=solution.AutoScaling.ReplaceCluster
-                waitOnSignal=solution.UseInitAsService
+                waitOnSignal=(solution.UseInitAsService != true)
                 startupTimeout=solution.AutoScaling.StartupTimeout
                 updatePauseTime=solution.AutoScaling.UpdatePauseTime
                 activityCooldown=solution.AutoScaling.ActivityCooldown

--- a/aws/templates/id/id_computecluster.ftl
+++ b/aws/templates/id/id_computecluster.ftl
@@ -20,24 +20,8 @@
                 "Default" : false
             },
             {
-                "Name" : "MinUpdateInstances",
-                "Type" : NUMBER_TYPE,
-                "Default" : 1
-            }
-            {
-                "Name" : "ReplaceOnUpdate",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
-            },
-            {
-                "Name" : "UpdatePauseTime",
-                "Type" : STRING_TYPE,
-                "Default" : "5M"
-            },
-            {
-                "Name" : "StartupTimeout",
-                "Type" : STRING_TYPE,
-                "Default" : "15M"
+                "Name" : "AutoScaling",
+                "Children" : autoScalingChildConfiguration
             },
             {
                 "Name" : "DockerHost",
@@ -95,12 +79,21 @@
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
                 },
                 "launchConfig" : {
-                    "Id" : formatResourceId(
+                    "Id" : solution.AutoScaling.AlwaysReplaceOnUpdate?then(
+                            formatResourceId(
                                 AWS_EC2_LAUNCH_CONFIG_RESOURCE_TYPE,
                                 core.Id,
                                 [#-- changing the launch config logical Id forces a replacement of the autoscale group instances --]
                                 [#-- we only want this to happen when the build reference changes --]
-                                replaceAlphaNumericOnly(buildReference)),
+                                replaceAlphaNumericOnly(buildReference,
+                                runId)),
+                            formatResourceId(
+                                AWS_EC2_LAUNCH_CONFIG_RESOURCE_TYPE,
+                                core.Id,
+                                [#-- changing the launch config logical Id forces a replacement of the autoscale group instances --]
+                                [#-- we only want this to happen when the build reference changes --]
+                                replaceAlphaNumericOnly(buildReference))
+                    ),
                     "Type" : AWS_EC2_LAUNCH_CONFIG_RESOURCE_TYPE
                 } 
             },

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -123,6 +123,10 @@
                     "Children" : linkChildrenConfiguration
                 },
                 {
+                    "Name" : "AutoScaling",
+                    "Children" : autoScalingChildConfiguration
+                },
+                {
                     "Name" : "DockerUsers",
                     "Subobjects" : true,
                     "Children" : [
@@ -293,7 +297,10 @@
                     "Type" : AWS_EC2_AUTO_SCALE_GROUP_RESOURCE_TYPE
                 },
                 "launchConfig" : {
-                    "Id" : formatEC2LaunchConfigId(core.Tier, core.Component),
+                    "Id" : solution.AutoScaling.AlwaysReplaceOnUpdate?then(
+                            formatEC2LaunchConfigId(core.Tier, core.Component, runId),
+                            formatEC2LaunchConfigId(core.Tier, core.Component)
+                    ),
                     "Type" : AWS_EC2_LAUNCH_CONFIG_RESOURCE_TYPE
                 },
                 "lg" : {

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -265,6 +265,50 @@
     ]
 ]
 
+[#assign autoScalingChildConfiguration = [
+    {
+        "Name" : "WaitForSignal",
+        "Type" : BOOLEAN_TYPE,
+        "Default" : true,
+        "Description" : "Wait for a cfn-signal before treating the instances as alive"
+    },
+    {
+        "Name" : "MinUpdateInstances",
+        "Type" : NUMBER_TYPE,
+        "Default" : 1,
+        "Description" : "The minimum number of instances which must be available during an update"
+    },
+    {
+        "Name" : "ReplaceCluster",
+        "Type" : BOOLEAN_TYPE,
+        "Default" : false,
+        "Description" : "When set to true a brand new cluster will be built, if false the instances in the current cluster will be replaced"
+    },
+    {
+        "Name" : "UpdatePauseTime",
+        "Type" : STRING_TYPE,
+        "Default" : "5M",
+        "Description" : "How long to pause betweeen updates of instances"
+    },
+    {
+        "Name" : "StartupTimeout",
+        "Type" : STRING_TYPE,
+        "Default" : "15M",
+        "Description" : "How long to wait for a cfn-signal to be received from a host"
+    },
+    {
+        "Name" : "AlwaysReplaceOnUpdate",
+        "Type" : BOOLEAN_TYPE,
+        "Default" : false,
+        "Description" : "Replace instances on every update action" 
+    },
+    {
+        "Name" : "ActivityCooldown",
+        "Type" : NUMBER_TYPE,
+        "Default" : 60
+    }
+]]
+
 [#include idList]
 [#include nameList]
 [#include policyList]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -305,7 +305,7 @@
     {
         "Name" : "ActivityCooldown",
         "Type" : NUMBER_TYPE,
-        "Default" : 60
+        "Default" : 30
     }
 ]]
 

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -234,12 +234,12 @@
                 configSets=configSets
                 launchConfigId=ecsLaunchConfigId
                 processorProfile=processorProfile
-                minUpdateInstances=solution.AutoScale.MinUpdateInstances
-                replaceOnUpdate=solution.AutoScale.ReplaceOnUpdate
-                waitOnSignal=solution.AutoScale.WaitForSignal
-                startupTimeout=solution.AutoScale.StartupTimeout
-                updatePauseTime=solution.AutoScale.UpdatePauseTime
-                activityCooldown=solution.AutoScale.ActivityCooldown  
+                minUpdateInstances=solution.AutoScaling.MinUpdateInstances
+                replaceOnUpdate=solution.AutoScaling.ReplaceCluster
+                waitOnSignal=solution.AutoScaling.WaitForSignal
+                startupTimeout=solution.AutoScaling.StartupTimeout
+                updatePauseTime=solution.AutoScaling.UpdatePauseTime
+                activityCooldown=solution.AutoScaling.ActivityCooldown  
                 multiAZ=multiAZ
                 tags=ecsTags
             /]
@@ -256,7 +256,7 @@
                 routeTable=tier.Network.RouteTable
                 configSet=configSetName
                 environmentId=environmentId
-                enableCfnSignal=false
+                enableCfnSignal=solution.AutoScaling.WaitForSignal
             /]
         [/#if]
     [/#list]


### PR DESCRIPTION
Adds control to the autoscale update process to control what happens when an autoscaling Ec2 Instance is updated. 

This does not cover off when to autoscale just what happens when Cloudofmation interacts with an autoscale cluster. 

This introduces a few changes to our current autoscale cluster setup 
- Enables CFN Signal by default, cfn signal is used to notify cloudformation that Ec2 has finished its cfn-init tasks and that the instance is ready to go. If the signal is not received the instance will be marked as a failure 
- Enables rolling updates of ec2 instances in the cluster - Cloudformation can be configured to either create a new Autoscale Group with brand new instances or roll through each instance in an existing Autoscale group and replace each instance in the cluster. This option can be configured in the AutoScaling Component configuration 
