### PR TITLE
Add support for Log Mertics and Alarms to Container Deployments

### DIFF
--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -580,7 +580,10 @@
                 "DefaultEnvironmentVariables" : true,
                 "DefaultLinkVariables" : true,
                 "Policy" : standardPolicies(task),
-                "Privileged" : container.Privileged
+                "Privileged" : container.Privileged,
+                "LogMetrics" : container.LogMetrics,
+                "LogWatchers" : container.LogWatchers,
+                "Alerts" : container.Alerts
             } +
             attributeIfContent("LogGroup", containerLogGroup) +
             attributeIfContent("ImageVersion", container.Version) +

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -34,6 +34,21 @@
             "Default" : "awslogs"
         },
         {
+            "Names" : "LogMetrics",
+            "Subobjects" : true,
+            "Children" : logMetricChildrenConfiguration
+        },
+        {
+            "Names" : "LogWatchers",
+            "Subobjects" : true,
+            "Children" : logWatcherChildrenConfiguration
+        },
+        {
+            "Names" : "Alerts",
+            "Subobjects" : true,
+            "Children" : alertChildrenConfiguration
+        },
+        {
             "Names" : "ContainerLogGroup",
             "Type" : BOOLEAN_TYPE,
             "Default" : false
@@ -231,6 +246,21 @@
                     "Default" : true
                 },
                 {
+                    "Names" : "LogMetrics",
+                    "Subobjects" : true,
+                    "Children" : logMetricChildrenConfiguration
+                },
+                {
+                    "Names" : "LogWatchers",
+                    "Subobjects" : true,
+                    "Children" : logWatcherChildrenConfiguration
+                },
+                {
+                    "Names" : "Alerts",
+                    "Subobjects" : true,
+                    "Children" : alertChildrenConfiguration
+                },
+                {
                     "Names" : "NetworkMode",
                     "Type" : STRING_TYPE,
                     "Values" : ["none", "bridge", "awsvpc", "host"],
@@ -310,6 +340,21 @@
                     "Names" : "TaskLogGroup",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : true
+                },
+                {
+                    "Names" : "LogMetrics",
+                    "Subobjects" : true,
+                    "Children" : logMetricChildrenConfiguration
+                },
+                {
+                    "Names" : "LogWatchers",
+                    "Subobjects" : true,
+                    "Children" : logWatcherChildrenConfiguration
+                },
+                {
+                    "Names" : "Alerts",
+                    "Subobjects" : true,
+                    "Children" : alertChildrenConfiguration
                 },
                 {
                     "Names" : "FixedName",

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -39,11 +39,6 @@
             "Children" : logMetricChildrenConfiguration
         },
         {
-            "Names" : "LogWatchers",
-            "Subobjects" : true,
-            "Children" : logWatcherChildrenConfiguration
-        },
-        {
             "Names" : "Alerts",
             "Subobjects" : true,
             "Children" : alertChildrenConfiguration
@@ -251,11 +246,6 @@
                     "Children" : logMetricChildrenConfiguration
                 },
                 {
-                    "Names" : "LogWatchers",
-                    "Subobjects" : true,
-                    "Children" : logWatcherChildrenConfiguration
-                },
-                {
                     "Names" : "Alerts",
                     "Subobjects" : true,
                     "Children" : alertChildrenConfiguration
@@ -345,11 +335,6 @@
                     "Names" : "LogMetrics",
                     "Subobjects" : true,
                     "Children" : logMetricChildrenConfiguration
-                },
-                {
-                    "Names" : "LogWatchers",
-                    "Subobjects" : true,
-                    "Children" : logWatcherChildrenConfiguration
                 },
                 {
                     "Names" : "Alerts",


### PR DESCRIPTION
Adds support for Alarms and Log Metrics on ECS Containers. 

Depending on the Logging type configured, Task Log Group or Container Log group the configuration is either defined on the Task or on the Container. 