### PR TITLE
add PRODUCT_URL attribute to sqs resource with sqs:// prefix

### DIFF
--- a/aws/templates/id/id_sqs.ftl
+++ b/aws/templates/id/id_sqs.ftl
@@ -110,6 +110,7 @@
                 "Attributes" : {
                     "NAME" : getExistingReference(id, NAME_ATTRIBUTE_TYPE),
                     "URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE),
+                    "PRODUCT_URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE)?replace("https", "sqs"),
                     "ARN" : getExistingReference(id, ARN_ATTRIBUTE_TYPE),
                     "REGION" : regionId
                 },

--- a/aws/templates/id/id_sqs.ftl
+++ b/aws/templates/id/id_sqs.ftl
@@ -110,7 +110,7 @@
                 "Attributes" : {
                     "NAME" : getExistingReference(id, NAME_ATTRIBUTE_TYPE),
                     "URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE),
-                    "PRODUCT_URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE)?replace("https", "sqs"),
+                    "PRODUCT_URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE)?replace("https://", "sqs://"),
                     "ARN" : getExistingReference(id, ARN_ATTRIBUTE_TYPE),
                     "REGION" : regionId
                 },


### PR DESCRIPTION
to get an additional broker url with sqs:// protocol instead of https://