### PR TITLE
Deployment Modes and Profiles

### DIFF
--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -7,6 +7,7 @@ trap '. ${GENERATION_DIR}/cleanupContext.sh' EXIT SIGHUP SIGINT SIGTERM
 # Defaults
 CONFIGURATION_REFERENCE_DEFAULT="unassigned"
 REQUEST_REFERENCE_DEFAULT="unassigned"
+DEPLOYMENT_MODE_DEFAULT="update"
 
 function usage() {
   cat <<EOF
@@ -27,6 +28,7 @@ where
 (d) -t LEVEL                   same as -l
 (o) -u DEPLOYMENT_UNIT         is the deployment unit to be included in the template
 (o) -z DEPLOYMENT_UNIT_SUBSET  is the subset of the deployment unit required
+(o) -d DEPLOYMENT_MODE         is the deployment mode the template will be generated for
 
 (m) mandatory, (o) optional, (d) deprecated
 
@@ -34,6 +36,7 @@ DEFAULTS:
 
 CONFIGURATION_REFERENCE = "${CONFIGURATION_REFERENCE_DEFAULT}"
 REQUEST_REFERENCE       = "${REQUEST_REFERENCE_DEFAULT}"
+DEPLOYMENT_MODE         = "${DEPLOYMENT_MODE_DEFAULT}"
 
 NOTES:
 
@@ -54,10 +57,11 @@ EOF
 function options() {
 
   # Parse options
-  while getopts ":b:c:hl:q:r:s:t:u:z:" option; do
+  while getopts ":b:c:d:hl:q:r:s:t:u:z:" option; do
       case "${option}" in
           b) BUILD_DEPLOYMENT_UNIT="${OPTARG}" ;;
           c) CONFIGURATION_REFERENCE="${OPTARG}" ;;
+          d) DEPLOYMENT_MODE="${OPTARG}" ;;
           h) usage; return 1 ;;
           l) LEVEL="${OPTARG}" ;;
           q) REQUEST_REFERENCE="${OPTARG}" ;;
@@ -74,6 +78,7 @@ function options() {
   # Defaults
   CONFIGURATION_REFERENCE="${CONFIGURATION_REFERENCE:-${CONFIGURATION_REFERENCE_DEFAULT}}"
   REQUEST_REFERENCE="${REQUEST_REFERENCE:-${REQUEST_REFERENCE_DEFAULT}}"
+  DEPLOYMENT_MODE="${DEPLOYMENT_MODE:-${DEPLOYMENT_MODE_DEFAULT}}"
 
   # Check level and deployment unit
   ! isValidUnit "${LEVEL}" "${DEPLOYMENT_UNIT}" && fatal "Deployment unit/level not valid" && return 1
@@ -165,6 +170,7 @@ function process_template() {
   local build_reference="${1}"; shift
   local request_reference="${1}"; shift
   local configuration_reference="${1}"; shift
+  local deployment_mode="${1}"; shift
 
   # Filename parts
   local level_prefix="${level}-"
@@ -370,6 +376,7 @@ function process_template() {
   args+=("-v" "stackOutputs=${COMPOSITE_STACK_OUTPUTS}")
   args+=("-v" "requestReference=${request_reference}")
   args+=("-v" "configurationReference=${configuration_reference}")
+  args+=("-v" "deploymentMode=${DEPLOYMENT_MODE}")
 
   # Directory for temporary files
   pushTempDir "create_template_XXXX"
@@ -569,7 +576,8 @@ function main() {
         "" \
         "${BUILD_DEPLOYMENT_UNIT}" "${BUILD_REFERENCE}" \
         "${REQUEST_REFERENCE}" \
-        "${CONFIGURATION_REFERENCE}"
+        "${CONFIGURATION_REFERENCE}" \
+        "${DEPLOYMENT_MODE}"
       ;;
 
     *)
@@ -581,7 +589,8 @@ function main() {
         "${REGION}" \
         "${BUILD_DEPLOYMENT_UNIT}" "${BUILD_REFERENCE}" \
         "${REQUEST_REFERENCE}" \
-        "${CONFIGURATION_REFERENCE}"
+        "${CONFIGURATION_REFERENCE}" \
+        "${DEPLOYMENT_MODE}"
       ;;
   esac
 }

--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1778,5 +1778,29 @@
     "_sns-failure": {
       "Pattern": "{ $.status = \"FAILURE\" }"
     }
+  },
+  "DeploymentProfiles" : {
+    "_default" :{ 
+      "Modes" : {
+        "maintenance" : {
+          "lb" : {
+            "PortMappings": {
+              "httpsmaintenance": {
+                "Mapping" : "https",
+                "Priority": 50,
+                "Fixed" : {
+                    "Message" : "This application is currently undergoing scheduled maintenance. Please try again later.",
+                    "ContentType" : "text/plain",
+                    "StatusCode" : "503"
+                }
+              }
+            }
+          },
+          "bastion" : {
+            "Active" : true
+          }
+        }
+      }
+    }
   }
 }

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1343,6 +1343,21 @@ behaviour.
         [#local typeObject = component ]
     [/#if]
 
+    [#--  Deployment Profile Configuration Overrides --] 
+    [#if ((getDeploymentProfile(component, type)).Modes[deploymentMode])?? ]
+        [#local deploymentProfileComponents = (getDeploymentProfile(component,type)).Modes[deploymentMode] ]
+
+        [#local deploymentProfile = {} ]
+
+        [#list deploymentProfileComponents as deploymentProfileType,deploymentProfileComponent ]
+            [#local deploymentProfile += {
+                deploymentProfileType?lower_case : deploymentProfileComponent
+             }]
+        [/#list]
+
+        [#local component = mergeObjects(component, { type: deploymentProfile[type]!{} } )]
+    [/#if]
+
     [#if tier?has_content]
         [#local tierId = getTierId(tier) ]
         [#local tierName = getTierName(tier) ]
@@ -1856,6 +1871,22 @@ behaviour.
     [#else]
         [#return profile ]
     [/#if]
+[/#function]
+
+[#function getDeploymentProfile component type ]
+    [#if ((component[type]).Profiles.Deployment)?? ]
+        [#return deploymentProfiles[(component[type]).Profiles.Deployment]]
+    [/#if]
+    [#if (environmentObject.Profiles["Deployment"])?? ]
+        [#return deploymentProfiles[environmentObject.Profiles["Deployment"]]]
+    [/#if]
+    [#if (productObject.Profiles["Deployment"])?? ]
+        [#return deploymentProfiles[solutionObject.Profiles["Deployment"]]]
+    [/#if]
+    [#if (tenantObject.Profiles["Deployment"])??]
+        [#return deploymentProfiles[tenantObject.Profiles["Deployment"]]]
+    [/#if]
+    [#return deploymentProfiles["_default"]]
 [/#function]
 
 [#-- Get storage settings --]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1355,7 +1355,7 @@ behaviour.
              }]
         [/#list]
 
-        [#local component = mergeObjects(component, { type: deploymentProfile[type]!{} } )]
+        [#local typeObject = mergeObjects(typeObject, deploymentProfile[type]!{} )]
     [/#if]
 
     [#if tier?has_content]

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -196,7 +196,7 @@ object.
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : [
+                    "Children" : profileChildConfiguration + [
                         {
                             "Names" : "Security",
                             "Type" : STRING_TYPE,

--- a/aws/templates/id/id_bastion.ftl
+++ b/aws/templates/id/id_bastion.ftl
@@ -43,6 +43,10 @@
                     "Children" : linkChildrenConfiguration
                 },
                 {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
+                },
+                {
                     "Names" : "AutoScaling",
                     "Children" : autoScalingChildConfiguration
                 },

--- a/aws/templates/id/id_cache.ftl
+++ b/aws/templates/id/id_cache.ftl
@@ -48,6 +48,10 @@
                             "Default" : ""
                         }
                     ]
+                },
+                {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
                 }
             ]
         }

--- a/aws/templates/id/id_cognito.ftl
+++ b/aws/templates/id/id_cognito.ftl
@@ -136,6 +136,10 @@
                     "Children" : linkChildrenConfiguration
                 },
                 {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
+                },
+                {
                     "Names" : "Schema",
                     "Subobjects" : true,
                     "Children" :    [

--- a/aws/templates/id/id_computecluster.ftl
+++ b/aws/templates/id/id_computecluster.ftl
@@ -30,6 +30,10 @@
                     "Children" : linkChildrenConfiguration
                 },
                 {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
+                },
+                {
                     "Names" : "UseInitAsService",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false

--- a/aws/templates/id/id_datapipeline.ftl
+++ b/aws/templates/id/id_datapipeline.ftl
@@ -58,6 +58,10 @@
                     "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
+                },
+                {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
                 }
             ]
         }

--- a/aws/templates/id/id_ec2.ftl
+++ b/aws/templates/id/id_ec2.ftl
@@ -116,6 +116,10 @@
                     "Children" : linkChildrenConfiguration
                 },
                 {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
+                },
+                {
                     "Names" : "Ports",
                     "Subobjects" : true,
                     "Children" : [

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -147,6 +147,10 @@
                     "Children" : linkChildrenConfiguration
                 },
                 {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
+                },
+                {
                     "Names" : "AutoScaling",
                     "Children" : autoScalingChildConfiguration
                 },
@@ -272,6 +276,10 @@
                             "Default" : ""
                         }
                     ]
+                },
+                {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
                 }
             ]
         },
@@ -345,6 +353,10 @@
                     "Names" : "FixedName",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
+                },
+                {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
                 }
             ]
         }

--- a/aws/templates/id/id_efs.ftl
+++ b/aws/templates/id/id_efs.ftl
@@ -46,6 +46,10 @@
                     "Names" : "Encrypted",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : true
+                },
+                {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
                 }
             ],
             "Components" : [

--- a/aws/templates/id/id_es.ftl
+++ b/aws/templates/id/id_es.ftl
@@ -73,6 +73,10 @@
                     "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
+                },
+                {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
                 }
             ]
         }

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -97,6 +97,10 @@
                     "Children" : linkChildrenConfiguration
                 },
                 {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
+                },
+                {
                     "Names" : "LogMetrics",
                     "Subobjects" : true,
                     "Children" : logMetricChildrenConfiguration

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -51,7 +51,7 @@
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : [
+                    "Children" : profileChildConfiguration + [
                         {
                             "Names" : "Security",
                             "Type" : STRING_TYPE,

--- a/aws/templates/id/id_mobilenotifier.ftl
+++ b/aws/templates/id/id_mobilenotifier.ftl
@@ -104,6 +104,10 @@
                     "Children" : linkChildrenConfiguration
                 },
                 {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
+                },
+                {
                     "Names" : "LogMetrics",
                     "Subobjects" : true,
                     "Children" : logMetricChildrenConfiguration

--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -117,6 +117,10 @@
                     "Names" : "DBParameters",
                     "Type" : OBJECT_TYPE,
                     "Default" : {}
+                },
+                {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
                 }
             ]
     }

--- a/aws/templates/id/id_s3.ftl
+++ b/aws/templates/id/id_s3.ftl
@@ -164,6 +164,10 @@
                     "Names" : "CORSBehaviours",
                     "Type" : ARRAY_OF_STRING_TYPE,
                     "Default" : []
+                },
+                {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
                 }
             ]
         }

--- a/aws/templates/id/id_spa.ftl
+++ b/aws/templates/id/id_spa.ftl
@@ -148,7 +148,7 @@
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : [
+                    "Children" : profileChildConfiguration + [
                         {
                             "Names" : "Security",
                             "Type" : STRING_TYPE,

--- a/aws/templates/id/id_sqs.ftl
+++ b/aws/templates/id/id_sqs.ftl
@@ -53,6 +53,10 @@
                 {
                     "Names" : "VisibilityTimeout",
                     "Type" : NUMBER_TYPE
+                },
+                {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
                 }
             ]
         }

--- a/aws/templates/id/id_user.ftl
+++ b/aws/templates/id/id_user.ftl
@@ -32,6 +32,10 @@
                     "Children" : linkChildrenConfiguration
                 },
                 {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
+                },
+                {
                     "Names" : "GenerateCredentials",
                     "Children" : [
                         {

--- a/aws/templates/resource/start.ftl
+++ b/aws/templates/resource/start.ftl
@@ -251,7 +251,7 @@
                     ""
                 )
         },
-        "DeploymentMode" : { "Vallue" : deploymentMode }
+        "DeploymentMode" : { "Value" : deploymentMode }
     }]
 [/#function]
 

--- a/aws/templates/resource/start.ftl
+++ b/aws/templates/resource/start.ftl
@@ -235,7 +235,7 @@
     [#return result]
 [/#function]
 
-[#function getCFTemplateCoreOutputs region={ "Ref" : "AWS::Region" } account={ "Ref" : "AWS::AccountId" } deploymentUnit=deploymentUnit level=componentLevel ]
+[#function getCFTemplateCoreOutputs region={ "Ref" : "AWS::Region" } account={ "Ref" : "AWS::AccountId" } deploymentUnit=deploymentUnit level=componentLevel deploymentMode=deploymentMode ]
     [#return {
         "Account" :{ "Value" : account },
         "Region" : {"Value" : region },
@@ -250,7 +250,8 @@
                     "-" + deploymentUnitSubset?lower_case,
                     ""
                 )
-        }
+        },
+        "DeploymentMode" : { "Vallue" : deploymentMode }
     }]
 [/#function]
 

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -384,6 +384,14 @@
     }
 ]]
 
+[#assign profileChildConfiguration = [
+    {
+        "Names" : "Deployment",
+        "Type" : STRING_TYPE
+    }
+]]
+
+
 [#include idList]
 [#include nameList]
 [#include policyList]
@@ -427,6 +435,7 @@
 [#assign bootstrapProfiles = blueprintObject.BootstrapProfiles]
 [#assign securityProfiles = blueprintObject.SecurityProfiles ]
 [#assign logFilters = blueprintObject.LogFilters]
+[#assign deploymentProfiles = blueprintObject.DeploymentProfiles]
 
 [#-- Regions --]
 [#if region?has_content]


### PR DESCRIPTION
Adds the idea of Deployment Profiles, deployment profiles modify the solution configuration based on the deploymentMode which the createTemplate job is being run under. 

This allows you to modify the template generation based on a given scenario. The main examples of this would be to enable maintenance mode or to hibernate a deployment. 

The default configuration that is part of this PR is to add custom configuration for the maintenance deployment Mode .

With the default configuration if you run a ManageEnvironment with the DEPLOYMENT_MODE set to maintenance all, deployed load balancers will be updated to include a new lbport ( listener rule )  called httpsmaintenance. This provides a fixed response that says the site is down for maintenance. 

DeploymentProfile configuration is based on component type, but you can override the deployment profile that will be used on each component to exempt specific components from the configuration applied by a DeploymentProfile