### PR TITLE
WIP: add support for global alert config and refactor logmetric

### DIFF
--- a/aws/templates/id/id_cw.ftl
+++ b/aws/templates/id/id_cw.ftl
@@ -41,6 +41,12 @@
                 extensions)]
 [/#function]
 
+[#function formatLogMetricId ids...]
+    [#return formatResourceId(
+                AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE,
+                ids)]
+[/#function]
+
 [#function formatDependentLogSubscriptionId resourceId extensions... ]
     [#return formatDependentResourceId(
                 AWS_CLOUDWATCH_LOG_SUBSCRIPTION_RESOURCE_TYPE,

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -367,6 +367,17 @@
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
 
+    [#local logMetrics = {} ]
+    [#list solution.LogMetrics as name,logMetric ]
+        [#local logMetrics += {
+            "lgMetric" + name : {
+                "Id" : formatLogMetricId( core.Id, logMetric.Id ),
+                "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, occurrence ),
+                "Type" : AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE
+            }
+        }]
+    [/#list]
+
     [#-- TODO(mfl): Use formatDependentRoleId() for roles --]
     [#return
         {
@@ -413,7 +424,8 @@
                     "Name" : formatAbsolutePath( core.FullAbsolutePath, "instancelog"),
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
                 }
-            },
+            } + 
+            logMetrics,
             "Attributes" : {
             },
             "Roles" : {
@@ -431,6 +443,17 @@
     [#local taskId = formatResourceId(AWS_ECS_TASK_RESOURCE_TYPE, core.Id) ]
     [#local taskName = core.Name]
 
+    [#local logMetrics = {} ]
+    [#list solution.LogMetrics as name,logMetric ]
+        [#local logMetrics += {
+            "lgMetric" + name : {
+                "Id" : formatLogMetricId( core.Id, logMetric.Id ),
+                "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, occurrence ),
+                "Type" : AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE
+            }
+        }]
+    [/#list]
+
     [#return
         {
             "Resources" : {
@@ -443,7 +466,8 @@
                     "Name" : taskName,
                     "Type" : AWS_ECS_TASK_RESOURCE_TYPE
                 }
-            } +
+            } + 
+            logMetrics +
             attributeIfTrue(
                 "lg",
                 solution.TaskLogGroup,
@@ -491,6 +515,17 @@
     [#local taskName = core.Name]
     [#local taskRoleId = formatDependentRoleId(taskId)]
 
+    [#local logMetrics = {} ]
+    [#list solution.LogMetrics as name,logMetric ]
+        [#local logMetrics += {
+            "lgMetric" + name : {
+                "Id" : formatLogMetricId( core.Id, logMetric.Id ),
+                "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, occurrence ),
+                "Type" : AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE
+            }
+        }]
+    [/#list]
+
     [#return
         {
             "Resources" : {
@@ -500,6 +535,7 @@
                     "Type" : AWS_ECS_TASK_RESOURCE_TYPE
                 }
             } +
+            logMetrics +
             attributeIfTrue(
                 "lg",
                 solution.TaskLogGroup,

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -248,13 +248,25 @@
 
     [#local fixedCodeVersion = isPresent(solution.FixedCodeVersion) ]
 
+    [#local logMetrics = {} ]
+    [#list solution.LogMetrics as name,logMetric ]
+        [#local logMetrics += {
+            "lgMetric" + name : {
+                "Id" : formatLogMetricId( core.Id, logMetric.Id ),
+                "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, occurrence ),
+                "Type" : AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE
+            }
+        }]
+    [/#list]
+
     [#return
         {
             "Resources" : {
                 "function" : {
                     "Id" : id,
                     "Name" : core.FullName,
-                    "Type" : AWS_LAMBDA_FUNCTION_RESOURCE_TYPE
+                    "Type" : AWS_LAMBDA_FUNCTION_RESOURCE_TYPE,
+                    "Monitored" : true
                 },
                 "lg" : {
                     "Id" : formatLogGroupId(core.Id),
@@ -269,7 +281,8 @@
                     "Id" : versionId,
                     "Type" : AWS_LAMBDA_VERSION_RESOURCE_TYPE
                 }
-            ),
+            ) + 
+            logMetrics,
             "Attributes" : {
                 "REGION" : regionId,
                 "ARN" : valueIfTrue(

--- a/aws/templates/id/id_mobilenotifier.ftl
+++ b/aws/templates/id/id_mobilenotifier.ftl
@@ -159,7 +159,32 @@
     [#local engine = solution.Engine!core.SubComponent.Name?upper_case  ]
 
     [#local lgId = formatMobileNotifierLogGroupId(engine, name, false) ]
+    [#local lgName = formatMobileNotifierLogGroupName(engine, name, false)]
+
     [#local lgFailureId = formatMobileNotifierLogGroupId(engine, name, true) ]
+    [#local lgFailureName = formatMobileNotifierLogGroupName(engine, name, true)]
+
+
+    [#local logMetrics = {} ]
+    [#list solution.LogMetrics as name,logMetric ]
+        [#local logMetrics += {
+            "lgMetric" + name + "success" : {
+                "Id" : formatLogMetricId( core.Id, logMetric.Id, "success" ),
+                "Name" : formatName(getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, occurrence ),"success"),
+                "Type" : AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE,
+                "LogGroupName" : lgName,
+                "LogGroupId" : lgId
+            },
+            "lgMetric" + name + "failure" : {
+                "Id" : formatLogMetricId( core.Id, logMetric.Id, "failure" ),
+                "Name" : formatName(getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, occurrence ),"failure"),
+                "Type" : AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE,
+                "LogGroupName" : lgFailureName,
+                "LogGroupId" : lgFailureId
+            }
+        }]
+    [/#list]
+
     [#local result =
         {
             "Resources" : {
@@ -171,15 +196,16 @@
                 },
                 "lg" : {
                     "Id" : lgId,
-                    "Name" : formatMobileNotifierLogGroupName(engine, name, false),
+                    "Name" : lgName,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
                 },
                 "lgfailure" : {
                     "Id" : lgFailureId,
-                    "Name" : formatMobileNotifierLogGroupName(engine, name, true),
+                    "Name" : lgFailureName,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
                 }
-            },
+            } +
+            logMetrics,
             "Attributes" : {
                 "ARN" : (engine == MOBILENOTIFIER_SMS_ENGINE)?then(
                             formatArn(

--- a/aws/templates/resource/resource_cw.ftl
+++ b/aws/templates/resource/resource_cw.ftl
@@ -16,6 +16,20 @@
     }
 ]
 
+[#-- Dummy metricAttributes to allow for log watchers --]
+[#assign metricAttributes +=
+    {
+        AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE : {
+            "Namespace" : "_productPath",
+            "Dimensions" : {
+                "None" : {
+                    "None" : ""
+                }
+            }
+        }
+    }
+]
+
 [#macro createLogGroup mode id name retention=0]
     [@cfResource
         mode=mode

--- a/aws/templates/resource/resource_lambda.ftl
+++ b/aws/templates/resource/resource_lambda.ftl
@@ -11,6 +11,19 @@
     }
 ]
 
+[#assign metricAttributes +=
+    {
+        AWS_LAMBDA_FUNCTION_RESOURCE_TYPE : {
+            "Namespace" : "AWS/Lambda",
+            "Dimensions" : {
+                "FunctionName" : {
+                    "ResouceProperty" : "Name" 
+                }
+            }
+        }
+    }
+]
+
 [#assign LAMBDA_VERSION_OUTPUT_MAPPINGS =
     {
         REFERENCE_ATTRIBUTE_TYPE : {

--- a/aws/templates/resource/resource_sqs.ftl
+++ b/aws/templates/resource/resource_sqs.ftl
@@ -22,6 +22,19 @@
     }
 ]
 
+[#assign metricAttributes +=
+    {
+        AWS_SQS_RESOURCE_TYPE : {
+            "Namespace" : "AWS/SQS",
+            "Dimensions" : {
+                "QueueName" : {
+                    "Output" : NAME_ATTRIBUTE_TYPE
+                }
+            }
+        }
+    }
+]
+
 [#macro createSQSQueue mode id name delay="" maximumSize="" retention="" receiveWait="" visibilityTimout="" dlq="" dlqReceives=1 dependencies=""]
     [@cfResource 
         mode=mode

--- a/aws/templates/resource/start.ftl
+++ b/aws/templates/resource/start.ftl
@@ -162,6 +162,9 @@
 [#-- Output mappings object is extended dynamically by each resource type --]
 [#assign outputMappings = {} ]
 
+[#-- Metric Dimensions are extended dynamically by each resouce type --]
+[#assign metricAttributes = {}]
+
 [#-- Include a reference to a resource --]
 [#-- Allows resources to share a template or be separated --]
 [#-- Note that if separate, creation order becomes important --]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -124,6 +124,19 @@
             "Mandatory" : true
         },
         {
+            "Names" : "Resource",
+            "Children" : [
+                {
+                    "Names" : "Name",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Names" : "Type",
+                    "Type" : STRING_TYPE
+                }
+            ]
+        },
+        {
             "Names" : "Metric",
             "Children" : [
                 {
@@ -134,7 +147,8 @@
                 {
                     "Names" : "Type",
                     "Type" : STRING_TYPE,
-                    "Mandatory" : true
+                    "Values" : [ "StandardMetric", "LogFilter" ],
+                    "Default" : "StandardMetric"
                 }
             ]
         },

--- a/aws/templates/solution/solution_mobilenotifier.ftl
+++ b/aws/templates/solution/solution_mobilenotifier.ftl
@@ -133,29 +133,20 @@
 
                 [#list solution.LogMetrics as logMetricName,logMetric ]
 
+                    [#assign logMetricResource = resources[("lgMetric" + logMetricName)] ]
                     [#assign logFilter = logFilters[logMetric.LogFilter].Pattern ]
 
                     [@createLogMetric
                         mode=listMode
-                        id=formatDependentLogMetricId(platformAppId, logMetric.Id)
-                        name=formatName(logMetricName, platformAppName)
-                        logGroup=lgName
+                        id=logMetricResource.Id
+                        name=logMetricResource.Name
+                        logGroup=logMetricResource.LogGroupName
                         filter=logFilter
-                        namespace=formatProductRelativePath()
+                        namespace=getResourceMetricNamespace(logMetricResource)
                         value=1
-                        dependencies=lgId
+                        dependencies=logMetricResource.LogGroupId
                     /]
 
-                    [@createLogMetric
-                        mode=listMode
-                        id=formatDependentLogMetricId(platformAppId, logMetric.Id, "failure")
-                        name=formatName(logMetricName, platformAppName, "failure")
-                        logGroup=lgFailureName
-                        filter=logFilter
-                        namespace=formatProductRelativePath()
-                        value=1
-                        dependencies=lgFailureId
-                    /]
                 [/#list]
             [/#if]
 


### PR DESCRIPTION
This includes two refactors which give us a flexible approach to adding any alarm to any resource.

- Alerts are now resource based and have dimension and namespcace look ups depending on the resource type. This ensures that alerts are filtered to only alert based on the component that they have been added to 

- LogMetrics have been re-factored to support the Alert changes above and adds them as proper resources in the component. 


When configuring an alert you can qualify the alert configuration in 3 different approaches 
- Resource Name - only applies the alert to a given resource 
- Resource Type - applies the alert to all resources in the component which match the specified type 
- Monitored Resources - applies to all resources with an attribute of Monitored set to true ( default ) 

