### PR TITLE
Don't default LB maintenance in DeploymentProfiles

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1780,7 +1780,7 @@
     }
   },
   "DeploymentProfiles" : {
-    "_default" :{ 
+    "_frontdoor" :{ 
       "Modes" : {
         "maintenance" : {
           "lb" : {
@@ -1795,9 +1795,6 @@
                 }
               }
             }
-          },
-          "bastion" : {
-            "Active" : true
           }
         }
       }

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1886,7 +1886,7 @@ behaviour.
     [#if (tenantObject.Profiles["Deployment"])??]
         [#return deploymentProfiles[tenantObject.Profiles["Deployment"]]]
     [/#if]
-    [#return deploymentProfiles["_default"]]
+    [#return {}]
 [/#function]
 
 [#-- Get storage settings --]


### PR DESCRIPTION
This causes issues with Network and classic load balancers because they don't support the protocols or fixed responses that application engine load balancers do