### PR TITLE
WIP: Add GEN3 framework version compatability checking

### DIFF
--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -4,6 +4,360 @@
 #
 # This script is designed to be sourced into other scripts
 
+# -- GEN3 directory structure --
+
+# Processing should start by calling this function to establish the scope of processing
+function findGen3RootDir() {
+  local current="$1"; shift
+
+  # First check for an explicitly marked root
+  local marked_root_dir="$(findAncestorDir root.json "${current}")"
+  [[ -n "${marked_root_dir}" ]] && echo -n "${marked_root_dir}" && return 0
+
+  # Now look for the first dir containing both a config and infrastructure directory
+  local config_root_dir="$(filePath "$(findAncestorDir config "${current}")")"
+  local infrastructure_root_dir="$(filePath "$(findAncestorDir infrastructure "${current}")")"
+  local root_dir="${config_root_dir:-${infrastructure_root_dir}}"
+
+  [[ (-d "${root_dir}/config") && (-d "${root_dir}/infrastructure") ]] && echo -n "${root_dir}" && return 0
+
+  return 1
+}
+
+function findGen3TenantDir() {
+  local root_dir="$1"; shift
+  local tenant="$1"; shift
+
+  findDir "${root_dir}" \
+    "${tenant}/tenant.json" \
+    "${tenant}/config/tenant.json" \
+    "tenant.json"
+}
+
+function findGen3TenantInfrastructureDir() {
+  local root_dir="$1"; shift
+  local tenant="$1"; shift
+
+  findDir "${root_dir}" \
+    "${tenant}/infrastructure"
+}
+
+function findGen3AccountDir() {
+  local root_dir="$1"; shift
+  local account="$1"; shift
+
+  findDir "${root_dir}" \
+    "${account}/account.json" \
+    "${account}/config/account.json"
+}
+
+function findGen3AccountSettingsDir() {
+  local root_dir="$1"; shift
+  local account="$1"; shift
+
+  local account_dir="$(findGen3AccountDir "${root_dir}" "${account}")"
+  if [[ -n "${account_dir}" ]]; then
+    echo -n "${account_dir}/settings"
+    return 0
+  fi
+  return 1
+}
+
+function findGen3AccountInfrastructureDir() {
+  local root_dir="$1"; shift
+  local account="$1"; shift
+
+  findDir "${root_dir}" \
+    "infrastructure/**/${account}" \
+    "${account}/infrastructure"
+}
+
+# It would be very rare that accounts would have standard settings and operations
+# settings as normally the accounts tree is controlled by the operations team.
+# Thus the settings directory should be adequate. Nonetheless it allows consistency
+# if the operations team always put their settings in the operations directory,
+# regardless of repo.
+function findGen3AccountOperationsDir() {
+  local root_dir="$1"; shift
+  local account="$1"; shift
+
+  local infrastructure_dir="$(findGen3AccountInfrastructureDir "${root_dir}" "${account}")"
+  if [[ -n "${infrastructure_dir}" ]]; then
+    echo -n "${infrastructure_dir}/operations"
+    return 0
+  fi
+  return 1
+}
+
+# TODO(mfl): Remove infrastructure checks when all repos converted to >=v2.0.0
+function findGen3AccountStateDir() {
+  local root_dir="$1"; shift
+  local account="$1"; shift
+
+  findDir "${root_dir}" \
+    "state/**/${account}" \
+    "${account}/state" \
+    "infrastructure/**/${account}" \
+    "${account}/infrastructure"
+}
+
+function findGen3ProductDir() {
+  local root_dir="$1"; shift
+  local product="$1"; shift
+
+  findDir "${root_dir}" \
+    "${product}/product.json" \
+    "${product}/config/product.json"
+}
+
+function findGen3ProductSettingsDir() {
+  local root_dir="$1"; shift
+  local product="$1"; shift
+
+  local product_dir="$(findGen3ProductDir "${root_dir}" "${product}")"
+  if [[ -n "${product_dir}" ]]; then
+    echo -n "${product_dir}/settings"
+    return 0
+  fi
+  return 1
+}
+
+function findGen3ProductInfrastructureDir() {
+  local root_dir="$1"; shift
+  local product="$1"; shift
+
+  findDir "${root_dir}" \
+    "infrastructure/**/${product}" \
+    "${product}/infrastructure"
+}
+
+function findGen3ProductOperationsDir() {
+  local root_dir="$1"; shift
+  local product="$1"; shift
+
+  local infrastructure_dir="$(findGen3ProductInfrastructureDir "${root_dir}" "${product}")"
+  if [[ -n "${infrastructure_dir}" ]]; then
+    echo -n "${infrastructure_dir}/operations"
+    return 0
+  fi
+  return 1
+}
+
+# TODO(mfl): Remove config checks when all repos converted to >=v2.0.0
+function findGen3ProductSolutionsDir() {
+  local root_dir="$1"; shift
+  local product="$1"; shift
+
+  findDir "${root_dir}" \
+    "infrastructure/**/${product}/solutions" \
+    "${product}/infrastructure/solutions" \
+    "config/**/${product}/solutionsv2" \
+    "${product}/config/solutionsv2"
+}
+
+# TODO(mfl): Remove config checks when all repos converted to >=v2.0.0
+function findGen3ProductBuildsDir() {
+  local root_dir="$1"; shift
+  local product="$1"; shift
+
+  findDir "${root_dir}" \
+    "infrastructure/**/${product}/builds" \
+    "${product}/infrastructure/builds" \
+    "config/**/${product}/settings" \
+    "${product}/config/settings"
+}
+
+# TODO(mfl): Remove infrastructure checks when all repos converted to >=v2.0.0
+function findGen3ProductStateDir() {
+  local root_dir="$1"; shift
+  local product="$1"; shift
+
+  findDir "${root_dir}" \
+    "state/**/${product}" \
+    "${product}/state" \
+    "infrastructure/**/${product}" \
+    "${product}/infrastructure"
+}
+
+function findGen3ProductEnvironmentDir() {
+  local root_dir="$1"; shift
+  local product="$1"; shift
+  local environment="$1"; shift
+
+  local solutions_dir="$(findGen3ProductSolutionsDir "${root_dir}" "${product}")"
+  [[ -z "${solutions_dir}" ]] && return 1
+
+  findDir "${solutions_dir}" "${environment}/environment.json"
+}
+
+function findGen3ProductEnvironmentSegmentDir() {
+  local root_dir="$1"; shift
+  local product="$1"; shift
+  local environment="$1"; shift
+  local segment="$1"; shift
+
+  local environment_dir="$(findGen3ProductEnvironmentDir "${root_dir}" "${product}" "${environment}")"
+  [[ -z "${environment_dir}" ]] && return 1
+
+  findDir "${environment_dir}" "${segment}/segment.json"
+}
+
+function getGen3Env() {
+  local env="$1"; shift
+  local prefix="$1"; shift
+
+  local env_name="${prefix}${env}"
+  echo "${!env_name}"
+}
+
+function setGen3DirEnv() {
+  local env="$1"; shift
+  local prefix="$1"; shift
+  local directories=("$@")
+
+  local env_name="${prefix}${env}"
+  for directory in "${directories[@]}"; do
+    if [[ -d "${directory}" ]]; then
+      declare -gx "${env_name}=${directory}"
+      return 0
+    fi
+  done
+
+  error $(locationMessage "Can't locate ${env} directory.")
+
+  return 1
+}
+
+# Once the root is established, this function identifies key directories
+# The prefix optionally allows multiple GEN3 context trees to be manipulated
+# simultaneously (e.g. during build promotion) but is generally omitted.
+function findGen3Dirs() {
+  local root_dir="$1"; shift
+  local tenant="${1:-${TENANT}}"; shift
+  local account="${1:-${ACCOUNT}}"; shift
+  local product="${1:-${PRODUCT}}"; shift
+  local environment="${1:-${ENVIRONMENT}}"; shift
+  local segment="${1:-${SEGMENT}}"; shift
+  local prefix="$1"; shift
+
+  setGen3DirEnv "ROOT_DIR" "${prefix}" "${root_dir}"
+  debug "ROOT_DIR=${ROOT_DIR}"
+
+  setGen3DirEnv "TENANT_DIR" "${prefix}" \
+    "$(findGen3TenantDir "${root_dir}" "${tenant}" )" || return 1
+  debug "TENANT_DIR=${TENANT_DIR}"
+
+  setGen3DirEnv "ACCOUNT_DIR" "${prefix}" \
+    "$(findGen3AccountDir "${root_dir}" "${account}" )" || return 1
+  debug "ACCOUNT_DIR=${ACCOUNT_DIR}"
+
+  setGen3DirEnv "ACCOUNT_SETTINGS_DIR" "${prefix}" \
+    "$(findGen3AccountSettingsDir "${root_dir}" "${account}" )" || return 1
+  debug "ACCOUNT_SETTINGS_DIR=${ACCOUNT_SETTINGS_DIR}"
+
+  setGen3DirEnv "ACCOUNT_INFRASTRUCTURE_DIR" "${prefix}" \
+    "$(findGen3AccountInfrastructureDir "${root_dir}" "${account}" )" || return 1
+  debug "ACCOUNT_INFRASTRUCTURE_DIR=${ACCOUNT_INFRASTRUCTURE_DIR}"
+
+  setGen3DirEnv "ACCOUNT_OPERATIONS_DIR" "${prefix}" \
+    "$(findGen3AccountOperationsDir "${root_dir}" "${account}" )" || return 1
+  debug "ACCOUNT_OPERATIONS_DIR=${ACCOUNT_OPERATIONS_DIR}"
+
+  setGen3DirEnv "ACCOUNT_STATE_DIR" "${prefix}" \
+    "$(findGen3AccountStateDir "${root_dir}" "${account}" )" || return 1
+  debug "ACCOUNT_STATE_DIR=${ACCOUNT_STATE_DIR}"
+
+  if [[ -n "${product}" ]]; then
+    setGen3DirEnv "PRODUCT_DIR" "${prefix}" \
+      "$(findGen3ProductDir "${root_dir}" "${product}")" || return 1
+    debug "PRODUCT_DIR=${PRODUCT_DIR}"
+
+    setGen3DirEnv "PRODUCT_SETTINGS_DIR" "${prefix}" \
+      "$(findGen3ProductSettingsDir "${root_dir}" "${product}" )" || return 1
+    debug "PRODUCT_SETTINGS_DIR=${PRODUCT_SETTINGS_DIR}"
+
+    setGen3DirEnv "PRODUCT_INFRASTRUCTURE_DIR" "${prefix}" \
+      "$(findGen3ProductInfrastructureDir "${root_dir}" "${product}")" || return 1
+    debug "PRODUCT_INFRASTRUCTURE_DIR=${PRODUCT_INFRASTRUCTURE_DIR}"
+
+    setGen3DirEnv "PRODUCT_OPERATIONS_DIR" "${prefix}" \
+      "$(findGen3ProductOperationsDir "${root_dir}" "${product}" )" || return 1
+    debug "PRODUCT_OPERATIONS_DIR=${PRODUCT_OPERATIONS_DIR}"
+
+    setGen3DirEnv "PRODUCT_SOLUTIONS_DIR" "${prefix}" \
+      "$(findGen3ProductSolutionsDir "${root_dir}" "${product}")" || return 1
+    debug "PRODUCT_SOLUTIONS_DIR=${PRODUCT_SOLUTIONS_DIR}"
+
+    setGen3DirEnv "PRODUCT_BUILDS_DIR" "${prefix}" \
+      "$(findGen3ProductBuildsDir "${root_dir}" "${product}")" || return 1
+    debug "PRODUCT_BUILDS_DIR=${PRODUCT_BUILDS_DIR}"
+
+    setGen3DirEnv "PRODUCT_STATE_DIR" "${prefix}" \
+      "$(findGen3ProductStateDir "${root_dir}" "${product}" )" || return 1
+    debug "PRODUCT_STATE_DIR=${PRODUCT_STATE_DIR}"
+
+    declare -gx ${prefix}PRODUCT_SHARED_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/shared
+    declare -gx ${prefix}PRODUCT_SHARED_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/shared
+    declare -gx ${prefix}PRODUCT_SHARED_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/shared
+
+    if [[ -n "${environment}" ]]; then
+      debug "ENVIRONMENT_DIR=$(findGen3ProductEnvironmentDir "${root_dir}" "${product}" "${environment}")"
+      declare -gx ${prefix}ENVIRONMENT_SHARED_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/${environment}
+      declare -gx ${prefix}ENVIRONMENT_SHARED_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/${environment}
+      declare -gx ${prefix}ENVIRONMENT_SHARED_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}
+
+      if [[ -n "${segment}" ]]; then
+        debug "SEGMENT_DIR=$(findGen3ProductEnvironmentSegmentDir "${root_dir}" "${product}" "${environment}" "${segment}")"
+
+        declare -gx ${prefix}SEGMENT_SHARED_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/shared/${segment}
+        declare -gx ${prefix}SEGMENT_SHARED_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/shared/${segment}
+        declare -gx ${prefix}SEGMENT_SHARED_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/shared/${segment}
+
+        declare -gx ${prefix}SEGMENT_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/${environment}/${segment}
+        declare -gx ${prefix}SEGMENT_BUILDS_DIR=$(getGen3Env     "PRODUCT_BUILDS_DIR"     "${prefix}")/${environment}/${segment}
+        declare -gx ${prefix}SEGMENT_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/${environment}/${segment}
+        declare -gx ${prefix}SEGMENT_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}/${segment}
+      fi
+    fi
+  fi
+
+  return 0
+}
+
+function checkInRootDirectory() {
+  local location="${1:-${LOCATION}}"
+
+  [[ ! ("root" =~ ${location}) ]] && fatalDirectory "root"
+}
+
+function checkInAccountDirectory() {
+  local location="${1:-${LOCATION}}"
+
+  [[ ! ("account" =~ ${location}) ]] && fatalDirectory "account"
+}
+
+function checkInProductDirectory() {
+  local location="${1:-${LOCATION}}"
+
+  [[ ! ("product" =~ ${location}) ]] && fatalDirectory "product"
+}
+
+function checkInEnvironmentDirectory() {
+  local location="${1:-${LOCATION}}"
+
+  [[ ! ("environment" =~ ${location}) ]] && fatalDirectory "environment"
+}
+
+function checkInSegmentDirectory() {
+  local location="${1:-${LOCATION}}"
+
+  [[ ! ("segment" =~ ${location}) ]] && fatalDirectory "segment"
+}
+
+function fatalProductOrSegmentDirectory() {
+  fatalDirectory "product or segment"
+}
+
 # -- Composites --
 
 function parse_stack_filename() {
@@ -204,7 +558,7 @@ function assemble_settings() {
     [[ -z "${name}" ]] && name="${id}"
     [[ (-n "${ACCOUNT}") && ("${ACCOUNT,,}" != "${name,,}") ]] && continue
 
-    local account_dir="$(filePath "${account_file}")/settings"
+    local account_dir="$(findGen3AccountSettingsDir "${root_dir}" "${name}")"
     debug "Processing ${account_dir} ..."
     pushd "${account_dir}" > /dev/null 2>&1 || continue
 
@@ -222,7 +576,6 @@ function assemble_settings() {
 
 #  debug "Products=${product_files[@]}"
 
-  # Settings
   for product_file in "${product_files[@]}"; do
 
     id="$(getJSONValue "${product_file}" ".Product.Id")"
@@ -230,103 +583,106 @@ function assemble_settings() {
     [[ -z "${name}" ]] && name="${id}"
     [[ (-n "${PRODUCT}") && ("${PRODUCT,,}" != "${name,,}") ]] && continue
 
-    local product_dir="$(filePath "${product_file}")/settings"
-    debug "Processing ${product_dir} ..."
-    pushd "${product_dir}" > /dev/null 2>&1 || continue
-
     # Settings
-    readarray -t setting_files < <(find . -type f \( \
-      -not \( -name "*build.json" -or -name "*credentials.json" -or -name "*sensitive.json" \) \
-      -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
-      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
-    if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "product_settings_XXXXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
-      tmp_file_list+=("${tmp_file}")
-    fi
+    local settings_dir="$(findGen3ProductSettingsDir "${root_dir}" "${name}")"
+    if [[ -d "${settings_dir}" ]]; then
+      debug "Processing ${settings_dir} ..."
+      pushd "${settings_dir}" > /dev/null
 
-    # Sensitive
-    readarray -t setting_files < <(find . -type f \( \
-      \( -name "*credentials.json" -or -name "*sensitive.json" \) \
-      -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
-      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
-    if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "product_sensitive_XXXXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Sensitive Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
-      tmp_file_list+=("${tmp_file}")
+      # Settings
+      readarray -t setting_files < <(find . -type f \( \
+        -not \( -name "*build.json" -or -name "*credentials.json" -or -name "*sensitive.json" \) \
+        -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+        -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
+      if ! arrayIsEmpty "setting_files" ; then
+        tmp_file="$( getTempFile "product_settings_XXXXXX.json" "${tmp_dir}")"
+        convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
+        tmp_file_list+=("${tmp_file}")
+      fi
+
+      # Sensitive
+      readarray -t setting_files < <(find . -type f \( \
+        \( -name "*credentials.json" -or -name "*sensitive.json" \) \
+        -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+        -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
+      if ! arrayIsEmpty "setting_files" ; then
+        tmp_file="$( getTempFile "product_sensitive_XXXXXX.json" "${tmp_dir}")"
+        convertFilesToJSONObject "Sensitive Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
+        tmp_file_list+=("${tmp_file}")
+      fi
+
+      # asFiles
+      readarray -t setting_files < <(find . -type f \( \
+        \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+        -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
+      if ! arrayIsEmpty "setting_files" ; then
+        tmp_file="$( getTempFile "product_settings_asfile_XXXXXX.json" "${tmp_dir}")"
+        convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "true" "${setting_files[@]}" > "${tmp_file}" || return 1
+        tmp_file_list+=("${tmp_file}")
+      fi
+
+      popd > /dev/null
     fi
 
     # Builds
-    readarray -t setting_files < <(find . -type f \( \
-      -name "*build.json" \
-      -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
-      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
-    if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "product_builds_XXXXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Builds Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
-      tmp_file_list+=("${tmp_file}")
+    local builds_dir="$(findGen3ProductBuildsDir "${root_dir}" "${name}")"
+    if [[ -d "${builds_dir}" ]]; then
+      debug "Processing ${builds_dir} ..."
+      pushd "${builds_dir}" > /dev/null
+
+      readarray -t build_files < <(find . -type f \( \
+        -name "*build.json" \
+        -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+        -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
+      if ! arrayIsEmpty "build_files" ; then
+        tmp_file="$( getTempFile "builds_builds_XXXXXX.json" "${tmp_dir}")"
+        convertFilesToJSONObject "Builds Products" "${name}" "${root_dir}" "false" "${build_files[@]}" > "${tmp_file}" || return 1
+        tmp_file_list+=("${tmp_file}")
+      fi
+
+      popd > /dev/null
     fi
 
-    # asFiles
-    readarray -t setting_files < <(find . -type f \( \
-      \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
-      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
-    if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "product_settings_asfile_XXXXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "true" "${setting_files[@]}" > "${tmp_file}" || return 1
-      tmp_file_list+=("${tmp_file}")
+    # Operations
+    local operations_dir="$(findGen3ProductOperationsDir "${root_dir}" "${name}")"
+    if [[ -d "${operations_dir}" ]]; then
+      debug "Processing ${operations_dir} ..."
+      pushd "${operations_dir}" > /dev/null
+
+      # Settings
+      readarray -t setting_files < <(find . -type f \( \
+        -not \( -name "*build.json" -or -name "*credentials.json" -or -name "*sensitive.json" \) \
+        -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+        -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
+      if ! arrayIsEmpty "setting_files" ; then
+        tmp_file="$( getTempFile "operations_settings_XXXXXX.json" "${tmp_dir}")"
+        convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
+        tmp_file_list+=("${tmp_file}")
+      fi
+
+      # Sensitive
+      readarray -t setting_files < <(find . -type f \( \
+        \( -name "*credentials.json" -or -name "*sensitive.json" \) \
+        -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+        -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
+      if ! arrayIsEmpty "setting_files" ; then
+        tmp_file="$( getTempFile "operations_sensitive_XXXXXX.json" "${tmp_dir}")"
+        convertFilesToJSONObject "Sensitive Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
+        tmp_file_list+=("${tmp_file}")
+      fi
+
+      # asFiles
+      readarray -t setting_files < <(find . -type f \( \
+        \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+        -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
+      if ! arrayIsEmpty "setting_files" ; then
+        tmp_file="$( getTempFile "operations_settings_asfile_XXXXXX.json" "${tmp_dir}")"
+        convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "true" "${setting_files[@]}" > "${tmp_file}" || return 1
+        tmp_file_list+=("${tmp_file}")
+      fi
+
+      popd > /dev/null
     fi
-
-    popd > /dev/null
-
-  done
-
-  # Operations
-  for product_file in "${product_files[@]}"; do
-
-    id="$(getJSONValue "${product_file}" ".Product.Id")"
-    name="$(getJSONValue "${product_file}" ".Product.Name")"
-    [[ -z "${name}" ]] && name="${id}"
-    [[ (-n "${PRODUCT}") && ("${PRODUCT,,}" != "${name,,}") ]] && continue
-
-    local operations_dir="$(findGen3ProductInfrastructureDir "${root_dir}" "${name}")/operations"
-    debug "Processing ${operations_dir} ..."
-    pushd "${operations_dir}" > /dev/null 2>&1 || continue
-
-    # Settings
-    readarray -t setting_files < <(find . -type f \( \
-      -not \( -name "*build.json" -or -name "*credentials.json" -or -name "*sensitive.json" \) \
-      -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
-      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
-    if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "operations_settings_XXXXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
-      tmp_file_list+=("${tmp_file}")
-    fi
-
-    # Sensitive
-    readarray -t setting_files < <(find . -type f \( \
-      \( -name "*credentials.json" -or -name "*sensitive.json" \) \
-      -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
-      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
-    if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "operations_sensitive_XXXXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Sensitive Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
-      tmp_file_list+=("${tmp_file}")
-    fi
-
-    # asFiles
-    readarray -t setting_files < <(find . -type f \( \
-      \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
-      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
-    if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "operations_settings_asfile_XXXXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "true" "${setting_files[@]}" > "${tmp_file}" || return 1
-      tmp_file_list+=("${tmp_file}")
-    fi
-
-    popd > /dev/null
-
   done
 
   # Generate the merged output
@@ -347,11 +703,11 @@ function assemble_composite_definitions() {
 
   local definitions_array=()
   [[ (-n "${ACCOUNT}") ]] &&
-      addToArray "definitions_array" "${ACCOUNT_INFRASTRUCTURE_DIR}"/cf/shared/defn*-definition.json
+      addToArray "definitions_array" "${ACCOUNT_STATE_DIR}"/cf/shared/defn*-definition.json
   [[ (-n "${PRODUCT}") && (-n "${REGION}") ]] &&
-      addToArray "definitions_array" "${PRODUCT_INFRASTRUCTURE_DIR}"/cf/shared/defn*-"${REGION}"*-definition.json
+      addToArray "definitions_array" "${PRODUCT_STATE_DIR}"/cf/shared/defn*-"${REGION}"*-definition.json
   [[ (-n "${ENVIRONMENT}") && (-n "${SEGMENT}") && (-n "${REGION}") ]] &&
-      addToArray "definitions_array" "${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"/*-definition.json
+      addToArray "definitions_array" "${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"/*-definition.json
 
   ${restore_nullglob}
 
@@ -374,11 +730,11 @@ function assemble_composite_stack_outputs() {
 
   local stack_array=()
   [[ (-n "${ACCOUNT}") ]] &&
-      addToArray "stack_array" "${ACCOUNT_INFRASTRUCTURE_DIR}"/cf/shared/acc*-stack.json
+      addToArray "stack_array" "${ACCOUNT_STATE_DIR}"/cf/shared/acc*-stack.json
   [[ (-n "${PRODUCT}") && (-n "${REGION}") ]] &&
-      addToArray "stack_array" "${PRODUCT_INFRASTRUCTURE_DIR}"/cf/shared/product*-"${REGION}"*-stack.json
+      addToArray "stack_array" "${PRODUCT_STATE_DIR}"/cf/shared/product*-"${REGION}"*-stack.json
   [[ (-n "${ENVIRONMENT}") && (-n "${SEGMENT}") && (-n "${REGION}") ]] &&
-      addToArray "stack_array" "${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"/*-stack.json
+      addToArray "stack_array" "${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"/*-stack.json
 
   ${restore_nullglob}
 
@@ -473,218 +829,6 @@ function getCodeBucket() {
   getBucketName "s3XaccountXcode"
 }
 
-# -- GEN3 directory structure --
-
-function findGen3RootDir() {
-  local current="$1"; shift
-
-  # First check for an explicitly marked root
-  local marked_root_dir="$(findAncestorDir root.json "${current}")"
-  [[ -n "${marked_root_dir}" ]] && echo -n "${marked_root_dir}" && return 0
-
-  # Now look for the first dir containing both a config and infrastructure directory
-  local config_root_dir="$(filePath "$(findAncestorDir config "${current}")")"
-  local infrastructure_root_dir="$(filePath "$(findAncestorDir infrastructure "${current}")")"
-  local root_dir="${config_root_dir:-${infrastructure_root_dir}}"
-
-  [[ (-d "${root_dir}/config") && (-d "${root_dir}/infrastructure") ]] && echo -n "${root_dir}" && return 0
-
-  return 1
-}
-
-function findGen3TenantDir() {
-  local root_dir="$1"; shift
-  local tenant="$1"; shift
-
-  findDir "${root_dir}" \
-    "${tenant}/tenant.json" \
-    "${tenant}/config/tenant.json" \
-    "tenant.json"
-}
-
-function findGen3TenantInfrastructureDir() {
-  local root_dir="$1"; shift
-  local tenant="$1"; shift
-
-  findDir "${root_dir}" \
-    "${tenant}/infrastructure"
-}
-
-function findGen3AccountDir() {
-  local root_dir="$1"; shift
-  local account="$1"; shift
-
-  findDir "${root_dir}" \
-    "${account}/account.json" \
-    "${account}/config/account.json"
-}
-
-function findGen3AccountInfrastructureDir() {
-  local root_dir="$1"; shift
-  local account="$1"; shift
-
-  findDir "${root_dir}" \
-    "infrastructure/**/${account}" \
-    "${account}/infrastructure"
-}
-
-function findGen3ProductDir() {
-  local root_dir="$1"; shift
-  local product="$1"; shift
-
-  findDir "${root_dir}" \
-    "${product}/product.json" \
-    "${product}/config/product.json"
-}
-
-function findGen3ProductInfrastructureDir() {
-  local root_dir="$1"; shift
-  local product="$1"; shift
-
-  findDir "${root_dir}" \
-    "infrastructure/**/${product}" \
-    "${product}/infrastructure"
-}
-
-function findGen3EnvironmentDir() {
-  local root_dir="$1"; shift
-  local product="${1:-${PRODUCT}}"; shift
-  local environment="${1:-${ENVIRONMENT}}"; shift
-
-  local product_dir="$(findGen3ProductDir "${root_dir}" "${product}")"
-  [[ -z "${product_dir}" ]] && return 1
-
-  findDir "${product_dir}" "solutionsv2/${environment}/environment.json"
-}
-
-function getGen3Env() {
-  local env="$1"; shift
-  local prefix="$1"; shift
-
-  local env_name="${prefix}${env}"
-  echo "${!env_name}"
-}
-
-function setGen3DirEnv() {
-  local env="$1"; shift
-  local prefix="$1"; shift
-  local directories=("$@")
-
-  local env_name="${prefix}${env}"
-  for directory in "${directories[@]}"; do
-    if [[ -d "${directory}" ]]; then
-      declare -gx "${env_name}=${directory}"
-      return 0
-    fi
-  done
-
-  error $(locationMessage "Can't locate ${env} directory.")
-
-  return 1
-}
-
-function findGen3Dirs() {
-  local root_dir="$1"; shift
-  local tenant="${1:-${TENANT}}"; shift
-  local account="${1:-${ACCOUNT}}"; shift
-  local product="${1:-${PRODUCT}}"; shift
-  local environment="${1:-${ENVIRONMENT}}"; shift
-  local segment="${1:-${SEGMENT}}"; shift
-  local prefix="$1"; shift
-
-  setGen3DirEnv "ROOT_DIR" "${prefix}" "${root_dir}"
-  debug "ROOT_DIR=${ROOT_DIR}"
-
-  setGen3DirEnv "TENANT_DIR" "${prefix}" \
-    "$(findGen3TenantDir "${root_dir}" "${tenant}" )" || return 1
-  debug "TENANT_DIR=${TENANT_DIR}"
-
-  setGen3DirEnv "ACCOUNT_DIR" "${prefix}" \
-    "$(findGen3AccountDir "${root_dir}" "${account}" )" || return 1
-  debug "ACCOUNT_DIR=${ACCOUNT_DIR}"
-
-  setGen3DirEnv "ACCOUNT_INFRASTRUCTURE_DIR" "${prefix}" \
-    "$(findGen3AccountInfrastructureDir "${root_dir}" "${account}" )" || return 1
-  debug "ACCOUNT_INFRASTRUCTURE_DIR=${ACCOUNT_INFRASTRUCTURE_DIR}"
-
-  declare -gx ${prefix}ACCOUNT_SETTINGS_DIR=$(getGen3Env "ACCOUNT_DIR" "${prefix}")/settings
-  declare -gx ${prefix}ACCOUNT_OPERATIONS_DIR=$(getGen3Env "ACCOUNT_INFRASTRUCTURE_DIR" "${prefix}")/operations
-
-  if [[ -n "${product}" ]]; then
-    setGen3DirEnv "PRODUCT_DIR" "${prefix}" \
-      "$(findGen3ProductDir "${root_dir}" "${product}")" || return 1
-    debug "PRODUCT_DIR=${PRODUCT_DIR}"
-
-    setGen3DirEnv "PRODUCT_INFRASTRUCTURE_DIR" "${prefix}" \
-      "$(findGen3ProductInfrastructureDir "${root_dir}" "${product}")" || return 1
-    debug "PRODUCT_INFRASTRUCTURE_DIR=${PRODUCT_INFRASTRUCTURE_DIR}"
-
-    declare -gx ${prefix}PRODUCT_SETTINGS_DIR=$(getGen3Env   "PRODUCT_DIR"                "${prefix}")/settings
-    declare -gx ${prefix}PRODUCT_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_DIR"                "${prefix}")/solutionsv2
-    declare -gx ${prefix}PRODUCT_OPERATIONS_DIR=$(getGen3Env "PRODUCT_INFRASTRUCTURE_DIR" "${prefix}")/operations
-
-    declare -gx ${prefix}PRODUCT_SHARED_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/shared
-    declare -gx ${prefix}PRODUCT_SHARED_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/shared
-    declare -gx ${prefix}PRODUCT_SHARED_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/shared
-
-    if [[ -n "${environment}" ]]; then
-
-      declare -gx ${prefix}ENVIRONMENT_SHARED_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/${environment}
-      declare -gx ${prefix}ENVIRONMENT_SHARED_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/${environment}
-      declare -gx ${prefix}ENVIRONMENT_SHARED_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}
-      debug "ENVIRONMENT_DIR=$(getGen3Env "PRODUCT_SOLUTIONS_DIR" "${prefix}")/${environment}"
-
-      if [[ -n "${segment}" ]]; then
-
-        declare -gx ${prefix}SEGMENT_SHARED_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/shared/${segment}
-        declare -gx ${prefix}SEGMENT_SHARED_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/shared/${segment}
-        declare -gx ${prefix}SEGMENT_SHARED_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/shared/${segment}
-
-        declare -gx ${prefix}SEGMENT_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/${environment}/${segment}
-        declare -gx ${prefix}SEGMENT_BUILDS_DIR=$(getGen3Env     "PRODUCT_SETTINGS_DIR"   "${prefix}")/${environment}/${segment}
-        declare -gx ${prefix}SEGMENT_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/${environment}/${segment}
-        declare -gx ${prefix}SEGMENT_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}/${segment}
-        debug "SEGMENT_DIR=$(getGen3Env "PRODUCT_SOLUTIONS_DIR" "${prefix}")/${environment}/${segment}"
-      fi
-    fi
-  fi
-
-  return 0
-}
-
-function checkInRootDirectory() {
-  local location="${1:-${LOCATION}}"
-
-  [[ ! ("root" =~ ${location}) ]] && fatalDirectory "root"
-}
-
-function checkInAccountDirectory() {
-  local location="${1:-${LOCATION}}"
-
-  [[ ! ("account" =~ ${location}) ]] && fatalDirectory "account"
-}
-
-function checkInProductDirectory() {
-  local location="${1:-${LOCATION}}"
-
-  [[ ! ("product" =~ ${location}) ]] && fatalDirectory "product"
-}
-
-function checkInEnvironmentDirectory() {
-  local location="${1:-${LOCATION}}"
-
-  [[ ! ("environment" =~ ${location}) ]] && fatalDirectory "environment"
-}
-
-function checkInSegmentDirectory() {
-  local location="${1:-${LOCATION}}"
-
-  [[ ! ("segment" =~ ${location}) ]] && fatalDirectory "segment"
-}
-
-function fatalProductOrSegmentDirectory() {
-  fatalDirectory "product or segment"
-}
 
 # -- Deployment Units --
 
@@ -1101,9 +1245,11 @@ function cleanup_cmdb_repo_to_v1_1_0() {
   local dry_run="$1";shift
 
   for source in "${!upgrade_v1_1_0_sources[@]}"; do
-    readarray -t source_dirs < <(find "${root_dir}" -mindepth 1 -maxdepth 2 -type d \
-      -name "${source}" )
+    readarray -t source_dirs < <(find "${root_dir}" -type d -name "${source}" )
     for source_dir in "${source_dirs[@]}"; do
+      local target_dir="$(filePath "${source_dir}")/${upgrade_v1_1_0_sources[${source}]}"
+      debug "Checking ${source_dir} ..."
+      [[ ! -d "${target_dir}" ]] && continue
       info "Deleting ${source_dir} ..."
       [[ -n "${dry_run}" ]] && continue
       git_rm -rf "${source_dir}" || return 1
@@ -1111,6 +1257,13 @@ function cleanup_cmdb_repo_to_v1_1_0() {
   done
 
   return 0
+}
+
+function cleanup_cmdb_repo_to_v1_1_1() {
+  # Rerun 1.1.0 to pick up errors in original implementation
+  # Previously it only worked for product repos but now should
+  # work for all repos
+  cleanup_cmdb_repo_to_v1_1_0 "$@"
 }
 
 # container_* files now should be fragment_*
@@ -1339,9 +1492,261 @@ function upgrade_cmdb_repo_to_v1_3_2() {
   upgrade_cmdb_repo_to_v1_3_1 "$@"
 }
 
+function upgrade_cmdb_repo_to_v2_0_0() {
+  # State is now in its own directory at the same level as config and infrastructure
+  # Solutions is now under infrastructure
+  # Builds are separated from settings and are now under infrastructure
+  #
+  # /config/settings
+  # /infrastructure/solutions
+  # /infrastructure/builds
+  # /infrastructure/operations
+  # /state/cf
+  # /state/cot
+  #
+  # If config and infrastructure are not in the one repo, then the upgrade must
+  # be performed manually and the cmdb version manually updated
+  local root_dir="$1";shift
+  local dry_run="$1";shift
+
+
+  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXX"
+  local tmp_dir="$(getTopTempDir)"
+  local return_status=0
+
+  readarray -t config_dirs < <(find "${root_dir}" -type d -name "config" )
+  for config_dir in "${config_dirs[@]}"; do
+    local base_dir="$(filePath "${config_dir}")"
+    local config_dir="${base_dir}/config"
+    local infrastructure_dir="${base_dir}/infrastructure"
+    local state_dir="${base_dir}/state"
+
+    local state_subdirs=("${infrastructure_dir}/cf" "${infrastructure_dir}/cot")
+
+    if [[ -d "${infrastructure_dir}" ]]; then
+      debug "${dry_run}Checking ${base_dir} ..."
+
+      # Move the state into its own top level tree
+      mkdir -p "${state_dir}"
+      for state_subdir in "${state_subdirs[@]}"; do
+        if [[ -d "${state_subdir}" ]]; then
+          info "${dry_run}Moving ${state_subdir} to ${state_dir} ..."
+          [[ -n "${dry_run}" ]] && continue
+          git_mv "${state_subdir}" "${state_dir}" || { return_status=1; break; }
+        fi
+      done
+
+      # Copy the solutions tree from config to infrastructure and rename
+      local solutions_dir="${config_dir}/solutionsv2"
+      if [[ -d "${solutions_dir}" ]]; then
+        info "${dry_run}Copying ${solutions_dir} to ${infrastructure_dir} ..."
+        if [[ -z "${dry_run}" ]]; then
+          # Leave existing solutions dir in place as it may be the current directory
+          cp -pr "${solutions_dir}" "${infrastructure_dir}" || return_status=1
+        fi
+        info "${dry_run}Renaming ${infrastructure_dir}/solutionsv2 to ${infrastructure_dir}/solutions ..."
+        if [[ -z "${dry_run}" ]]; then
+          mv "${infrastructure_dir}/solutionsv2" "${infrastructure_dir}/solutions"
+        fi
+      fi
+
+      # Copy the builds into their own tree
+      local settings_dir="${config_dir}/settings"
+      local builds_dir="${infrastructure_dir}/builds"
+      if [[ ! -d "${builds_dir}" ]]; then
+        info "${dry_run}Copying ${settings_dir} to ${builds_dir} ..."
+        if [[ -z "${dry_run}" ]]; then
+          cp -pr "${settings_dir}" "${builds_dir}"
+        fi
+      fi
+
+      # Remove the build files from the settings tree
+      # Blob will pick up build references and shared builds
+      info "${dry_run}Cleaning the settings tree ..."
+      readarray -t setting_files < <(find "${settings_dir}" -type f \( \
+        -name "*build.json" \) )
+      for setting_file in "${setting_files[@]}"; do
+        info "${dry_run}Deleting ${setting_file} ..."
+        [[ -n "${dry_run}" ]] && continue
+        git_rm "${setting_file}" || { return_status=1; break; }
+      done
+
+      # Build tree should only contain build references and shared builds
+      info "${dry_run}Cleaning the builds tree ..."
+      [[ -n "${dry_run}" ]] &&
+        readarray -t build_files < <(find "${settings_dir}"   -type f \( \
+        -not -name "*build.json" \) ) ||
+        readarray -t build_files < <(find "${builds_dir}"   -type f \( \
+        -not -name "*build.json" \) )
+      for build_file in "${build_files[@]}"; do
+        info "${dry_run}Deleting ${build_file} ..."
+        [[ -n "${dry_run}" ]] && continue
+        rm "${build_file}" || { return_status=1; break; }
+      done
+
+    else
+      warn "${dry_run}Update to v2.0.0 for ${config_dir} must be manually performed for split cmdb repos"
+    fi
+  done
+
+  popTempDir
+
+  return $return_status
+}
+
+function cleanup_cmdb_repo_to_v2_0_0() {
+  local root_dir="$1";shift
+  local dry_run="$1";shift
+
+  readarray -t config_dirs < <(find "${root_dir}" -type d -name "config" )
+  for config_dir in "${config_dirs[@]}"; do
+    local solutions_dir="${config_dir}/solutionsv2"
+    if [[ -d "${solutions_dir}" ]]; then
+      info "Deleting ${solutions_dir} ..."
+      [[ -n "${dry_run}" ]] && continue
+      git_rm -rf "${solutions_dir}" || return 1
+    fi
+  done
+
+  return 0
+}
+
+declare -A gen3_compatability
+# TODO: Align to GEN3 framework version where v2.0.0 format is to be introduced
+gen3_compatability=(
+  ["2.0.0"]=">=6.0.0"
+)
+
+function is_upgrade_compatible() {
+  local cmdb_version="$(semver_clean "$1")"; shift
+  local gen3_version="$1"; shift
+
+  local compatible_range="${gen3_compatability[${cmdb_version}]}"
+
+  if [[ -n "${compatible_range}" ]]; then
+
+    # Must know the gen3 version
+    [[ -z "${gen3_version}" ]] && return 2
+
+    semver_satisfies "${gen3_version}" "${compatible_range}"
+    return $?
+  fi
+
+  # Upgrade is compatible
+  return 0
+}
+
+# Determine the environments present in the current branch
+function list_environments() {
+  local root_dir="$1";shift
+
+  local environments=()
+
+  # Find all the environment names
+    readarray -t environment_files < <(find "${root_dir}" -name "environment.json")
+    for environment_file in "${environment_files[@]}"; do
+      local path="$(filePath "${environment_file}")"
+      local environment="$(fileName "${path}")"
+
+      [[ -n "${environment}" ]] && environments+=("${environment}")
+    done
+
+    echo "${environments[*]}"
+}
+
+# Reorganise branch on the basis of one branch per environment
+# Environment components of directory hierarchy are removed and only
+# files from the requested environment or shared files are retained
+function clean_environment_branch() {
+  local root_dir="$1"; shift
+  local environment="$1"; shift
+  local dry_run="$1";shift
+
+  # Find all the parent dirs for the environment
+  readarray -t environment_dirs < <(find "${root_dir}" -type d -name "${environment}")
+  for environment_dir in "${environment_dirs[@]}"; do
+
+    # Ignore .git directory in case environment matches index e.g. e0, e7 etc
+    echo "${environment_dir}" | grep -q ".git" && continue
+
+    # Process the environment dirs
+    local parent_dir="$(filePath "${environment_dir}")"
+    readarray -t sibling_environment_dirs < <(find "${parent_dir}" -mindepth 1 -maxdepth 1 -type d )
+    for sibling_environment_dir in "${sibling_environment_dirs[@]}"; do
+      case "$(fileName "${sibling_environment_dir}")" in
+        "${environment}")
+          # Move environment files up one level
+          readarray -t environment_items < <(find "${sibling_environment_dir}" -mindepth 1 -maxdepth 1)
+          if [[ "${#environment_items[@]}" -gt 0 ]]; then
+            info "${dry_run}Moving ${sibling_environment_dir}/* to ${parent_dir} ..."
+            if [[ -z "${dry_run}" ]]; then
+              git_mv "${sibling_environment_dir}"/* "${parent_dir}"
+            fi
+          fi
+          info "${dry_run}Deleting ${sibling_environment_dir} ..."
+          if [[ -z "${dry_run}" ]]; then
+            git_rm -r "${sibling_environment_dir}"
+          fi
+          ;;
+        shared)
+          ;;
+        *)
+          # Remove other environments
+          info "${dry_run}Deleting ${sibling_environment_dir} ..."
+          if [[ -z "${dry_run}" ]]; then
+            git_rm -r "${sibling_environment_dir}"
+          fi
+          ;;
+      esac
+    done
+  done
+
+  return 0
+}
+
+function add_environment_branches() {
+  local root_dir="$1";shift
+  local product="$1"; shift
+  local dry_run="$1";shift
+
+  # Base branches on state of master branch
+  # Do nothing if no master branch
+  git branch | grep -q "master" || return 0
+
+  local current_ref="$(git rev-parse --abbrev-ref HEAD)"
+
+  [[ "${current_ref}" != "master" ]] && git checkout -q master > /dev/null
+
+  for environment in $(list_environments "${root_dir}"); do
+
+    # Include product in branch name if provided
+    local branch="${product}${product:+-}${environment}"
+
+    info "${dry_run}Creating branch ${branch} for ${environment} environment ..."
+    if [[ -z "${dry_run}" ]]; then
+      if git branch | grep -q "${branch}"; then
+        debug "Branch already exists for ${environment} environment."
+      else
+        # Create the branch using the current state of the master branch
+        git checkout -q -b "${branch}" "master"
+
+        # Clean up the branch
+        clean_environment_branch "${root_dir}" "${environment}" || return 1
+
+        # Save the changes
+        git add -A
+        git commit -m "Add ${branch} branch"
+      fi
+    fi
+  done
+
+  git checkout -q "${current_ref}"
+}
+
 function process_cmdb() {
   local root_dir="$1";shift
   local action="$1";shift
+  local gen3_version="$1"; shift
   local version_list="$1";shift
   local dry_run="${1:+(Dryrun) }";shift
 
@@ -1377,13 +1782,25 @@ function process_cmdb() {
     for version in "${versions[@]}"; do
       # Nothing to do if not less than version being checked
       local semver_check="$(semver_compare "${current_version}" "${version}")"
-
       if [[ "${semver_check}" == "-1" ]]; then
         info "${dry_run}${action^} of repo "${cmdb_repo}" to ${version} required ..."
       else
         debug "${action^} of repo "${cmdb_repo}" to ${version} is not required"
         continue
       fi
+
+      # Ensure current gen3 framework version is compatible with the upgrade
+      is_upgrade_compatible "${version}" "${gen3_version}"; upgrade_status=$?
+      case "${upgrade_status}" in
+        2)
+          warn "${dry_run}${action^} of repo "${cmdb_repo}" to ${version} requires the GEN3 framework version to be defined. Skipping upgrade process ..."
+          break
+          ;;
+        1)
+          warn "${dry_run}${action^} of repo "${cmdb_repo}" to ${version} is not compatible with the current gen3 framework version of ${gen3_version}. Skipping upgrade process ..."
+          break
+          ;;
+      esac
 
       pushd "${cmdb_repo}" > /dev/null 2>&1
       ${action,,}_cmdb_repo_to_${version//./_} "${cmdb_repo}" "${dry_run}"; return_status=$?
@@ -1415,21 +1832,24 @@ function process_cmdb() {
 
 function upgrade_cmdb() {
   local root_dir="$1";shift
+  local gen3_version="$1";shift
   local dry_run="$1";shift
   local versions="$1";shift
 
-  local required_versions=(${versions})
-  [[ -z "${versions}" ]] && required_versions=("v1.0.0" "v1.1.0" "v1.2.0" "v1.3.0" "v1.3.1" "v1.3.2")
+  local required_cmdb_versions=(${versions})
+  [[ -z "${versions}" ]] && required_cmdb_versions=("v1.0.0" "v1.1.0" "v1.2.0" "v1.3.0" "v1.3.1" "v1.3.2")
 
-  process_cmdb "${root_dir}" "upgrade" "${required_versions[*]}" ${dry_run}
+  process_cmdb "${root_dir}" "upgrade" "${gen3_version}" "${required_cmdb_versions[*]}" "${dry_run}"
 }
 
 function cleanup_cmdb() {
   local root_dir="$1";shift
+  local gen3_version="$1";shift
   local dry_run="$1";shift
+  local versions="$1";shift
 
-  local required_versions=(${versions})
-  [[ -z "${versions}" ]] && required_versions=("v1.0.0" "v1.1.0")
+  local required_cmdb_versions=(${versions})
+  [[ -z "${versions}" ]] && required_cmdb_versions=("v1.0.0" "v1.1.0" "v1.1.1")
 
-  process_cmdb "${root_dir}" "cleanup" "${required_versions[*]}" ${dry_run}
+  process_cmdb "${root_dir}" "cleanup" "${gen3_version}" "${required_cmdb_versions[*]}" "${dry_run}"
 }


### PR DESCRIPTION
Add support for semver range checking based on the syntax used by
node-semver.

Add the ability to constrain a cmdb upgrade to a range of versions of
the GEN3 framework, mainly to allow an upgrade to be added to the
framework but not applied until the upgrade is active.

Also add the first cut of the upgrade to v2.0.0 of the cmdb, which
separates state from config/infrastructure, and introduces the use of
branches to separate environments rather than directory trees.