### PR TITLE
Add support for user defined schema attributes on userpools

### DIFF
--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -134,6 +134,28 @@
                     "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
+                },
+                {
+                    "Names" : "Schema",
+                    "Subobjects" : true,
+                    "Children" :    [
+                        {
+                            "Names" : "DataType",
+                            "Values" : [ "String", "Number", "DateTime","Boolean"],
+                            "Type" : STRING_TYPE,
+                            "Default" : "String"
+                        },
+                        {
+                            "Names" : "Mutable",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Names" : "Required",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        }
+                    ]
                 }
             ]
         }

--- a/aws/templates/resource/resource_cognito.ftl
+++ b/aws/templates/resource/resource_cognito.ftl
@@ -69,12 +69,14 @@
 
 [#function getUserPoolSchemaObject name, datatype, mutable, required]
     [#return
-        {
-            "Name" : name,
-            "AttributeDataType" : datatype,
-            "Mutable" : mutable,
-            "Required" : required
-        }
+        [
+            {
+                "Name" : name,
+                "AttributeDataType" : datatype,
+                "Mutable" : mutable,
+                "Required" : required
+            }
+        ]
     ]
 [/#function]
 

--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -57,25 +57,32 @@
 
         [#if ((solution.MFA) || ( solution.VerifyPhone))]
 
-            [#assign phoneSchema = getUserPoolSchemaObject( 
+            [#assign schema += getUserPoolSchemaObject( 
                                         "phone_number",
                                         "String",
                                         true,
-                                        true)]
-            [#assign schema = schema + [ phoneSchema ]]
+                                        true) ]
 
             [#assign smsConfig = getUserPoolSMSConfiguration( getReference(userPoolRoleId, ARN_ATTRIBUTE_TYPE), userPoolName )]
             [#assign smsVerification = true]
         [/#if]
 
         [#if solution.VerifyEmail || ( solution.LoginAliases.seq_contains("email"))]
-                    [#assign emailSchema = getUserPoolSchemaObject( 
+                    [#assign schema += getUserPoolSchemaObject( 
                                                 "email",
                                                 "String",
                                                 true,
-                                                true)]
-                    [#assign schema = schema +  [ emailSchema ]]
+                                                true) ]
         [/#if]
+
+        [#list solution.Schema as key,schemaAttribute ]
+            [#assign schema +=  getUserPoolSchemaObject(
+                                key,
+                                schemaAttribute.DataType,
+                                schemaAttribute.Mutable,
+                                schemaAttribute.Required
+            )]
+        [/#list]
 
         [#list solution.Links?values as link]
             [#assign linkTarget = getLinkTarget(occurrence, link)]


### PR DESCRIPTION
Allows for schema attributes to be configured as part of a userpool creation. The email and phonenumber attributes are still managed based on the email or sms configuration applied, this just allows for extra schema attributes to be controlled.