### PR TITLE
Extend alerting and Log Metric support

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -444,6 +444,8 @@
                 [#assign monitoredResources = getMonitoredResources(resources, alert.Resource)]
                 [#list monitoredResources as name,monitoredResource ]
 
+                    [@cfDebug listMode monitoredResource false /]
+
                     [#switch alert.Comparison ]
                         [#case "Threshold" ]
                             [@createCountAlarm
@@ -453,8 +455,8 @@
                                 actions=[
                                     getReference(formatSegmentSNSTopicId())
                                 ]
-                                metric=getMetricName(alert.Metric, monitoredResource.Type, occurrence)
-                                namespace=getResourceMetricNamespace(monitoredResource)
+                                metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
+                                namespace=getResourceMetricNamespace(monitoredResource.Type)
                                 description=alert.Description!alert.Name
                                 threshold=alert.Threshold
                                 statistic=alert.Statistic
@@ -479,7 +481,7 @@
                     name=logMetric.Name
                     logGroup=logMetric.LogGroupName
                     filter=logFilters[logMetric.LogFilter].Pattern
-                    namespace=getResourceMetricNamespace(logMetric)
+                    namespace=getResourceMetricNamespace(logMetric.Type)
                     value=1
                     dependencies=logMetric.LogGroupId
                 /]

--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -371,7 +371,7 @@
                                         operator=alert.Operator
                                         reportOK=alert.ReportOk
                                         missingData=alert.MissingData
-                                        dimensions=getResourceMetricDimensions(monitoredResource)
+                                        dimensions=getResourceMetricDimensions(monitoredResource, resources)
                                         dependencies=monitoredResource.Id
                                     /]
                                 [#break]
@@ -404,7 +404,7 @@
                                     operator=alert.Operator
                                     reportOK=alert.ReportOk
                                     missingData=alert.MissingData
-                                    dimensions=getResourceMetricDimensions(monitoredResource)
+                                    dimensions=getResourceMetricDimensions(monitoredResource, resources)
                                     dependencies=monitoredResource.Id
                                 /]
                             [#break]

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -387,7 +387,7 @@
                                     operator=alert.Operator
                                     reportOK=alert.ReportOk
                                     missingData=alert.MissingData
-                                    dimensions=getResourceMetricDimensions(monitoredResource)
+                                    dimensions=getResourceMetricDimensions(monitoredResource, resources)
                                     dependencies=monitoredResource.Id
                                 /]
                             [#break]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -2381,25 +2381,33 @@ behaviour.
 
 [/#function]
 
-[#function getResourceMetricNamespace resource ]
-    [#local resourceTypeNameSpace = (metricAttributes[resource.Type]).Namespace ]
+[#function getResourceMetricNamespace resourceType ]
+    [#local resourceTypeNameSpace = (metricAttributes[resourceType]).Namespace!"" ]
 
-    [#switch resourceTypeNameSpace ]
-        [#case "_productPath" ]
-            [#return formatProductRelativePath()]
-            [#break]
-        
-        [#default]
-            [#return resourceTypeNameSpace]
-    [/#switch]
+    [#if resourceTypeNameSpace?has_content ]
+        [#switch resourceTypeNameSpace ]
+            [#case "_productPath" ]
+                [#return formatProductRelativePath()]
+                [#break]
+            
+            [#default]
+                [#return resourceTypeNameSpace]
+        [/#switch]
+    [#else]
+        [@cfException
+            mode=listMode
+            description="Namespace not mapped for this resource"
+            context=resource.Type
+        /]
+    [/#if]
 [/#function]
 
-[#function getMetricName metricName resourceType occurrence ]
+[#function getMetricName metricName resourceType shortFullName ]
 
     [#-- For some metrics we need to append the resourceName to add a qualifier if they don't support dimensions --]
     [#switch resourceType]
         [#case AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE ]
-            [#return formatName(metricName, occurrence.Core.ShortFullName) ]
+            [#return formatName(metricName, shortFullName) ]
     [#break]
 
     [#default]

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -302,16 +302,16 @@ object.
     [#list solution.LogMetrics as name,logMetric ]
         [#local logMetrics += {
             "lgMetric" + name : {
-                "Id" : formatLogMetricId( core.Id, logMetric.Id ),
-                "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, occurrence ),
+                "Id" : formatDependentLogMetricId( lgId, logMetric.Id ),
+                "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, core.ShortFullName ),
                 "Type" : AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE,
                 "LogGroupName" : lgName,
                 "LogGroupId" : lgId,
                 "LogFilter" : logMetric.LogFilter
             },
             "lgMetric" + name + "access" : {
-                "Id" : formatLogMetricId( core.Id, logMetric.Id, "access" ),
-                "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, occurrence ),
+                "Id" : formatDependentLogMetricId( accessLgId, logMetric.Id ),
+                "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, core.ShortFullName ),
                 "Type" : AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE,
                 "LogGroupName" : accessLgName,
                 "LogGroupId" : accessLgId,

--- a/aws/templates/id/id_cw.ftl
+++ b/aws/templates/id/id_cw.ftl
@@ -41,12 +41,6 @@
                 extensions)]
 [/#function]
 
-[#function formatLogMetricId ids...]
-    [#return formatResourceId(
-                AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE,
-                ids)]
-[/#function]
-
 [#function formatDependentLogSubscriptionId resourceId extensions... ]
     [#return formatDependentResourceId(
                 AWS_CLOUDWATCH_LOG_SUBSCRIPTION_RESOURCE_TYPE,

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -378,7 +378,10 @@
             "lgMetric" + name : {
                 "Id" : formatLogMetricId( core.Id, logMetric.Id ),
                 "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, occurrence ),
-                "Type" : AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE
+                "Type" : AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE,
+                "LogGroupName" : lgName,
+                "LogGroupId" : lgId,
+                "LogFilter" : logMetric.LogFilter
             }
         }]
     [/#list]

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -173,6 +173,11 @@
                     "Names" : "LogMetrics",
                     "Subobjects" : true,
                     "Children" : logMetricChildrenConfiguration
+                },
+                {
+                    "Names" : "Alerts",
+                    "Subobjects" : true,
+                    "Children" : alertChildrenConfiguration
                 }
             ],
             "Components" : [
@@ -382,16 +387,16 @@
     [#list solution.LogMetrics as name,logMetric ]
         [#local logMetrics += {
             "lgMetric" + name : {
-                "Id" : formatLogMetricId( core.Id, logMetric.Id ),
-                "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, occurrence ),
+                "Id" : formatDependentLogMetricId( lgId, logMetric.Id ),
+                "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, core.ShortFullName ),
                 "Type" : AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE,
                 "LogGroupName" : lgName,
                 "LogGroupId" : lgId,
                 "LogFilter" : logMetric.LogFilter
             },
             "lgMetric" + name + "instancelog": {
-                "Id" : formatLogMetricId( core.Id, logMetric.Id ),
-                "Name" : formatName(getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, occurrence ),  "instancelog"),
+                "Id" : formatDependentLogMetricId( lgInstanceLogId, logMetric.Id ),
+                "Name" : formatName(getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, core.ShortFullName ),  "instancelog"),
                 "Type" : AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE,
                 "LogGroupName" : lgInstanceLogName,
                 "LogGroupId" : lgInstanceLogId,
@@ -407,7 +412,8 @@
                 "cluster" : {
                     "Id" : formatResourceId(AWS_ECS_RESOURCE_TYPE, core.Id),
                     "Name" : core.FullName,
-                    "Type" : AWS_ECS_RESOURCE_TYPE
+                    "Type" : AWS_ECS_RESOURCE_TYPE,
+                    "Monitored" : true
                 },
                 "securityGroup" : {
                     "Id" : formatComponentSecurityGroupId(core.Tier, core.Component),
@@ -445,9 +451,9 @@
                     "Id" : lgInstanceLogId,
                     "Name" : lgInstanceLogName,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
-                }
-            } + 
-            logMetrics,
+                },
+                "logMetrics" : logMetrics
+            },
             "Attributes" : {
             },
             "Roles" : {
@@ -472,8 +478,8 @@
     [#list solution.LogMetrics as name,logMetric ]
         [#local logMetrics += {
             "lgMetric" + name : {
-                "Id" : formatLogMetricId( core.Id, logMetric.Id ),
-                "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, occurrence ),
+                "Id" : formatDependentLogMetricId( lgId, logMetric.Id ),
+                "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, core.ShortFullName ),
                 "Type" : AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE,
                 "LogGroupName" : lgName,
                 "LogGroupId" : lgId,
@@ -487,7 +493,8 @@
             "Resources" : {
                 "service" : {
                     "Id" : formatResourceId(AWS_ECS_SERVICE_RESOURCE_TYPE, core.Id),
-                    "Type" : AWS_ECS_SERVICE_RESOURCE_TYPE
+                    "Type" : AWS_ECS_SERVICE_RESOURCE_TYPE,
+                    "Monitored" : true
                 },
                 "task" : {
                     "Id" : taskId,
@@ -495,7 +502,7 @@
                     "Type" : AWS_ECS_TASK_RESOURCE_TYPE
                 }
             } + 
-            soluion.TaskLogGroup?then(
+            solution.TaskLogGroup?then(
                 {
                     "lg" : {
                         "Id" : lgId,
@@ -551,8 +558,8 @@
     [#list solution.LogMetrics as name,logMetric ]
         [#local logMetrics += {
             "lgMetric" + name : {
-                "Id" : formatLogMetricId( core.Id, logMetric.Id ),
-                "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, occurrence ),
+                "Id" : formatDependentLogMetricId( lgId, logMetric.Id ),
+                "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, core.ShortFullName ),
                 "Type" : AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE,
                 "LogGroupName" : lgName,
                 "LogGroupId" : lgId,
@@ -570,7 +577,7 @@
                     "Type" : AWS_ECS_TASK_RESOURCE_TYPE
                 }
             } +
-            soluion.TaskLogGroup?then(
+            solution.TaskLogGroup?then(
                 {
                     "lg" : {
                         "Id" : lgId,

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -252,9 +252,12 @@
     [#list solution.LogMetrics as name,logMetric ]
         [#local logMetrics += {
             "lgMetric" + name : {
-                "Id" : formatLogMetricId( core.Id, logMetric.Id ),
-                "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, occurrence ),
-                "Type" : AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE
+                "Id" : formatDependentLogMetricId( lgId, logMetric.Id ),
+                "Name" : getMetricName( logMetric.Name, AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE, core.ShortFullName ),
+                "Type" : AWS_CLOUDWATCH_LOG_METRIC_RESOURCE_TYPE,
+                "LogGroupName" : lgName,
+                "LogGroupId" : lgId,
+                "LogFilter" : logMetric.LogFilter
             }
         }]
     [/#list]
@@ -272,7 +275,8 @@
                     "Id" : formatLogGroupId(core.Id),
                     "Name" : lgName,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
-                }
+                },
+                "logMetrics" : logMetrics
             } +
             attributeIfTrue(
                 "version",
@@ -281,8 +285,7 @@
                     "Id" : versionId,
                     "Type" : AWS_LAMBDA_VERSION_RESOURCE_TYPE
                 }
-            ) + 
-            logMetrics,
+            ),
             "Attributes" : {
                 "REGION" : regionId,
                 "ARN" : valueIfTrue(

--- a/aws/templates/resource/resource_apigateway.ftl
+++ b/aws/templates/resource/resource_apigateway.ftl
@@ -10,6 +10,26 @@
         }
     }
 ]
+
+[#assign metricAttributes +=
+    {
+        AWS_APIGATEWAY_RESOURCE_TYPE : {
+            "Namespace" : "AWS/ApiGateway",
+            "Dimensions" : {
+                "ApiName" : {
+                    "ResourceProperty" : "Name" 
+                },
+                "Stage" : {
+                    "OtherResourceProperty" : {
+                        "Id" : "apistage",
+                        "Property" : "Name"
+                    }
+                }
+            }
+        }
+    }
+]
+
 [#assign APIGATEWAY_USAGEPLAN_OUTPUT_MAPPINGS =
     {
         REFERENCE_ATTRIBUTE_TYPE : {

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -1,5 +1,63 @@
 [#-- ECS --]
 
+[#assign ECS_SERVICE_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        NAME_ATTRIBUTE_TYPE : { 
+            "Attribute" : "Name"
+        }
+    }
+]
+
+[#assign ECS_OUTPUT_MAPPINGS = 
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        ARN_ATTRIBUTE_TYPE : {
+            "Attribute" : "Arn"
+        }
+    }]
+
+[#assign outputMappings +=
+    {
+        AWS_ECS_RESOURCE_TYPE : ECS_OUTPUT_MAPPINGS,
+        AWS_ECS_SERVICE_RESOURCE_TYPE : ECS_SERVICE_OUTPUT_MAPPINGS
+    }
+]
+
+[#assign metricAttributes +=
+    {
+        AWS_ECS_RESOURCE_TYPE : {
+            "Namespace" : "AWS/ECS",
+            "Dimensions" : {
+                "ClusterName" : {
+                    "Output" : "ref" 
+                }
+            }
+        },
+        AWS_ECS_SERVICE_RESOURCE_TYPE : {
+            "Namespace" : "AWS/ECS",
+            "Dimensions" : {
+                "ServiceName" : {
+                    "Output" : "name"
+                }
+            }
+        }
+    }
+]
+
+[#macro createECSCluster mode id ]
+        [@cfResource
+            mode=mode
+            id=id
+            type="AWS::ECS::Cluster"
+            outputs=ECS_OUTPUT_MAPPINGS
+        /]
+[/#macro]
+
 [#macro createECSTask mode id name containers networkMode="" fixedName=false role="" dependencies=""]
 
     [#local definitions = [] ]
@@ -186,6 +244,7 @@
                 (loadBalancers![])?has_content && networkMode != "awsvpc"
             )
         dependencies=dependencies
+        outputs=ECS_SERVICE_OUTPUT_MAPPINGS
     /]
 [/#macro]
 

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -5,8 +5,22 @@
         REFERENCE_ATTRIBUTE_TYPE : {
             "UseRef" : true
         },
+        "ARN_ATTRIBUTE_TYPE" : {
+            "UseRef" : true
+        },
         NAME_ATTRIBUTE_TYPE : { 
             "Attribute" : "Name"
+        }
+    }
+]
+
+[#assign ECS_TASK_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        ARN_ATTRIBUTE_TYPE : { 
+            "UseRef" : true
         }
     }
 ]
@@ -24,7 +38,8 @@
 [#assign outputMappings +=
     {
         AWS_ECS_RESOURCE_TYPE : ECS_OUTPUT_MAPPINGS,
-        AWS_ECS_SERVICE_RESOURCE_TYPE : ECS_SERVICE_OUTPUT_MAPPINGS
+        AWS_ECS_SERVICE_RESOURCE_TYPE : ECS_SERVICE_OUTPUT_MAPPINGS,
+        AWS_ECS_TASK_RESOURCE_TYPE : ECS_TASK_OUTPUT_MAPPINGS
     }
 ]
 
@@ -177,6 +192,7 @@
         type="AWS::ECS::TaskDefinition"
         properties=taskProperties
         dependencies=dependencies
+        outputs=ECS_TASK_OUTPUT_MAPPINGS
     /]
 [/#macro]
 

--- a/aws/templates/resource/resource_lambda.ftl
+++ b/aws/templates/resource/resource_lambda.ftl
@@ -17,7 +17,7 @@
             "Namespace" : "AWS/Lambda",
             "Dimensions" : {
                 "FunctionName" : {
-                    "ResouceProperty" : "Name" 
+                    "ResourceProperty" : "Name" 
                 }
             }
         }

--- a/aws/templates/resource/resource_sns.ftl
+++ b/aws/templates/resource/resource_sns.ftl
@@ -33,6 +33,22 @@
     }
 ]
 
+[#assign metricAttributes +=
+    {
+        AWS_SNS_PLATFORMAPPLICATION_RESOURCE_TYPE : {
+            "Namespace" : "AWS/SNS",
+            "Dimensions" : {
+                "Application" : {
+                    "ResourceProperty" : "Name" 
+                },
+                "Platform" : {
+                    "ResourceProperty" : "Engine"
+                }
+            }
+        }
+    }
+]
+
 [#macro createSNSTopic mode id displayName topicName=""]
     [@cfResource
         mode=mode

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -127,7 +127,7 @@
             "Names" : "Resource",
             "Children" : [
                 {
-                    "Names" : "Name",
+                    "Names" : "Id",
                     "Type" : STRING_TYPE
                 },
                 {

--- a/aws/templates/solution/solution_sqs.ftl
+++ b/aws/templates/solution/solution_sqs.ftl
@@ -69,7 +69,7 @@
                             operator=alert.Operator
                             reportOK=alert.ReportOk
                             missingData=alert.MissingData
-                            dimensions=getResourceMetricDimensions(monitoredResource)
+                            dimensions=getResourceMetricDimensions(monitoredResource, resources)
                             dependencies=monitoredResource.Id
                         /]
                     [#break]

--- a/aws/templates/solution/solution_sqs.ftl
+++ b/aws/templates/solution/solution_sqs.ftl
@@ -59,8 +59,8 @@
                             actions=[
                                 getReference(formatSegmentSNSTopicId())
                             ]
-                            metric=getMetricName(alert.Metric, monitoredResource.Type, fn)
-                            namespace=getResourceMetricNamespace(monitoredResource)
+                            metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
+                            namespace=getResourceMetricNamespace(monitoredResource.Type)
                             description=alert.Description!alert.Name
                             threshold=alert.Threshold
                             statistic=alert.Statistic


### PR DESCRIPTION
This PR adds support for Metric based alerting and Log Metrics for the following Components

- APIGateway - Metric Alerts and Log Metrics 
- Mobile Notifier - Metric Alerts and Log Metrics 
- Lambda - Metric Alerts and Log Metrics 
- ECS Hosts - Metric Alerts and Log Metrics 
    - ECS Services - Metric Alerts and Log Metrics 
    - ECS Tasks - Log Metrics  ( Metrics not available for Tasks ) 
       - ECS Containers - Log Metric ( When container based logs are enabled ) 

To support this all of the resources metrics and dimensions have been mapped to their appropriate values and outputs have been added for ECS hosts and ECS Tasks 

My brain hurts now...