### PR TITLE
Add support for time based scheduled ECS tasks

### DIFF
--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -298,14 +298,18 @@
 
                     [#assign scheduleRuleId = formatEventRuleId(fn, "schedule", schedule.Id) ]
 
+                    [#assign targetParameters = {
+                        "Arn" : getReference(fnId, ARN_ATTRIBUTE_TYPE),
+                        "Id" : fnId,
+                        "Input" : getJSON(input?has_content?then(schedule.Input,{ "path" : schedule.InputPath }))
+                    }]
+
                     [@createScheduleEventRule
                         mode=listMode
                         id=scheduleRuleId
-                        targetId=fnId
                         enabled=schedule.Enabled
                         scheduleExpression=schedule.Expression
-                        input=schedule.Input
-                        path=schedule.InputPath
+                        targetParameters=targetParameters
                         dependencies=fnId
                     /]
 

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -362,6 +362,23 @@
                 {
                     "Names" : "Profiles",
                     "Children" : profileChildConfiguration
+                },
+                {
+                    "Names" : "Schedules",
+                    "Subobjects" : true,
+                    "Children" : [
+                        {
+                            "Names" : "Expression",
+                            "Type" : STRING_TYPE,
+                            "Default" : "rate(1 hours)"
+                        },
+                        {
+                            "Names" : "TaskCount",
+                            "Description" : "The number of tasks to run on the schedule",
+                            "Type" : NUMBER_TYPE
+                            "Default" : 1
+                        }
+                    ]
                 }
             ]
         }
@@ -561,11 +578,19 @@
             "Attributes" : {
                 "ECSHOST" : getExistingReference(ecsId)
             } +
-                attributeIfTrue(
-                    "DEFINITION",
-                    solution.FixedName,
-                    taskName
-                ),
+            attributeIfTrue(
+                "DEFINITION",
+                solution.FixedName,
+                taskName
+            ) + 
+            attributeIfContent(
+                "scheduleRole",
+                solution.Schedules,
+                {
+                    "Id" : formatDependentRoleId(taskId, "schedule"),
+                    "TYPE" : AWS_IAM_ROLE_RESOURCE_TYPE
+                }
+            ),
             "Roles" : {
                 "Inbound" : {},
                 "Outbound" : {

--- a/aws/templates/policy/policy_ecs.ftl
+++ b/aws/templates/policy/policy_ecs.ftl
@@ -20,7 +20,7 @@
     ]
 [/#function]
 
-[#function ecsTaskRunPermission ecsId ]
+[#function ecsTaskRunPermission ecsId taskId="" ]
 
     [#local clusterArn = formatEcsClusterArn(ecsId)]
     [#return
@@ -41,7 +41,10 @@
                     "ecs:StartTask",
                     "ecs:StopTask"
                 ],
-                "*",
+                taskId?has_content(
+                    getReference(taskId, ARN_ATTRIBUTE_TYPE),
+                    "*"
+                ),
                 "",
                 {
                     "ArnEquals" :{

--- a/aws/templates/resource/resource_event.ftl
+++ b/aws/templates/resource/resource_event.ftl
@@ -16,17 +16,19 @@
         AWS_EVENT_RULE_RESOURCE_TYPE : EVENT_RULE_OUTPUT_MAPPINGS
     }
 ]
-[#macro createScheduleEventRule mode id targetId enabled scheduleExpression input={} path="" dependencies=""]
-
-
+[#macro createScheduleEventRule mode id 
+        targetId 
+        enabled 
+        scheduleExpression 
+        targetParameters
+        dependencies="" ]
+        
     [#if enabled ] 
         [#assign state = "ENABLED" ]
     [#else]
         [#assign state = "DISABLED" ]
     [/#if]
     
-    
-
     [@cfResource
         mode=mode
         id=id
@@ -35,11 +37,7 @@
             {
                 "ScheduleExpression" : scheduleExpression,
                 "State" : state,
-                "Targets" : [{
-                    "Arn" : getReference(targetId, ARN_ATTRIBUTE_TYPE),
-                    "Id" : targetId,
-                    "Input" : getJSON(input?has_content?then(input,{ "path" : path }))
-                }]
+                "Targets" : asArray(targetParameters)
             }
         outputs=EVENT_RULE_OUTPUT_MAPPINGS
         dependencies=dependencies


### PR DESCRIPTION
Depends on #621 for ECS output mappings

ECS tasks can be triggered through CloudWatch events which provide a cron like schedule for running tasks.

We currently use this on lambda functions and this PR extends that functionality for ECS tasks. This can be used for long running tasks or using code already in a container for a scheduled task.

The command/entrypoint can not be overridden when it is invoked so the task must be able to run using the command/entry point the task is deployed with ( They can be overriden when defining the task using fragment files )