### PR TITLE
Add support for componets to hibernate resources

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1798,6 +1798,22 @@
           }
         }
       }
+    },
+    "_hibernate" : {
+      "Modes" : {
+        "maintenance" : {
+          "ecs" : {
+            "Hibernate" : {
+              "Enabled" : true
+            }
+          },
+          "rds" : {
+            "Hibernate" : {
+              "Enabled" : true
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -178,6 +178,22 @@
                     "Names" : "Alerts",
                     "Subobjects" : true,
                     "Children" : alertChildrenConfiguration
+                },
+                {
+                    "Names" : "Hibernate",
+                    "Children" : [
+                        {
+                            "Names" : "Enabled",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : false
+                        },
+                        {
+                            "Names" : "StartUpMode",
+                            "Type" : STRING_TYPE,
+                            "Values" : ["replace"],
+                            "Default" : "replace"
+                        }
+                    ]
                 }
             ],
             "Components" : [

--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -102,6 +102,12 @@
                             "Names" : "SnapshotOnDeploy",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
+                        },
+                        {
+                            "Names" : "DeleteAutoBackups",
+                            "Type" : BOOLEAN_TYPE,
+                            "Description" : "Delete automated snapshots when the instance is deleted",
+                            "Default" : true
                         }
                     ]
                 },
@@ -121,6 +127,22 @@
                 {
                     "Names" : "Profiles",
                     "Children" : profileChildConfiguration
+                },
+                {
+                    "Names" : "Hibernate",
+                    "Children" : [
+                        {
+                            "Names" : "Enabled",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : false
+                        },
+                        {
+                            "Names" : "StartUpMode",
+                            "Type" : STRING_TYPE,
+                            "Values" : ["restore", "replace"],
+                            "Default" : "restore"
+                        }
+                    ]
                 }
             ]
     }

--- a/aws/templates/resource/resource_ec2.ftl
+++ b/aws/templates/resource/resource_ec2.ftl
@@ -669,6 +669,7 @@
     autoScalingConfig
     multiAZ
     tags
+    hibernate=false
     loadBalancers=[]
     targetGroups=[]
     dependencies="" 
@@ -701,6 +702,12 @@
                     processorProfile.DesiredPerZone * zones?size,
                     processorProfile.DesiredPerZone
     )]
+
+    [#if hibernate ]
+        [#assign minSize = 0 ]
+        [#assign desiredCapacity = 0 ]
+        [#assign maxSize = 0]
+    [/#if]
 
     [@cfResource
         mode=mode

--- a/aws/templates/resource/resource_rds.ftl
+++ b/aws/templates/resource/resource_rds.ftl
@@ -41,6 +41,7 @@
     dependencies="" 
     outputId=""
     autoMinorVersionUpgrade=true
+    deleteAutomatedBackups=true
 ]
     [@cfResource 
     mode=listMode
@@ -53,6 +54,7 @@
             "DBInstanceClass" : processor,
             "AllocatedStorage": size,
             "AutoMinorVersionUpgrade": autoMinorVersionUpgrade,
+            "DeleteAutomatedBackups" : deleteAutomatedBackups,
             "StorageType" : "gp2",
             "Port" : port,
             "BackupRetentionPeriod" : retentionPeriod,

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -27,6 +27,9 @@
         [#assign defaultLogDriver = solution.LogDriver ]
         [#assign fixedIP = solution.FixedIP ]
 
+        [#assign hibernate = solution.Hibernate.Enabled && 
+                                getExistingReference(ecsId)?has_content ]
+
         [#assign logFileProfile = getLogFileProfile(tier, component, "ECS")]
         [#assign bootstrapProfile = getBootstrapProfile(tier, component, "ECS")]
         [#assign processorProfile = getProcessor(tier, component, "ECS")]
@@ -283,6 +286,7 @@
                 autoScalingConfig=solution.AutoScaling
                 multiAZ=multiAZ
                 tags=ecsTags
+                hibernate=hibernate
             /]
 
             [@createEC2LaunchConfig


### PR DESCRIPTION
Allows for a component to be deployed in a hibernated state. 
In a hibernated state resources which are generally charged on a time basis are shutdown or removed with specific configuration to restore them if they are state based, like RDS. 

This is intended to be used with deployment Profiles/deployment modes so that you can run a management environment using a specific deployment mode which enables hibernation on the component. 

This PR adds hibernate support for two components 
- RDS 
  - Creates a snapshot of the database and then removes the RDS instance from the cloudformation template, leaving everything else behind. RDS instances can be shutdown but will automatically restart after 7 days 
   - Has two startup modes, restore and replace. restore uses the snapshot to rebuild the database and replace will provision a new data base 
- ECS 
  - Sets the desired count on the autoscale group to 0
   - Sets any Services deployed in the component's desired count to 0 
  - disables any schedule tasks cloudwatch events 
