### PR TITLE
ES Override the reference config for external roles

### DIFF
--- a/aws/templates/solution/solution_ElasticSearch.ftl
+++ b/aws/templates/solution/solution_ElasticSearch.ftl
@@ -161,12 +161,15 @@
                             
                             [#if deploymentSubsetRequired("es", true)]
                                 [#if link.Tier == "external" ]
-                                    [@createPolicy 
+                                    [@cfResource
                                         mode=listMode
                                         id=policyId
-                                        name=esName
-                                        statements=asFlattenedArray(roles.Outbound["consume"])
-                                        roles=linkTargetAttributes.USERPOOL_USERROLE_ARN
+                                        type="AWS::IAM::Policy"
+                                        properties=
+                                            getPolicyDocument(asFlattenedArray(roles.Outbound["consume"]), esName) +
+                                            {
+                                                "Roles" : [ linkTargetAttributes.USERPOOL_USERROLE_ARN ]
+                                            }
                                     /]
                                 [#else] 
                                     [@createPolicy


### PR DESCRIPTION
When using an external ES index we can't use a get ref for the role to attach to. This overrides the Policy configuration to ensure that get Reference isn't called