### PR TITLE
Add a forward rule if no redirect or fixed rule

### DIFF
--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -388,7 +388,7 @@
                     [/#if]
 
                     [#-- Basic Forwarding --]
-                    [#if !listenerRulesConfig?has_content ]
+                    [#if !(isPresent(solution.Redirect) || isPresent(solution.Fixed)) ]
                         [#assign listenerRulesConfig +=
                             {
                                 listenerRuleId : {


### PR DESCRIPTION
With the potential for multiple rules in the config due to domain
redirects, change the logic for determining if a forward rule is
required.