### PR TITLE
Add Jenkins auth override for custom authentication

### DIFF
--- a/aws/templates/fragment/fragment_jenkins.ftl
+++ b/aws/templates/fragment/fragment_jenkins.ftl
@@ -11,6 +11,11 @@
         }
     /]
 
+    [@AltSettings 
+        {
+            "JENKINS_URL" : "JENKINSLB_URL"
+        }/]
+
     [#-- Validate that the appropriate settings have been provided for the container to work --]
     [#switch settings["JENKINSENV_SECURITYREALM"]!""]
         [#case "local"]
@@ -44,6 +49,10 @@
                 /]
             [/#if]
             [#break]
+
+        [#case "custom"]
+            [#break]
+
         [#default]
             [@cfException
                 mode=listMode


### PR DESCRIPTION
Adds an override for the jenkins fragment so that you can specify custom authentication without raising an exception