### PR TITLE
Minor fix for bucket policy Id lookup

### DIFF
--- a/aws/templates/solution/solution_s3.ftl
+++ b/aws/templates/solution/solution_s3.ftl
@@ -53,7 +53,6 @@
             [/#if]
         [/#list]
 
-        [#assign bucketPolicyId = resources["bucketpolicy"].Id ]
         [#assign policyStatements = [] ]
 
         [#list solution.PublicAccess?values as publicAccessConfiguration]
@@ -93,7 +92,7 @@
         [/#list]
         
         [#if policyStatements?has_content ]
-
+            [#assign bucketPolicyId = resources["bucketpolicy"].Id ]
             [@createBucketPolicy
                 mode=listMode
                 id=bucketPolicyId


### PR DESCRIPTION
The bucketPolicy Resource is only available if bucket policy has been configured. Minor fix to make sure the bucketPolicy ID isn't looked up when its not needed