### PR TITLE
Always add IPs to SSH SG if SSH enabled

### DIFF
--- a/aws/templates/segment/segment_bastion.ftl
+++ b/aws/templates/segment/segment_bastion.ftl
@@ -167,7 +167,7 @@
                             {
                                 "Port" : "ssh",
                                 "CIDR" :
-                                    (sshActive && !consoleOnly)?then(
+                                    (sshEnabled && !consoleOnly)?then(
                                         getGroupCIDRs(
                                             (segmentObject.SSH.IPAddressGroups)!
                                                 (segmentObject.IPAddressGroups)!


### PR DESCRIPTION
While the active count is dependent on SSH being active, the SG should
be defined to have the IP addresses so access is allowed if the SSH ASG
is adjusted manually.