### PR TITLE
ECS Service - Fix Port Mapping to Host and add daemon placement strategy

### DIFF
--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -226,6 +226,7 @@
                         loadBalancers=loadBalancers
                         roleId=ecsServiceRoleId
                         networkMode=networkMode
+                        placement=solution.Placement
                         subnets=subnets![]
                         securityGroups=getReferences(ecsSecurityGroupId)![]
                         dependencies=dependencies

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -247,7 +247,7 @@
                         {
                             "Names" : "Strategy",
                             "Type" : STRING_TYPE,
-                            "Values" : ["daemon"],
+                            "Values" : [ "", "daemon"],
                             "Description" : "How to place containers on the cluster",
                             "Default" : ""
                         }

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -240,6 +240,18 @@
                     "Names" : "ContainerNetworkLinks",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
+                },
+                {
+                    "Names" : "Placement",
+                    "Children" : [
+                        {
+                            "Names" : "Strategy",
+                            "Type" : STRING_TYPE,
+                            "Values" : ["daemon"],
+                            "Description" : "How to place containers on the cluster",
+                            "Default" : ""
+                        }
+                    ]
                 }
             ]
         },

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -122,7 +122,18 @@
     /]
 [/#macro]
 
-[#macro createECSService mode id ecsId desiredCount taskId loadBalancers networkMode="" subnets=[] securityGroups=[] roleId="" dependencies=""]
+[#macro createECSService mode id 
+            ecsId 
+            desiredCount 
+            taskId 
+            loadBalancers 
+            networkMode="" 
+            subnets=[] 
+            securityGroups=[] 
+            roleId="" 
+            placement={}
+            dependencies=""
+    ]
 
     [@cfResource
         mode=mode
@@ -131,7 +142,6 @@
         properties=
             {
                 "Cluster" : getExistingReference(ecsId),
-                "DesiredCount" : desiredCount,
                 "TaskDefinition" : getReference(taskId),
                 "DeploymentConfiguration" :
                     (desiredCount > 1)?then(
@@ -159,7 +169,16 @@
                     }
                 },
                 networkMode == "awsvpc"
-            ) + 
+            ) +
+            valueIfTrue(
+                {
+                    "SchedulingStrategy" : "DAEMON"
+                },
+                (placement.Strategy?has_content) && (placement.Strategy == "daemon"),
+                {
+                    "DesiredCount" : desiredCount
+                }
+            ) +
             valueIfTrue(
                 {
                     "Role" : getReference(roleId)

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -174,7 +174,7 @@
                 {
                     "SchedulingStrategy" : "DAEMON"
                 },
-                (placement.Strategy?has_content) && (placement.Strategy == "daemon"),
+                placement.Strategy == "daemon",
                 {
                     "DesiredCount" : desiredCount
                 }


### PR DESCRIPTION
Fix: for Port Mapping configuration which allows for Host - Container mappings to be defined without a load balancer. 

Feature: ECS placement strategies - initially adds daemon support which ensures that all ECS instance have a single instance of the service running all the time