### PR TITLE
Skip type processing for external links

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -808,7 +808,17 @@ behaviour.
             [#if externalAttributes?has_content]
                 [#local result += { "Attributes" : externalAttributes } ]
             [/#if]
-        [/#if]
+
+            [#local result += 
+                    {
+                        "Roles" : {
+                            "Inbound" : {},
+                            "Outbound" : {}
+                        }
+                    }
+                ]]
+
+        [#else]
 
         [#switch core.Type!""]
             [#case LB_COMPONENT_TYPE]
@@ -871,17 +881,6 @@ behaviour.
                 [#local result = getESState(occurrence)]
                 [#break]
 
-            [#case "external"]
-                [#local result +=
-                    {
-                        "Roles" : {
-                            "Inbound" : {},
-                            "Outbound" : {}
-                        }
-                    }
-                ]
-                [#break]
-
             [#case "function"]
                 [#local result = getFunctionState(occurrence, parentOccurrence)]
                 [#break]
@@ -935,6 +934,7 @@ behaviour.
                 [#break]
 
         [/#switch]
+        [/#if]
     [/#if]
 
     [#-- Update resource deployment status --]

--- a/aws/templates/solution/solution_ElasticSearch.ftl
+++ b/aws/templates/solution/solution_ElasticSearch.ftl
@@ -139,7 +139,6 @@
                 [#assign linkTargetConfiguration = linkTarget.Configuration ]
                 [#assign linkTargetResources = linkTarget.State.Resources ]
                 [#assign linkTargetAttributes = linkTarget.State.Attributes ]
-
                 [#switch linkTargetCore.Type]
 
                     [#case USERPOOL_COMPONENT_TYPE]
@@ -159,15 +158,25 @@
                                                     esId,
                                                     link.Name)]
 
-
+                            
                             [#if deploymentSubsetRequired("es", true)]
-                                [@createPolicy
-                                    mode=listMode
-                                    id=policyId
-                                    name=esName
-                                    statements=asFlattenedArray(roles.Outbound["consume"])
-                                    roles=linkTargetResources["authrole"].Id
-                                /]
+                                [#if link.Tier == "external" ]
+                                    [@createPolicy 
+                                        mode=listMode
+                                        id=policyId
+                                        name=esName
+                                        statements=asFlattenedArray(roles.Outbound["consume"])
+                                        roles=linkTargetAttributes.USERPOOL_USERROLE_ARN
+                                    /]
+                                [#else] 
+                                    [@createPolicy
+                                        mode=listMode
+                                        id=policyId
+                                        name=esName
+                                        statements=asFlattenedArray(roles.Outbound["consume"])
+                                        roles=linkTargetResources["authrole"].Id
+                                    /]
+                                [/#if]
                             [/#if]
                         [#break]
                 [/#switch]


### PR DESCRIPTION
When using types for external links skip the collection of the type specific occurrence configuration as it won't be available for the link. 

This means that external links with types do need to be processed specially but this was required anyway. 