### PR TITLE
Rabbit - Remove variables and make log level configurable

### DIFF
--- a/aws/templates/fragment/fragment_rabbit.ftl
+++ b/aws/templates/fragment/fragment_rabbit.ftl
@@ -5,11 +5,18 @@
 
     [@Attributes image="rabbitmq-autocluster" /]
 
+    [#assign settings = _context.DefaultEnvironment]
+    [#assign logLevel = (settings["LOG_LEVEL"])!"info"]
+
+    [@DefaultLinkVariables enabled=false /]
+    [@DefaultCoreVariables enabled=false /]
+    [@DefaultEnvironmentVariables enabled=false /]
+
     [@Variables
         {
             "AUTOCLUSTER_TYPE" : "aws",
             "AUTOCLUSTER_CLEANUP" : "true",
-            "AUTOCLUSTER_LOG_LEVEL" : "debug",
+            "AUTOCLUSTER_LOG_LEVEL" : logLevel,
             "CLEANUP_WARN_ONLY" : "false",
             "AWS_AUTOSCALING" : "true",
             "AWS_DEFAULT_REGION" : regionId


### PR DESCRIPTION
Remove the default settings from the container and make the loglevel configurable using settings. 

 