### PR TITLE
Ensure StackOutputs and SSH Keys reference their account and region

### DIFF
--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -1160,54 +1160,69 @@ function upgrade_cmdb_repo_to_v1_3_0() {
     account_mappings+=(["${aws_id}"]="${account_id}")
   done
 
-  # Rename Stack Outputs to include Account and Region 
-  readarray -t stack_files < <(find "${root_dir}" -type f -name "*stack.json")
-  for stack_file in "${stack_files[@]}"; do 
-
-    parse_stack_filename "${stack_file}" 
-    stack_dir="$(filePath "${stack_file}")"
-
-    if [[ -z "${stack_account}" ]]; then 
-      
-      stack_file_name="$(fileName "${stack_file}" )"
-      stack_output_aws_account="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Account" ) | .OutputValue' < "${stack_file}" )"
-  
-      if [[ -n "${stack_output_aws_account}" ]]; then
-
-        stack_output_account="${account_mappings[${stack_output_aws_account}]}"
-        new_stack_file_name="${stack_file_name/"-${stack-region}-"/"-${stack_output_account}-${stack_region}-"}"
-
-        if [[ "${stack_file_name}" != "${new_stack_file_name}" ]]; then
-          debug "Moving ${stack_file} to ${stack_dir}/${new_stack_file_name}"
-
-          if [[ -n "${dry_run}" ]]; then
-            continue
-          fi
-          
-          mv "${stack_file}" "${stack_dir}/${new_stack_file_name}"
-        fi
-      else
-        fatal "Could not determine Account for file - please update the file manually with Account & region outputs"
-        fatal "   - ${stack_file}"
-        return_status=128
-      fi
-    fi
-  done
-
-  # Move SSH keys to Account/Region 
   readarray -t cf_dirs < <(find "${root_dir}" -type d -name "cf" )
   for cf_dir in "${cf_dirs[@]}"; do
-    readarray -t cmk_stacks < <(find "${cf_dir}" -type f -name "seg-cmk-*-stack.json" )
+    readarray -t cmk_stacks < <(find "${cf_dir}" -type f -name "seg-cmk-*[0-9]-stack.json" )
     for cmk_stack in "${cmk_stacks[@]}"; do
+
+      info "Looking for CMK account in ${cmk_stack}"
       cmk_account="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Account" ) | .OutputValue' < "${cmk_stack}" )"
       cmk_region="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Region" ) | .OutputValue' < "${cmk_stack}" )"
 
-      info "Stack ${cmk_stack} Belongs to ${cmk_account} - ${cmk_region}"
-
       if [[ -n "${cmk_account}" ]]; then
         cmk_account_id="${account_mappings[${cmk_account}]}"
-        
         cmk_path="$(filePath "${cmk_stack}")"
+
+        readarray -t segment_stacks < <(find "${cmk_path}"  -type f -name "*stack.json")
+        for stack_file in "${segment_stacks[@]}"; do 
+
+          parse_stack_filename "${stack_file}" 
+          stack_dir="$(filePath "${stack_file}")"
+
+          # Add Standard Account and Region Stack Outputs 
+          stackoutput_account="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Account" ) | .OutputValue' < "${stack_file}" )"
+          stackoutput_region="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Region" ) | .OutputValue' < "${stack_file}" )"
+          stackoutput_level="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Level" ) | .OutputValue' < "${stack_file}" )"
+          stackoutput_deployment_unit="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="DeploymentUnit" ) | .OutputValue' < "${stack_file}" )"
+
+          if [[ -z "${stackoutput_account}" ]]; then 
+              debug "Adding Account Output to ${stack_file}"
+              mkdir --parents "${tmp_dir}/$(filePath "${stack_file}")" 
+              jq -r --arg account "${cmk_account}" '.Stacks[].Outputs += [{ "OutputKey" : "Account", "OutputValue" : $account  }]' < "${stack_file}" > "${tmp_dir}/${stack_file}" 
+              if [[ $? == 0 ]]; then
+                mv "${tmp_dir}/${stack_file}" "${stack_file}"
+              fi
+          fi
+
+          if [[ -z "${stackoutput_region}" ]]; then 
+              debug "Adding Region Output to ${stack_file}"
+              mkdir --parents "${tmp_dir}/$(filePath "${stack_file}")" 
+              jq -r --arg region "${stack_region}" '.Stacks[].Outputs += [{ "OutputKey" : "Region", "OutputValue" : $region  }]' < "${stack_file}" > "${tmp_dir}/${stack_file}"
+              if [[ $? == 0 ]]; then
+                mv "${tmp_dir}/${stack_file}" "${stack_file}"
+              fi
+          fi
+          
+          
+          if [[ -z "${stack_account}" ]]; then
+
+            # Rename file to inclue Region and Account
+            stack_file_name="$(fileName "${stack_file}" )"
+            new_stack_file_name="${stack_file_name/"-${stack_region}-"/"-${cmk_account_id}-${stack_region}-"}"
+
+            if [[ "${stack_file_name}" != "${new_stack_file_name}" && "${stack_file_name}" != *"${cmk_account_id}"* ]]; then
+              debug "Moving ${stack_file} to ${stack_dir}/${new_stack_file_name}"
+
+              if [[ -n "${dry_run}" ]]; then
+                continue
+              fi
+              
+              mv "${stack_file}" "${stack_dir}/${new_stack_file_name}"
+            fi
+          fi
+        done
+
+        # Rename SSH keys to include Account/Region 
         operations_path="${cmk_path/"infrastructure/cf"/"infrastructure/operations"}"
 
         info "checking for SSH Keys in ${operations_path}"

--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -1143,6 +1143,94 @@ function upgrade_cmdb_repo_to_v1_2_0() {
   return ${return_status}
 }
 
+function upgrade_cmdb_repo_to_v1_3_0() { 
+  local root_dir="$1";shift
+  local dry_run="$1";shift
+
+  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXX"
+  local tmp_dir="$(getTopTempDir)"
+  local return_status=0
+
+  # Find accounts
+  declare -A account_mappings
+  readarray -t account_files < <(find "${GENERATION_DATA_DIR}" -type f -name "account.json" )
+  for account_file in "${account_files[@]}"; do
+    aws_id="$( jq -r '.Account.AWSId' <"${account_file}" )"
+    account_id="$( jq -r '.Account.Id' < "${account_file}" )"
+    account_mappings+=(["${aws_id}"]="${account_id}")
+  done
+
+  # Move SSH keys to Account/Region 
+  readarray -t cf_dirs < <(find "${root_dir}" -type d -name "cf" )
+  for cf_dir in "${cf_dirs[@]}"; do
+    readarray -t cmk_stacks < <(find "${cf_dir}" -type f -name "seg-cmk-*-stack.json" )
+    for cmk_stack in "${cmk_stacks[@]}"; do
+      cmk_account="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Account" ) | .OutputValue' < "${cmk_stack}" )"
+
+      if [[ -n "${cmk_account}" ]]; then
+        cmk_account_id="${account_mappings[${cmk_account}]}"
+        cmk_region="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Region" ) | .OutputValue' < "${cmk_stack}" )"
+        
+        cmk_path="$(filePath "${cmk_stack}")"
+        operations_path="${cmk_path/"infrastructure/cf"/"infrastructure/operations"}"
+
+        info "checking for SSH Keys in ${operations_path}"
+        readarray -t pem_files < <(find "${operations_path}" -type f -name ".aws-ssh*.pem*" )
+
+        for pem_file in "${pem_files[@]}"; do
+          local pem_file_path="$(filePath "${pem_file}")"
+          local file_name="$(fileName "${pem_file}")"
+          local new_file_name="${file_name/"aws-"/"aws-${cmk_account_id}-${cmk_region}-"}"
+
+          # Move the pem files to make them invisible to the generation process
+          debug "Moving ${pem_file} to ${pem_file_path}/${new_file_name} ..."
+
+          if [[ -n "${dry_run}" ]]; then
+            continue
+          fi
+          mv "${pem_file}" "${pem_file_path}/${new_file_name}"
+        done
+      fi
+    done
+  done
+
+  # Rename Stack Outputs to include Account and Region 
+  readarray -t stack_files < <(find "${root_dir}" -type f -name "*stack.json")
+  for stack_file in "${stack_files[@]}"; do 
+
+    parse_stack_filename "${stack_file}" 
+    stack_dir="$(filePath "${stack_file}")"
+
+    if [[ -z "${stack_account}" ]]; then 
+      
+      stack_file_name="$(fileName "${stack_file}" )"
+      stack_output_aws_account="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Account" ) | .OutputValue' < "${stack_file}" )"
+  
+      if [[ -n "${stack_output_aws_account}" ]]; then
+
+        stack_output_account="${account_mappings[${stack_output_aws_account}]}"
+        new_stack_file_name="${stack_file_name/"-${stack-region}-"/"-${stack_output_account}-${stack_region}-"}"
+
+        if [[ "${stack_file_name}" != "${new_stack_file_name}" ]]; then
+          debug "Moving ${stack_file} to ${stack_dir}/${new_stack_file_name}"
+
+          if [[ -n "${dry_run}" ]]; then
+            continue
+          fi
+          
+          mv "${stack_file}" "${stack_dir}/${new_stack_file_name}"
+        fi
+      else
+        fatal "Could not determine Account for file - please update the file manually with Account & region outputs"
+        fatal "   - ${stack_file}"
+        return_status=128
+      fi
+    fi
+  done
+
+  return $return_status
+}
+
 function process_cmdb() {
   local root_dir="$1";shift
   local action="$1";shift
@@ -1223,7 +1311,7 @@ function upgrade_cmdb() {
   local versions="$1";shift
 
   local required_versions=(${versions})
-  [[ -z "${versions}" ]] && required_versions=("v1.0.0" "v1.1.0" "v1.2.0")
+  [[ -z "${versions}" ]] && required_versions=("v1.0.0" "v1.1.0" "v1.2.0" "v1.3.0")
 
   process_cmdb "${root_dir}" "upgrade" "${required_versions[*]}" ${dry_run}
 }

--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -1152,7 +1152,7 @@ function upgrade_cmdb_repo_to_v1_3_0() {
   local return_status=0
 
   # Find accounts
-  declare -A account_mappings
+  local -A account_mappings
   readarray -t account_files < <(find "${GENERATION_DATA_DIR}" -type f -name "account.json" )
   for account_file in "${account_files[@]}"; do
     aws_id="$( jq -r '.Account.AWSId' <"${account_file}" )"

--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -1166,10 +1166,10 @@ function upgrade_cmdb_repo_to_v1_3_0() {
     readarray -t cmk_stacks < <(find "${cf_dir}" -type f -name "seg-cmk-*-stack.json" )
     for cmk_stack in "${cmk_stacks[@]}"; do
       cmk_account="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Account" ) | .OutputValue' < "${cmk_stack}" )"
+      cmk_region="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Region" ) | .OutputValue' < "${cmk_stack}" )"
 
       if [[ -n "${cmk_account}" ]]; then
         cmk_account_id="${account_mappings[${cmk_account}]}"
-        cmk_region="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Region" ) | .OutputValue' < "${cmk_stack}" )"
         
         cmk_path="$(filePath "${cmk_stack}")"
         operations_path="${cmk_path/"infrastructure/cf"/"infrastructure/operations"}"

--- a/aws/templates/segment/segment_cmk.ftl
+++ b/aws/templates/segment/segment_cmk.ftl
@@ -41,23 +41,25 @@
                         "  #",
                         "  # Create SSH credential for the segment",
                         "  mkdir -p \"$\{SEGMENT_OPERATIONS_DIR}\"",
-                        "  create_pki_credentials \"$\{SEGMENT_OPERATIONS_DIR}\" || return $?",
+                        "  create_pki_credentials \"$\{SEGMENT_OPERATIONS_DIR}\" " + 
+                                "\"" + regionId + "\" " +
+                                "\"" + accountObject.Id + "\" || return $?",
                         "  #",
                         "  # Update the credential if required",
                         "  if ! check_ssh_credentials" + " " +
                             "\"" + regionId + "\" " +
                              "\"$\{key_pair_name}\"; then",
-                        "    pem_file=\"$\{SEGMENT_OPERATIONS_DIR}/.aws-ssh-crt.pem\"",
+                        "    pem_file=\"$\{SEGMENT_OPERATIONS_DIR}/.aws-" + accountObject.Id + "-" + regionId + "-ssh-crt.pem\"",
                         "    update_ssh_credentials" + " " +
                                "\"" + regionId + "\" " +
                                "\"$\{key_pair_name}\" " +
                                "\"$\{pem_file}\" || return $?",
-                        "    [[ -f \"$\{SEGMENT_OPERATIONS_DIR}/.aws-ssh-prv.pem.plaintext\" ]] && ",
+                        "    [[ -f \"$\{SEGMENT_OPERATIONS_DIR}/.aws-" + accountObject.Id + "-" + regionId + "-ssh-prv.pem.plaintext\" ]] && ",
                         "      { encrypt_file" + " " +
                                  "\"" + regionId + "\"" + " " +
                                  "segment" + " " +
-                                 "\"$\{SEGMENT_OPERATIONS_DIR}/.aws-ssh-prv.pem.plaintext\"" + " " +
-                                 "\"$\{SEGMENT_OPERATIONS_DIR}/.aws-ssh-prv.pem\" || return $?; }",
+                                 "\"$\{SEGMENT_OPERATIONS_DIR}/.aws-" + accountObject.Id + "-" + regionId + "-ssh-prv.pem.plaintext\"" + " " +
+                                 "\"$\{SEGMENT_OPERATIONS_DIR}/.aws-" + accountObject.Id + "-" + regionId + "-ssh-prv.pem\" || return $?; }",
                         "  fi",
                         "  #"
                       ] +

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -1062,15 +1062,20 @@ function update_sms_account_attributes() {
 }
 
 # -- PKI --
+# -- PKI --
 function create_pki_credentials() {
   local dir="$1"; shift
+  local region="$1"; shift
+  local account="$1"; shift
 
   if [[ (! -f "${dir}/aws-ssh-crt.pem") &&
         (! -f "${dir}/aws-ssh-prv.pem") &&
         (! -f "${dir}/.aws-ssh-crt.pem") &&
-        (! -f "${dir}/.aws-ssh-prv.pem") ]]; then
-      openssl genrsa -out "${dir}/.aws-ssh-prv.pem.plaintext" 2048 || return $?
-      openssl rsa -in "${dir}/.aws-ssh-prv.pem.plaintext" -pubout > "${dir}/.aws-ssh-crt.pem" || return $?
+        (! -f "${dir}/.aws-ssh-prv.pem") && 
+        (! -f "${dir}/.aws-${account}-${region}-ssh-crt.pem") &&
+        (! -f "${dir}/.aws-${account}-${region}-ssh-prv.pem") ]]; then
+      openssl genrsa -out "${dir}/.aws-${account}-${region}-ssh-prv.pem.plaintext" 2048 || return $?
+      openssl rsa -in "${dir}/.aws-${account}-${region}-ssh-prv.pem.plaintext" -pubout > "${dir}/.aws-${account}-${region}-ssh-crt.pem" || return $?
   fi
 
   if [[ ! -f "${dir}/.gitignore" ]]; then
@@ -1086,12 +1091,13 @@ EOF
 
 function delete_pki_credentials() {
   local dir="$1"; shift
+  local region="$1"; shift
+  local account="$1"; shift
 
   local restore_nullglob="$(shopt -p nullglob)"
   shopt -s nullglob
 
-  rm -f "${dir}"/aws-ssh-crt* "${dir}"/aws-ssh-prv*
-  rm -f "${dir}"/.aws-ssh-crt* "${dir}"/.aws-ssh-prv*
+  rm -f "${dir}"/.aws-${account}-${region}-ssh-crt* "${dir}"/.aws-${account}-${region}-ssh-prv*
 
   ${restore_nullglob}
 }


### PR DESCRIPTION
When deploying the same environment to a new account or to multiple regions we need to have separate encyrpted ssh keys for each account-region combination for the environment-segment. 

This PR adds this behaviour for the creation of new ssh keys and upgrades the existing CMDB update existing ssh keys 

Along with this, older stack output files didn't reference the account in the file name. This PR adds an upgrade step which renames all stack output files to include the account-region combination. 

It also checks that the minimum stack output values are available in the stack outputs file itself. and adds the default Account and Region to the files.