### PR TITLE
Fix log metric attribute definition on ecs host

### DIFF
--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -168,6 +168,11 @@
                             "Mandatory" : true
                         }
                     ]
+                },
+                {
+                    "Names" : "LogMetrics",
+                    "Subobjects" : true,
+                    "Children" : logMetricChildrenConfiguration
                 }
             ],
             "Components" : [


### PR DESCRIPTION
Added to state generation but not attributes