### PR TITLE
SPA Support fragment based cloudfront header management

### DIFF
--- a/aws/templates/application/application_spa.ftl
+++ b/aws/templates/application/application_spa.ftl
@@ -43,7 +43,7 @@
         [#if deploymentSubsetRequired("config", false)]
             [@cfConfig
                 mode=listMode
-                content=_context.Environment
+                content={ "RUN_ID" : runId } + _context.Environment
             /]
         [/#if]
         [#if deploymentSubsetRequired("prologue", false)]

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -349,6 +349,30 @@
     [/#if]
 [/#macro]
 
+[#-- CloudFront Specific Fragment Macros --]
+[#macro cfCustomHeader name value ]
+    [#if (fragmentListMode!"") == "model" ]
+        [#assign _context +=
+            {
+                "CustomOriginHeaders" : (_context.CustomOriginHeaders![]) + [
+                    getCFHTTPHeader(
+                        name,
+                        value )
+                ]
+            }]
+    [/#if]
+[/#macro]
+
+[#macro cfForwardHeaders names... ]
+    [#if (fragmentListMode!"") == "model" ]
+        [#assign _context += 
+            {
+                "ForwardHeaders" : (_context.ForwardHeaders![]) + 
+                                        asArray(names)
+            }]
+    [/#if]
+[/#macro]
+
 [#assign ECS_DEFAULT_MEMORY_LIMIT_MULTIPLIER=1.5 ]
 
 [#function defaultEnvironment occurrence links]


### PR DESCRIPTION
Adds support for adding your own custom headers and defining header forwarding in a fragment file for SPA deployments. 

Along with this always put content into the spa config file to make sure one can always be copied