### PR TITLE
Minor fix to bucket sync to allow for new prefix

### DIFF
--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -937,7 +937,7 @@ function syncFilesToBucket() {
   local optional_arguments=("$@")
 
   # Does the bucket/prefix exist?
-  if isBucketAccessible "${region}" "${bucket}" "${prefix}"; then
+  if isBucketAccessible "${region}" "${bucket}"; then
     pushTempDir "${FUNCNAME[0]}_XXXX"
     local tmp_dir="$(getTopTempDir)"
     local return_status


### PR DESCRIPTION
When syncing to an S3 bucket we don't need to know if the prefix already exists since we will be copying new data up to it.