### PR TITLE
Make sure forwarding is a last resort

### DIFF
--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -388,7 +388,7 @@
                     [/#if]
 
                     [#-- Basic Forwarding --]
-                    [#if !(isPresent(solution.Redirect) || isPresent(solution.Fixed)) ]
+                    [#if !listenerRulesConfig[listenerRuleId]?has_content ]
                         [#assign listenerRulesConfig +=
                             {
                                 listenerRuleId : {
@@ -398,7 +398,6 @@
                                             getListenerRuleForwardAction(targetGroupId))
                                 }
                             } ]
-
                     [/#if]
 
                     [#if deploymentSubsetRequired("cli", false)]


### PR DESCRIPTION
Standard forwarding on an application load balancer should be the last resort so that it can be overridden with anything more specific. 

This change only adds the forward rule if no other primary rule has been added