### PR TITLE
Fix Schedule Task role for IAM pass

### DIFF
--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -256,7 +256,7 @@
                             trustedServices=["events.amazonaws.com"]
                             policies=[
                                 getPolicyDocument(
-                                    ecsTaskRunPermission(ecsId, taskId)
+                                    ecsTaskRunPermission(ecsId)
                                 ,
                                 "schedule")
                             ]


### PR DESCRIPTION
The task arn is not available in an initial iam pass at the application level. So we can't actually limit the service role to only run the nominated task. We can at least limit the ECS cluster it runs on