### PR TITLE
Fix lambda version config

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -907,17 +907,25 @@
       },
       "Components": {
         "cfredirect" : {
-          "DeploymentUnits" : ["cfredirect"],
           "Lambda" : {
+              "Instances" : {
+                "default" : {
+                  "Versions" : {
+                      "v1" : {
+                        "DeploymentUnits" : ["cfredirect-v1"],
+                        "Fragment" : "_cfredirect-v1"
+                    }
+                  }
+                }
+              },
               "DeploymentType" : "EDGE",
               "RunTime" : "nodejs6.10",
               "MemorySize" : 128,
               "Timeout" : 1,
-              "Versioned" : true,
+              "FixedCodeVersion" : {},
               "Functions" : {
                   "cfredirect" : {
                       "Handler" : "index.handler",
-                      "Fragment" : "_cfredirect",
                       "VPCAccess" : false,
                       "Permissions" : {
                         "Decrypt" : false,
@@ -1032,7 +1040,7 @@
     }
   },
   "Product": {
-    "cfredirect" : {
+    "cfredirect-v1" : {
       "Region" : "us-east-1"
     },
     "Builds": {

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -53,7 +53,12 @@
     [/#if]
 [/#macro]
 
-[#macro lambdaAttributes imageBucket="" imagePrefix="" zipFile="" ]
+[#macro lambdaAttributes 
+        imageBucket="" 
+        imagePrefix="" 
+        zipFile=""
+        codeHash=""  ]
+
     [#if (fragmentListMode!"") == "model"]
         [#assign _context += {
                 "S3Bucket" : imageBucket,
@@ -63,7 +68,8 @@
                         "\n",
                         asArray(zipFile)
                     ]
-                }
+                },
+                "CodeHash" : codeHash
             }
         ]
     [/#if]

--- a/aws/templates/fragment/fragment_cfredirect.ftl
+++ b/aws/templates/fragment/fragment_cfredirect.ftl
@@ -1,5 +1,4 @@
-[#case "cfredirect"]
-[#case "_cfredirect"]
+[#case "_cfredirect-v1"]
 
     [@DefaultLinkVariables enabled=false /]
     [@DefaultCoreVariables enabled=false /]
@@ -66,9 +65,4 @@
         zipFile=redirectScript
     /]
 
-    [#-- Ensure Environment Variables are empty for lambda@Edge --]
-    [#assign _context += {
-        "DefaultEnvironment" : {},
-        "Environment" : {}
-    }]
     [#break]

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -193,9 +193,14 @@
                     "Children" : settingsChildConfiguration
                 },
                 {
-                    "Names" : "Versioned",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
+                    "Names" : "FixedCodeVersion",
+                    "Children" : [
+                        {
+                            "Names" : "CodeHash",
+                            "Description" : "A sha256 hash of the code zip file",
+                            "Default" : ""
+                        }
+                    ]
                 }
             ]
         }
@@ -237,6 +242,8 @@
     [#local lgId = formatLogGroupId(core.Id)]
     [#local lgName = formatAbsolutePath("aws", "lambda", core.FullName)]
 
+    [#local fixedCodeVersion = isPresent(solution.FixedCodeVersion) ]
+
     [#return
         {
             "Resources" : {
@@ -253,7 +260,7 @@
             } +
             attributeIfTrue(
                 "version",
-                solution.Versioned,
+                fixedCodeVersion,
                 {
                     "Id" : versionId,
                     "Type" : AWS_LAMBDA_VERSION_RESOURCE_TYPE
@@ -263,7 +270,7 @@
                 "REGION" : regionId,
                 "ARN" : valueIfTrue(
                             getExistingReference( versionId ),
-                            solution.Versioned
+                            fixedCodeVersion
                             formatArn(
                                 regionObject.Partition,
                                 "lambda",

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -237,7 +237,7 @@
     [#local parentSolution = parent.Configuration.Solution ]
 
     [#local id = formatResourceId(AWS_LAMBDA_FUNCTION_RESOURCE_TYPE, core.Id)]
-    [#local versionId = formatResourceId(AWS_LAMBDA_VERSION_RESOURCE_TYPE, core.Id, runId)]
+    [#local versionId = formatResourceId(AWS_LAMBDA_VERSION_RESOURCE_TYPE, core.Id )]
 
     [#local lgId = formatLogGroupId(core.Id)]
     [#local lgName = formatAbsolutePath("aws", "lambda", core.FullName)]

--- a/aws/templates/id/id_spa.ftl
+++ b/aws/templates/id/id_spa.ftl
@@ -94,6 +94,17 @@
                             "Default" : true
                         },
                         {
+                            "Names" : "RedirectAliases",
+                            "Description" : "Redirect secondary domains to the primary domain name",
+                            "Children" : [
+                                {
+                                    "Names" : "RedirectVersion",
+                                    "Type" : STRING_TYPE,
+                                    "Default" : "v1"
+                                }
+                            ]
+                        },
+                        {
                             "Names" : "EventHandlers",
                             "Description" : "Attach a function to a stage in the Cloudfront Processing",
                             "Subobjects" : true,

--- a/aws/templates/resource/resource_lambda.ftl
+++ b/aws/templates/resource/resource_lambda.ftl
@@ -87,7 +87,11 @@
     /]
 [/#macro]
 
-[#macro createLambdaVersion mode id targetId description="" dependencies="" ]
+[#macro createLambdaVersion mode id 
+            targetId 
+            codeHash=""
+            description="" 
+            dependencies="" ]
     [@cfResource
         mode=mode
         id=id
@@ -99,6 +103,10 @@
             attributeIfContent(
                 "Description",
                 description
+            ) +
+            attributeIfContent(
+                "CodeSha256",
+                codeHash
             )
         outputs=LAMBDA_VERSION_OUTPUT_MAPPINGS
         dependencies=dependencies

--- a/aws/templates/solution/solution_spa.ftl
+++ b/aws/templates/solution/solution_spa.ftl
@@ -34,13 +34,13 @@
         [#assign eventHandlerLinks = {} ]
         [#assign eventHandlers = []]
 
-        [#if aliases?has_content ]
+        [#if solution.CloudFront.RedirectAliases.Enabled && aliases?has_content ]
             [#assign forwardHeaders += [ "Host" ]]
             [#assign eventHandlerLinks += {
                 "cfredirect" : {
                     "Tier" : "global",
                     "Component" : "cfredirect",
-                    "Version" : "",
+                    "Version" : solution.CloudFront.RedirectAliases.RedirectVersion,
                     "Instance" : "",
                     "Function" : "cfredirect",
                     "Action" : "origin-request"


### PR DESCRIPTION
Adds a version to the cfredirect configuration. Once deployed Lambda@Edge functions have big problems with being updated. 

Locking the cfredirect function to only deploy once means that you have a fixed version Id that can be referenced by CloudFront. If any updates need to be made to the function then a new version of the function needs to be created in the codeontap repository and then rolled out to each CloudFront distribution thorugh the configuration option

```
RedirectAliases : {
      RedirectVersion : ""
}
```

Also introduces codeHash checking for lambda functions which does allow the lambda version to enforce no new changes to the code package. However this does not work for inline ZipFile contents since the deployment package changes on each deployment. 