### PR TITLE
Make sure Path property is a valid path

### DIFF
--- a/aws/templates/resource/resource_lb.ftl
+++ b/aws/templates/resource/resource_lb.ftl
@@ -230,7 +230,7 @@
                 "Protocol": protocol,
                 "Port": port,
                 "Host": host,
-                "Path": path,
+                "Path": path?ensure_starts_with("/"),
                 "Query": query,
                 "StatusCode": valueIfTrue("HTTP_301", permanent, "HTTP_302")
             }


### PR DESCRIPTION
Redirect rules always need to start with a / to signify the start of the path. 