### PR TITLE
Fix casing for LB ->  SPA redirect rule

### DIFF
--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -305,7 +305,7 @@
                                         "Priority" : listenerRulePriority,
                                         "Actions" : asArray(
                                                         getListenerRuleRedirectAction(
-                                                            "https",
+                                                            "HTTPS",
                                                             "443",
                                                             linkTargetAttributes.FQDN,
                                                             "",


### PR DESCRIPTION
Minor fix for LB to SPA redirect rule to make sure protocol matches casing requirements