### PR TITLE
Force Host header to match origin

### DIFF
--- a/aws/templates/fragment/fragment_cfredirect.ftl
+++ b/aws/templates/fragment/fragment_cfredirect.ftl
@@ -7,7 +7,7 @@
 
     [#assign redirectScript = [
         "'use strict';",
-        "/* This function is used to perform redirects when an application has moved domains", 
+        "/* This function is used to perform redirects when an application has moved domains",
         "    Any request that does not have a host header which matches the Primary Domain",
         "    will be redirected to the same location with the new domain name */",
         "exports.handler = (event, context, callback) => {",
@@ -16,9 +16,11 @@
         "    const host = headers.host[0].value.toLowerCase();",
         "    if ( request.origin.custom ) {",
         "        var customHeaders = request.origin.custom.customHeaders;",
+        "        var originDomain  = request.origin.custom.domainName;",
         "    }",
         "    if ( request.origin.s3 ) { ",
         "        var customHeaders = request.origin.s3.customHeaders;",
+        "        var originDomain  = request.origin.s3.domainName;",
         "    }",
         "    const redirectPrimaryDomainHeaderName = 'X-Redirect-Primary-Domain-Name';",
         "    const redirectResponseCodeHeaderName = 'X-Redirect-Response-Code';",
@@ -34,6 +36,7 @@
         "    }",
         "    /* If for primary domain, proceed with request */",
         "    if ( host === primaryHost  ) {",
+        "        request.headers['host'] = [{key: 'Host', value: originDomain}];",
         "        callback(null, request);",
         "    } else {",
         "        var redirectUrl = 'https://' + primaryHost;",
@@ -59,10 +62,10 @@
         "};"
             ]]
 
-    [@lambdaAttributes 
-        zipFile=redirectScript 
+    [@lambdaAttributes
+        zipFile=redirectScript
     /]
-    
+
     [#-- Ensure Environment Variables are empty for lambda@Edge --]
     [#assign _context += {
         "DefaultEnvironment" : {},

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -201,7 +201,7 @@
         }
     }
 ]
-    
+
 [#function getLambdaState occurrence]
     [#local core = occurrence.Core]
 
@@ -232,7 +232,7 @@
     [#local parentSolution = parent.Configuration.Solution ]
 
     [#local id = formatResourceId(AWS_LAMBDA_FUNCTION_RESOURCE_TYPE, core.Id)]
-    [#local versionId = formatResourceId(AWS_LAMBDA_VERSION_RESOURCE_TYPE, core.Id)]
+    [#local versionId = formatResourceId(AWS_LAMBDA_VERSION_RESOURCE_TYPE, core.Id, runId)]
 
     [#local lgId = formatLogGroupId(core.Id)]
     [#local lgName = formatAbsolutePath("aws", "lambda", core.FullName)]
@@ -250,7 +250,7 @@
                     "Name" : lgName,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
                 }
-            } + 
+            } +
             attributeIfTrue(
                 "version",
                 solution.Versioned,
@@ -266,7 +266,7 @@
                             solution.Versioned
                             formatArn(
                                 regionObject.Partition,
-                                "lambda", 
+                                "lambda",
                                 regionId,
                                 accountObject.AWSId,
                                 "function:" + core.FullName,


### PR DESCRIPTION
For S3, the host needs to be adjusted to match the signature
that will be generated as part of the origin request.