### PR TITLE
Introduce framework for typed links

### DIFF
--- a/aws/templates/id/id_sqs.ftl
+++ b/aws/templates/id/id_sqs.ftl
@@ -42,44 +42,71 @@
         ]
     }]
     
-[#function getSQSState occurrence]
+[#function getSQSState occurrence baseState]
     [#local core = occurrence.Core]
 
-    [#local id = formatResourceId(AWS_SQS_RESOURCE_TYPE, core.Id) ]
-    [#local name = core.FullName ]
-
-    [#local dlqId = formatDependentResourceId(AWS_SQS_RESOURCE_TYPE, id, "dlq") ]
-    [#local dlqName = formatName(name, "dlq")]
-
-    [#return
-        {
-            "Resources" : {
-                "queue" : {
-                    "Id" : id,
-                    "Name" : name,
-                    "Type" : AWS_SQS_RESOURCE_TYPE
+    [#if core.External!false]
+        [#local id = baseState.Attributes["ARN"]!"" ]
+        [#return
+            baseState +
+            valueIfContent(
+                {
+                    "Roles" : {
+                        "Inbound" : {},
+                        "Outbound" : {
+                            "all" : sqsAllPermission(id),
+                            "event" : sqsConsumePermission(id),
+                            "produce" : sqsProducePermission(id),
+                            "consume" : sqsConsumePermission(id)
+                        }
+                    }
                 },
-                "dlq" : {
-                    "Id" : dlqId,
-                    "Name" : dlqName,
-                    "Type" : AWS_SQS_RESOURCE_TYPE
+                id,
+                {
+                    "Roles" : {
+                        "Inbound" : {},
+                        "Outbound" : {}
+                    }
                 }
-            },
-            "Attributes" : {
-                "NAME" : getExistingReference(id, NAME_ATTRIBUTE_TYPE),
-                "URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE),
-                "ARN" : getExistingReference(id, ARN_ATTRIBUTE_TYPE),
-                "REGION" : regionId
-            },
-            "Roles" : {
-                "Inbound" : {},
-                "Outbound" : {
-                    "all" : sqsAllPermission(id),
-                    "event" : sqsConsumePermission(id),
-                    "produce" : sqsProducePermission(id),
-                    "consume" : sqsConsumePermission(id)
+            )
+        ]
+    [#else]
+        [#local id = formatResourceId(AWS_SQS_RESOURCE_TYPE, core.Id) ]
+        [#local name = core.FullName ]
+    
+        [#local dlqId = formatDependentResourceId(AWS_SQS_RESOURCE_TYPE, id, "dlq") ]
+        [#local dlqName = formatName(name, "dlq")]
+    
+        [#return
+            {
+                "Resources" : {
+                    "queue" : {
+                        "Id" : id,
+                        "Name" : name,
+                        "Type" : AWS_SQS_RESOURCE_TYPE
+                    },
+                    "dlq" : {
+                        "Id" : dlqId,
+                        "Name" : dlqName,
+                        "Type" : AWS_SQS_RESOURCE_TYPE
+                    }
+                },
+                "Attributes" : {
+                    "NAME" : getExistingReference(id, NAME_ATTRIBUTE_TYPE),
+                    "URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE),
+                    "ARN" : getExistingReference(id, ARN_ATTRIBUTE_TYPE),
+                    "REGION" : regionId
+                },
+                "Roles" : {
+                    "Inbound" : {},
+                    "Outbound" : {
+                        "all" : sqsAllPermission(id),
+                        "event" : sqsConsumePermission(id),
+                        "produce" : sqsProducePermission(id),
+                        "consume" : sqsConsumePermission(id)
+                    }
                 }
             }
-        }
-    ]
+        ]
+    [/#if]
 [/#function]

--- a/aws/templates/policy/policy_sqs.ftl
+++ b/aws/templates/policy/policy_sqs.ftl
@@ -6,7 +6,7 @@
             getPolicyStatement(
                 actions,
                 valueIfContent(
-                    getReference(id, ARN_ATTRIBUTE_TYPE),
+                    getArn(id),
                     id,
                     formatRegionalArn("sqs", "*")),
                 principals,

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -82,6 +82,10 @@
             {
                 "Name" : "Direction",
                 "Type" : STRING_TYPE
+            },
+            {
+                "Name" : "Type",
+                "Type" : STRING_TYPE
             }
         ]
 ]


### PR DESCRIPTION
A link can now have a "Type" attribute. It is only considered where the
link is external.

If present, it is used to determine what the target component type is
and generate the occurrence structure on this basis. this permits IAM
roles etc to still be generated even though the target is external.

Support needs to be explicitly added to any component state routine for
it to be supported. At present only SQS queues are implemented.