### PR TITLE
Add active link target detection

### DIFF
--- a/aws/templates/application/application_apiusageplan.ftl
+++ b/aws/templates/application/application_apiusageplan.ftl
@@ -33,10 +33,6 @@
                 [#assign linkTargetResources = linkTarget.State.Resources ]
                 [#assign linkTargetAttributes = linkTarget.State.Attributes ]
 
-                [#if !(linkTargetConfiguration.Solution.Enabled!true) ]
-                    [#continue]
-                [/#if]
-
                 [#switch linkTargetCore.Type]
                     [#case APIGATEWAY_COMPONENT_TYPE ]
                         [#assign stages +=

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -67,14 +67,12 @@
                                         [#case USERPOOL_COMPONENT_TYPE ]
                                         [#case LAMBDA_FUNCTION_COMPONENT_TYPE ]
                                         [#case APIGATEWAY_COMPONENT_TYPE ]
-                                            [#if linkTargetResources[(linkTargetCore.Type)].Deployed]
-                                                [@createLambdaPermission
-                                                    mode=listMode
-                                                    id=formatLambdaPermissionId(fn, "link", linkName)
-                                                    targetId=fnId
-                                                    source=linkTargetRoles.Inbound["invoke"]
-                                                /]
-                                            [/#if]
+                                            [@createLambdaPermission
+                                                mode=listMode
+                                                id=formatLambdaPermissionId(fn, "link", linkName)
+                                                targetId=fnId
+                                                source=linkTargetRoles.Inbound["invoke"]
+                                            /]
                                             [#break]
 
                                     [/#switch]

--- a/aws/templates/application/application_user.ftl
+++ b/aws/templates/application/application_user.ftl
@@ -131,7 +131,7 @@
             [#assign apikeyNeeded = false ]
             [#list solution.Links?values as link]
                 [#if link?is_hash]
-                    [#assign linkTarget = getLinkTarget(occurrence, link) ]
+                    [#assign linkTarget = getLinkTarget(occurrence, link, false) ]
 
                     [@cfDebug listMode linkTarget false /]
 
@@ -143,7 +143,7 @@
 
                     [#switch linkTarget.Core.Type]
                         [#case APIGATEWAY_USAGEPLAN_COMPONENT_TYPE ]
-                            [#if linkTargetResources["apiusageplan"].Deployed]
+                            [#if isLinkTargetActive(linkTarget) ]
                                 [@createAPIUsagePlanMember
                                     mode=listMode
                                     id=formatDependentResourceId(AWS_APIGATEWAY_USAGEPLAN_MEMBER_RESOURCE_TYPE, apikeyId, link.Id)

--- a/aws/templates/solution/solution_userpool.ftl
+++ b/aws/templates/solution/solution_userpool.ftl
@@ -118,96 +118,90 @@
                     
                 [#case LAMBDA_FUNCTION_COMPONENT_TYPE]
 
-                    [#if linkTargetResources[LAMBDA_FUNCTION_COMPONENT_TYPE].Deployed]
-                        [#-- Cognito Userpool Event Triggers --]
-                        [#-- TODO: When all Cognito Events are available via Cloudformation update the userPoolManualTriggerConfig to userPoolTriggerConfig --]
-                        [#switch link.Name?lower_case]
-                            [#case "createauthchallenge"]
-                                [#assign userPoolTriggerConfig +=
-                                    attributeIfContent (
-                                        "CreateAuthChallenge",
-                                        linkTargetAttributes.ARN
-                                    )
-                                ]
-                                [#break]
-                            [#case "custommessage"]
-                                [#assign userPoolTriggerConfig +=
-                                    attributeIfContent (
-                                        "CustomMessage",
-                                        linkTargetAttributes.ARN
-                                    )
-                                ]
-                                [#break]
-                            [#case "defineauthchallenge"]
-                                [#assign userPoolTriggerConfig +=
-                                    attributeIfContent (
-                                        "DefineAuthChallenge",
-                                        linkTargetAttributes.ARN
-                                    )
-                                ]
-                                [#break]
-                            [#case "postauthentication"]
-                                [#assign userPoolTriggerConfig +=
-                                    attributeIfContent (
-                                        "PostAuthentication",
-                                        linkTargetAttributes.ARN
-                                    )
-                                ]
-                                [#break]
-                            [#case "postconfirmation"]
-                                [#assign userPoolTriggerConfig +=
-                                    attributeIfContent (
-                                        "PostConfirmation",
-                                        linkTargetAttributes.ARN
-                                    )
-                                ]
-                                [#break]
-                            [#case "preauthentication"]
-                                [#assign userPoolTriggerConfig +=
-                                    attributeIfContent (
-                                        "PreAuthentication",
-                                        linkTargetAttributes.ARN
-                                    )
-                                ]
-                                [#break]
-                            [#case "presignup"]
-                                [#assign userPoolTriggerConfig += 
-                                    attributeIfContent (
-                                        "PreSignUp",
-                                        linkTargetAttributes.ARN
-                                    )
-                                ]
-                                [#break]
-                            [#case "verifyauthchallengeresponse"]
-                                [#assign userPoolTriggerConfig += 
-                                    attributeIfContent (
-                                        "VerifyAuthChallengeResponse",
-                                        linkTargetAttributes.ARN
-                                    )
-                                ]
-                                [#break]
-                            [#case "pretokengeneration"]
-                                [#assign userPoolManualTriggerConfig +=
-                                    attributeIfContent (
-                                        "PreTokenGeneration",
-                                        linkTargetAttributes.ARN
-                                    )
-                                ]
-                                [#break]
-                            [#case "usermigration"]
-                                [#assign userPoolManualTriggerConfig +=
-                                    attributeIfContent (
-                                        "UserMigration",
-                                        linkTargetAttributes.ARN
-                                    )
-                                ]
-                                [#break]
-                        [/#switch]
-                    [/#if]
-                [#break]
-                [#case LB_PORT_COMPONENT_TYPE]
-                    [#if linkTargetResources[LB_PORT_COMPONENT_TYPE].Deployed]
-                    [/#if]
+                    [#-- Cognito Userpool Event Triggers --]
+                    [#-- TODO: When all Cognito Events are available via Cloudformation update the userPoolManualTriggerConfig to userPoolTriggerConfig --]
+                    [#switch link.Name?lower_case]
+                        [#case "createauthchallenge"]
+                            [#assign userPoolTriggerConfig +=
+                                attributeIfContent (
+                                    "CreateAuthChallenge",
+                                    linkTargetAttributes.ARN
+                                )
+                            ]
+                            [#break]
+                        [#case "custommessage"]
+                            [#assign userPoolTriggerConfig +=
+                                attributeIfContent (
+                                    "CustomMessage",
+                                    linkTargetAttributes.ARN
+                                )
+                            ]
+                            [#break]
+                        [#case "defineauthchallenge"]
+                            [#assign userPoolTriggerConfig +=
+                                attributeIfContent (
+                                    "DefineAuthChallenge",
+                                    linkTargetAttributes.ARN
+                                )
+                            ]
+                            [#break]
+                        [#case "postauthentication"]
+                            [#assign userPoolTriggerConfig +=
+                                attributeIfContent (
+                                    "PostAuthentication",
+                                    linkTargetAttributes.ARN
+                                )
+                            ]
+                            [#break]
+                        [#case "postconfirmation"]
+                            [#assign userPoolTriggerConfig +=
+                                attributeIfContent (
+                                    "PostConfirmation",
+                                    linkTargetAttributes.ARN
+                                )
+                            ]
+                            [#break]
+                        [#case "preauthentication"]
+                            [#assign userPoolTriggerConfig +=
+                                attributeIfContent (
+                                    "PreAuthentication",
+                                    linkTargetAttributes.ARN
+                                )
+                            ]
+                            [#break]
+                        [#case "presignup"]
+                            [#assign userPoolTriggerConfig += 
+                                attributeIfContent (
+                                    "PreSignUp",
+                                    linkTargetAttributes.ARN
+                                )
+                            ]
+                            [#break]
+                        [#case "verifyauthchallengeresponse"]
+                            [#assign userPoolTriggerConfig += 
+                                attributeIfContent (
+                                    "VerifyAuthChallengeResponse",
+                                    linkTargetAttributes.ARN
+                                )
+                            ]
+                            [#break]
+                        [#case "pretokengeneration"]
+                            [#assign userPoolManualTriggerConfig +=
+                                attributeIfContent (
+                                    "PreTokenGeneration",
+                                    linkTargetAttributes.ARN
+                                )
+                            ]
+                            [#break]
+                        [#case "usermigration"]
+                            [#assign userPoolManualTriggerConfig +=
+                                attributeIfContent (
+                                    "UserMigration",
+                                    linkTargetAttributes.ARN
+                                )
+                            ]
+                            [#break]
+                    [/#switch]
                 [#break]
             [/#switch]
         [/#list]


### PR DESCRIPTION
By default, getLinkTargets will only return active links - the target is
enabled and deployed. It will still return external links regardless.

This means there is no need to check for deployment in most situations.

Occasionally, such as with users, you may wish to have different logic
depending on whether the target is deployed or not, in which case the
Octivenly flag can be set to false, and isTargetActive() used to control
the logic flow.