### PR TITLE
Support for RDS data registry

### DIFF
--- a/aws/templates/account/account_s3.ftl
+++ b/aws/templates/account/account_s3.ftl
@@ -138,7 +138,7 @@
                         "case $\{STACK_OPERATION} in",
                         "  create|update)",
                         "    sync_code_bucket || return $?",
-                        "    initialise_registries \"dataset\" \"contentnode\" \"lambda\" \"pipeline\" \"scripts\" \"spa\" \"swagger\" || return $?",
+                        "    initialise_registries \"dataset\" \"contentnode\" \"lambda\" \"pipeline\" \"scripts\" \"spa\" \"swagger\" \"rdssnapshot\" || return $?",
                         "    ;;",
                         " esac"
                     ]

--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -158,6 +158,7 @@
     [#local fqdn = getExistingReference(id, DNS_ATTRIBUTE_TYPE)]
     [#local port = getExistingReference(id, PORT_ATTRIBUTE_TYPE)]
     [#local name = getExistingReference(id, DATABASENAME_ATTRIBUTE_TYPE)]
+    [#local region = getExistingReference(id, REGION_ATTRIBUTE_TYPE)]
     [#local encryptionScheme = (solution.GenerateCredentials.EncryptionScheme)?has_content?then(
                         solution.GenerateCredentials.EncryptionScheme?ensure_ends_with(":"),
                         "" )]
@@ -201,7 +202,8 @@
                 "NAME" : name,
                 "USERNAME" : masterUsername,
                 "PASSWORD" : masterPassword,
-                "URL" : url
+                "INSTANCEID" : core.FullName,
+                "REGION" : region
             },
             "Roles" : {
                 "Inbound" : {},

--- a/aws/templates/resource/resource_rds.ftl
+++ b/aws/templates/resource/resource_rds.ftl
@@ -10,6 +10,9 @@
         },
         PORT_ATTRIBUTE_TYPE : { 
             "Attribute" : "Endpoint.Port"
+        },
+        REGION_ATTRIBUTE_TYPE : {
+            "Value" : { "Ref" : "AWS::Region" }
         }
     }
 ]


### PR DESCRIPTION
Add support for the RDS Data Registry 

This is a continuation of treating data as code within codeontap. The snapshot registry is used to store RDS snapshot artefacts as they cannot be moved out of S3. 

These changes are some minor changes used to support creating a buildblueprint and adds support for the rdssnapshot registry type