### PR TITLE
Add Standard outputs to pseudo stack outputs

### DIFF
--- a/aws/templates/application/application_datapipeline.ftl
+++ b/aws/templates/application/application_datapipeline.ftl
@@ -284,12 +284,16 @@
                             "       \"$\{pipelineId}\" " +
                             "       \"$\{tmpdir}/pipeline/pipeline-definition.json\" " + 
                             "       \"$\{tmpdir}/pipeline/pipeline-parameters.json\" " + 
-                            "       \"$\{tmpdir}/config.json\" || return $?",
-                            "       pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-pseudo-stack.json\" ",
-                            "       create_pseudo_stack" + " " +
-                            "       \"Data Pipeline\"" + " " +
-                            "       \"$\{pseudo_stack_file}\"" + " " +
-                            "       \"" + pipelineId + "\" \"$\{pipelineId}\" || return $?"
+                            "       \"$\{tmpdir}/config.json\" || return $?"
+                        ] +
+                        pseudoStackOutputScript(
+                            "Data Pipeline",
+                            { 
+                                pipelineId : "$\{pipelineId}"
+                            },
+                            "creds-system"
+                        ) + 
+                        [
                             "   ;;",
                             "   esac"
                         ]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -2135,8 +2135,17 @@ behaviour.
         ] ]
 [/#function]
 
-[#function pseudoStackOutputScript description outputs filesuffix="pseudo" ]
+[#function pseudoStackOutputScript description outputs filesuffix="" ]
     [#local outputString = ""]
+
+    [#list getCFTemplateCoreOutputs(region, accountObject.AWSId) as  key,value ]
+        [#if value?is_hash ]
+            [#local outputs += { key, value.Value } ]
+        [#else ]
+            [#local outputs += { key, vaue } ]
+        [/#if]
+    [/#list]
+
     [#list outputs as key,value ]
         [#local outputString +=
           "\"" + key + "\" \"" + value + "\" "
@@ -2147,7 +2156,7 @@ behaviour.
         [
             "create_pseudo_stack" + " " +
             "\"" + description + "\"" + " " +
-            "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-" + filesuffix + "-stack.json\" " +
+            "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")" + (filesuffix?has_content)?then("-" + filesuffix, "") + "-pseudo-stack.json\" " +
             outputString + " || return $?"
         ]
     ]

--- a/aws/templates/createAccountTemplate.ftl
+++ b/aws/templates/createAccountTemplate.ftl
@@ -15,6 +15,7 @@
         [#break]
 [/#switch]
 
+[#assign componentLevel="account" ]
 [@cfTemplate
-    level="account"
+    level=componentLevel
     include=accountList /]

--- a/aws/templates/createApplicationTemplate.ftl
+++ b/aws/templates/createApplicationTemplate.ftl
@@ -21,6 +21,7 @@
 
 [/#switch]
 
+[#assign componentLevel="application" ]
 [@cfTemplate
-    level="application"
+    level=componentLevel
     compositeLists=applicationList /]

--- a/aws/templates/createMultipleTemplate.ftl
+++ b/aws/templates/createMultipleTemplate.ftl
@@ -34,6 +34,7 @@
         [#break]
 [/#switch]
 
+[#assign componentLevel="multiple" ]
 [@cfTemplate
-    level="multiple"
+    level=componentLevel
     compositeLists=compositeLists /]

--- a/aws/templates/createProductTemplate.ftl
+++ b/aws/templates/createProductTemplate.ftl
@@ -36,6 +36,7 @@
 [#-- Product --]
 [#assign rotateKeys = (productObject.RotateKeys)!true]
 
+[#assign componentLevel="product" ]
 [@cfTemplate
-    level="product"
+    level=componentLevel
     include=productList/]

--- a/aws/templates/createSegmentTemplate.ftl
+++ b/aws/templates/createSegmentTemplate.ftl
@@ -14,8 +14,9 @@
         [#break]
 [/#switch]
 
+[#assign componentLevel="segment" ]
 [@cfTemplate
-    level="segment"
+    level=componentLevel
     compositeLists=segmentList /]
 
 

--- a/aws/templates/createSolutionTemplate.ftl
+++ b/aws/templates/createSolutionTemplate.ftl
@@ -14,6 +14,7 @@
         [#break]
 [/#switch]
 
+[#assign componentLevel="solution" ]
 [@cfTemplate
-    level="solution"
+    level=componentLevel
     compositeLists=solutionList /]

--- a/aws/templates/resource/start.ftl
+++ b/aws/templates/resource/start.ftl
@@ -235,6 +235,25 @@
     [#return result]
 [/#function]
 
+[#function getCFTemplateCoreOutputs region={ "Ref" : "AWS::Region" } account={ "Ref" : "AWS::AccountId" } deploymentUnit=deploymentUnit level=componentLevel ]
+    [#return {
+        "Account" :{ "Value" : account },
+        "Region" : {"Value" : region },
+        "Level" : {"Value" : level},
+        "DeploymentUnit" : {
+            "Value" :
+                deploymentUnit +
+                (
+                    (!(ignoreDeploymentUnitSubsetInOutputs!false)) &&
+                    (deploymentUnitSubset?has_content)
+                )?then(
+                    "-" + deploymentUnitSubset?lower_case,
+                    ""
+                )
+        }
+    }]
+[/#function]
+
 [#function getCfTemplateCoreTags name="" tier="" component="" zone="" propagate=false flatten=false]
     [#local result =
         [
@@ -664,23 +683,7 @@
               "Resources" : templateResources,
               "Outputs" :
                   templateOutputs +
-                  {
-                      "Account" :{"Value" : { "Ref" : "AWS::AccountId" }},
-                      "Region" : {"Value" : { "Ref" : "AWS::Region" }},
-                      "Level" : {"Value" : level},
-                      "DeploymentUnit" :
-                          {
-                              "Value" :
-                                  deploymentUnit +
-                                  (
-                                      (!(ignoreDeploymentUnitSubsetInOutputs!false)) &&
-                                      (deploymentUnitSubset?has_content)
-                                  )?then(
-                                      "-" + deploymentUnitSubset?lower_case,
-                                      ""
-                                  )
-                          }
-                  }
+                    getCFTemplateCoreOutputs()
           } +
           valueIfContent(
               {

--- a/aws/templates/solution/solution_contenthub.ftl
+++ b/aws/templates/solution/solution_contenthub.ftl
@@ -18,23 +18,18 @@
         [#if deploymentSubsetRequired("prologue", false)]
             [@cfScript
                 mode=listMode
-                content=
-                [
-                    "function create_contenthub_snapshot() {",
-                        "# Create contenthub stack",
-                        "create_pseudo_stack" + " " + 
-                        "\"Content Hub Deployment\"" + " " +
-                        "\"$\{pseudo_stack_file}\"" + " " +
-                        "\"" + contentHubId + "Xengine\" \"" + solution.Engine + "\" " +  
-                        "\"" + contentHubId + "Xrepository\" \"" + solution.Repository + "\" " +
-                        "\"" + contentHubId + "Xprefix\" \"" + contentHubPrefix + "\" " +
-                        "\"" + contentHubId + "Xbranch\" \"" + solution.Branch + "\" " +
-                        "|| return $?", 
-                    "}",
-                    "pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-pseudo-stack.json\" ",
-                    "info \"Creating Contenthub Pseudo Stack\"",
-                    "create_contenthub_snapshot || return $?"
-                ]
+                content=[
+                        "info \"Creating Contenthub Pseudo Stack\""
+                    ] + 
+                    pseudoStackOutputScript(
+                        "Content Hub Deployment",
+                        { 
+                            formatId(contentHubId, "engine") : solution.Engine,
+                            formatId(contentHubId, "repository") : solution.Repository,
+                            formatId(contentHubId, "prefix") : contentHubPrefix,
+                            formatId(contentHubId, "branch") : solution.Branch
+                        }
+                    )
             /]
         [/#if]
     [/#list]

--- a/aws/templates/solution/solution_mobilenotifier.ftl
+++ b/aws/templates/solution/solution_mobilenotifier.ftl
@@ -197,13 +197,17 @@
                                 "       \"" + encryptionScheme + "\" " +
                                 "       \"" + engine + "\" " +
                                 "       \"$\{tmpdir}/cli-" +
-                                        platformAppAttributesCliId + "-" + platformAppAttributesCommand + ".json\")\"",
-                                "       pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-" + core.SubComponent.Id + "-pseudo-stack.json\" ",
-                                "       create_pseudo_stack" + " " +
-                                "       \"SNS Platform App\"" + " " +
-                                "       \"$\{pseudo_stack_file}\"" + " " +
-                                "       \"" + platformAppId + "Xarn\" \"$\{platform_app_arn}\"" +
-                                "       \"" + platformAppId + "\" \"" + core.Name + "\" || return $?",
+                                        platformAppAttributesCliId + "-" + platformAppAttributesCommand + ".json\")\""
+                            ] + 
+                            pseudoStackOutputScript(
+                                "SNS Platform App",
+                                { 
+                                    formatId(platformAppId, "arn") : "$\{platform_app_arn}",
+                                    platformAppId : core.Name
+                                },
+                                core.SubComponent.Id
+                            ) +
+                            [
                                 "       ;;",
                                 "  delete)",
                                 "       # Delete SNS Platform Application",

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -144,13 +144,17 @@
                             "create_snapshot" +
                             " \"" + region + "\" " +
                             " \"" + rdsFullName + "\" " +
-                            " \"" + rdsPreDeploySnapshotId + "\" || return $?",
-                            "create_pseudo_stack" + " " +
-                            "\"RDS Pre-Deploy Snapshot\"" + " " +
-                            "\"$\{pseudo_stack_file}\"" + " " +
-                            "\"snapshotX" + rdsId + "Xname\" " + "\"" + rdsPreDeploySnapshotId + "\" || return $?",
+                            " \"" + rdsPreDeploySnapshotId + "\" || return $?"
+                        ] + 
+                        pseudoStackOutputScript(
+                            "RDS Pre-Deploy Snapshot",
+                            { 
+                                formatId("snapshot", rdsId, "name") : rdsPreDeploySnapshotId,
+                                formatId("manualsnapshot", rdsId, "name") : ""
+                            }
+                        ) +
+                        [
                             "}",
-                            "pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-pseudo-stack.json\" ",
                             "create_deploy_snapshot || return $?"
                         ],
                         []) +
@@ -168,13 +172,10 @@
                         ],
                         []
                     ),
-                    [
-                        "pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-pseudo-stack.json\" ",
-                        "create_pseudo_stack" + " " +
-                        "\"RDS Manual Snapshot Restore\"" + " " +
-                        "\"$\{pseudo_stack_file}\"" + " " +
-                        "\"manualsnapshotX" + rdsId + "Xname\" " + "\"\" || return $?"
-                    ] 
+                    pseudoStackOutputScript(
+                            "RDS Manual Snapshot Restore",
+                            { formatId("manualsnapshot", rdsId, "name") : "" }
+                        )
                 ) +
                 [
                     " ;;",
@@ -337,11 +338,14 @@
                         "set_rds_master_password" +
                         " \"" + region + "\" " +
                         " \"" + rdsFullName + "\" " +
-                        " \"$\{master_password}\" || return $?",
-                        "create_pseudo_stack" + " " +
-                        "\"RDS Master Password\"" + " " +
-                        "\"$\{password_pseudo_stack_file}\"" + " " +
-                        "\"" + rdsId + "Xgeneratedpassword\" \"$\{encrypted_master_password}\" || return $?",
+                        " \"$\{master_password}\" || return $?"
+                    ] +
+                    pseudoStackOutputScript(
+                            "RDS Master Password",
+                            { formatId(rdsId, "generatedpassword") : "$\{encrypted_master_password}" },
+                            "password"
+                    ) +
+                    [
                         "info \"Generating URL... \"",
                         "rds_hostname=\"$(get_rds_hostname" + 
                         " \"" + region + "\" " +
@@ -356,14 +360,15 @@
                         "encrypted_rds_url=\"$(encrypt_kms_string" +
                         " \"" + region + "\" " +
                         " \"$\{rds_url}\" " +
-                        " \"" + segmentKMSKey + "\" || return $?)\"",
-                        "create_pseudo_stack" + " " +
-                        "\"RDS Connection URL\"" + " " +
-                        "\"$\{url_pseudo_stack_file}\"" + " " +
-                        "\"" + rdsId + "Xurl\" \"$\{encrypted_rds_url}\" || return $?",
+                        " \"" + segmentKMSKey + "\" || return $?)\""
+                    ] +
+                    pseudoStackOutputScript(
+                            "RDS Connection URL",
+                            { formatId(rdsId, "url") : "$\{encrypted_rds_url}" },
+                            "url"
+                    ) +
+                    [
                         "}",
-                        "password_pseudo_stack_file=" + passwordPseudoStackFile,
-                        "url_pseudo_stack_file=" +  urlPseudoStackFile,
                         "generate_master_password || return $?"
                     ],
                     []) +
@@ -395,13 +400,15 @@
                         "encrypted_rds_url=\"$(encrypt_kms_string" +
                         " \"" + region + "\" " +
                         " \"$\{rds_url}\" " +
-                        " \"" + segmentKMSKey + "\" || return $?)\"",
-                        "create_pseudo_stack" + " " +
-                        "\"RDS Connection URL\"" + " " +
-                        "\"$\{url_pseudo_stack_file}\"" + " " +
-                        "\"" + rdsId + "Xurl\" \"$\{encrypted_rds_url}\" || return $?"
+                        " \"" + segmentKMSKey + "\" || return $?)\""
+                    ] +
+                    pseudoStackOutputScript(
+                            "RDS Connection URL",
+                            { formatId(rdsId, "url") : "$\{encrypted_rds_url}" },
+                            "url"
+                    ) +
+                    [
                         "}",
-                        "url_pseudo_stack_file=" +  urlPseudoStackFile,
                         "reset_master_password || return $?"
                     ],
                 []) +


### PR DESCRIPTION
Add the standard stack outputs to pseudo stack files generated as part of the epilogue/prologue process. 

This ensures that when deploying the same environment to multiple accounts that the stack outputs align as they are supposed to be. 

Also adds some minor fixes for system users with console credentials