### PR TITLE
Add support for cross region replication in S3

### DIFF
--- a/aws/templates/id/id_s3.ftl
+++ b/aws/templates/id/id_s3.ftl
@@ -237,7 +237,7 @@
                 "INTERNAL_FQDN" : getExistingReference(id, DNS_ATTRIBUTE_TYPE),
                 "WEBSITE_URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE),
                 "ARN" : getExistingReference(id, ARN_ATTRIBUTE_TYPE),
-                "REGION" : (getExistngReference(id, REGION_ATTRIBUTE_TYPE))!regionId
+                "REGION" : getExistingReference(id, REGION_ATTRIBUTE_TYPE)
             },
             "Roles" : {
                 "Inbound" : {},
@@ -245,7 +245,8 @@
                     "all" : s3AllPermission(id),
                     "produce" : s3ProducePermission(id),
                     "consume" : s3ConsumePermission(id),
-                    "replicadestination" : s3ReplicaDestinationPermission(id)
+                    "replicadestination" : s3ReplicaDestinationPermission(id),
+                    "replicasource" : {}
                }
             }
         }

--- a/aws/templates/id/id_s3.ftl
+++ b/aws/templates/id/id_s3.ftl
@@ -168,6 +168,26 @@
                 {
                     "Names" : "Profiles",
                     "Children" : profileChildConfiguration
+                },
+                {
+                    "Names" : "Replication",
+                    "Children" : [
+                        {
+                            "Names" : "Prefixes",
+                            "Type" : ARRAY_OF_STRING_TYPE,
+                            "Default" : [ "" ]
+                        },
+                        {
+                            "Names" : "Enabled",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        }
+                    ]
+                },
+                {
+                    "Names" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
                 }
             ]
         }
@@ -196,6 +216,10 @@
                             getExistingReference(id, NAME_ATTRIBUTE_TYPE),
                             name),
                     "Type" : AWS_S3_RESOURCE_TYPE
+                },
+                "role" : {
+                    "Id" : formatResourceId( AWS_IAM_ROLE_RESOURCE_TYPE, core.Id ),
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
                 }
             } +
             publicAccessEnabled?then(
@@ -213,14 +237,15 @@
                 "INTERNAL_FQDN" : getExistingReference(id, DNS_ATTRIBUTE_TYPE),
                 "WEBSITE_URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE),
                 "ARN" : getExistingReference(id, ARN_ATTRIBUTE_TYPE),
-                "REGION" : regionId
+                "REGION" : (getExistngReference(id, REGION_ATTRIBUTE_TYPE))!regionId
             },
             "Roles" : {
                 "Inbound" : {},
                 "Outbound" : {
                     "all" : s3AllPermission(id),
                     "produce" : s3ProducePermission(id),
-                    "consume" : s3ConsumePermission(id)
+                    "consume" : s3ConsumePermission(id),
+                    "replicadestination" : s3ReplicaDestinationPermission(id)
                }
             }
         }

--- a/aws/templates/id/start.ftl
+++ b/aws/templates/id/start.ftl
@@ -133,6 +133,7 @@
 [#assign BRANCH_ATTRIBUTE_TYPE = "branch" ]
 [#assign PREFIX_ATTRIBUTE_TYPE = "prefix" ]
 [#assign LASTRESTORE_ATTRIBUTE_TYPE = "lastrestore" ]
+[#assign REGION_ATTRIBUTE_TYPE = "region"]
 
 [#-- special attribute type to handle references --]
 [#assign REFERENCE_ATTRIBUTE_TYPE = "ref" ]

--- a/aws/templates/policy/policy_s3.ftl
+++ b/aws/templates/policy/policy_s3.ftl
@@ -202,3 +202,46 @@
             principals,
             conditions)]
 [/#function]
+
+[#function s3ReplicaSourcePermission bucket prefix="" object="*"]
+    [#return 
+
+        getS3Statement(
+            [
+                "s3:GetObjectVersion",
+                "s3:GetObjectVersionAcl",
+                "s3:GetObjectVersionTagging"
+            ],
+            bucket,
+            prefix,
+            object
+        )
+    ]
+[/#function]
+
+[#function s3ReplicationConfigurationPermission bucket ]
+    [#return 
+        getS3BucketStatement(
+            [
+                "s3:GetReplicationConfiguration",
+                "s3:ListBucket"
+            ],
+            bucket
+        )
+    ]
+[/#function]
+
+[#function s3ReplicaDestinationPermission bucket prefix="" object="*" ]
+    [#return 
+        getS3Statement(
+            [
+                "s3:ReplicateObject",
+                "s3:ReplicateDelete",
+                "s3:ReplicateTags"
+            ],
+            bucket,
+            prefix,
+            object
+        )
+    ]
+[/#function]


### PR DESCRIPTION
Adds the ability to replicate data between s3 buckets in different regions ( the actual functionality supports accounts but hasn't been implemented in this PR) 

To enable replication the following configuration needs to be applied
- 2 Solution level S3 buckets deployed 
   - 1 in your primary region 
   - 1 in a secondary region ( region can be set using the product object and adding a region override for the bucket's deployment unit ) i.e. if deployment unit was `stgrep`
```
{
    "Product" : {
        "Title" : "Walks Register",
        "Name" : "walksregister",
        "Id" : "register",
        "Domain" : "walksregister",
        "stgrep" : {
            "Region" : "eu-west-1"
        }
    }
}
```

- On the Source Bucket  add a link to the destination bucket with the role `replicadestination`
- On the Destination Bucket add a link to the source bucket with the role `replicasource`

This will enable Versioning on both buckets and enable replication. 

Further configuration of the replication can be configured on the Source bucket 
- Prefixes - Specifies an array of prefixes which will only be replicated
- Enabled - Creates the replication rule but sets its status to disabled