### PR TITLE
Add maximum tag counts for aws resource limitations

### DIFF
--- a/aws/templates/account/account_audit.ftl
+++ b/aws/templates/account/account_audit.ftl
@@ -40,7 +40,7 @@
                         {
                             "QueueConfigurations" : sqsNotifications
                         }) 
-                tags=getCfTemplateCoreTags()
+                tags=getCfTemplateCoreTags("", tier, component, "", false, false, 7)
                 outputs=S3_OUTPUT_MAPPINGS
             /]
         [/#if]

--- a/aws/templates/application/application_datapipeline.ftl
+++ b/aws/templates/application/application_datapipeline.ftl
@@ -193,11 +193,15 @@
             [#assign coreTags = getCfTemplateCoreTags(
                         pipelineName,
                         tier,
-                        component) ]
+                        component,
+                        "",
+                        false,
+                        false,
+                        10) ]
 
             [#assign cliTags = [] ]
             [#-- datapiplines only allow 10 tags --]
-            [#list coreTags[0..*10] as tag ]
+            [#list coreTags as tag ]
                 [#assign cliTags += [
                     {
                     "key" : tag.Key,

--- a/aws/templates/resource/resource_s3.ftl
+++ b/aws/templates/resource/resource_s3.ftl
@@ -277,7 +277,7 @@
                 "ReplicationConfiguration",
                 replicationConfiguration
             )
-        tags=getCfTemplateCoreTags("", tier, component)
+        tags=getCfTemplateCoreTags("", tier, component, "", false, false, 7)
         outputs=S3_OUTPUT_MAPPINGS
         outputId=outputId
         dependencies=dependencies

--- a/aws/templates/resource/start.ftl
+++ b/aws/templates/resource/start.ftl
@@ -258,7 +258,7 @@
     }]
 [/#function]
 
-[#function getCfTemplateCoreTags name="" tier="" component="" zone="" propagate=false flatten=false]
+[#function getCfTemplateCoreTags name="" tier="" component="" zone="" propagate=false flatten=false maxTagCount=-1]
     [#local result =
         [
             { "Key" : "cot:request", "Value" : requestReference }
@@ -341,6 +341,10 @@
             ]
         [/#list]
         [#local result=returnValue]
+    [/#if]
+
+    [#if maxTagCount gte 0 ]
+        [#local result=result[0..( maxTagCount -1 )]]
     [/#if]
     [#return result]
 [/#function]


### PR DESCRIPTION
AWS resources seem to have varying limitations on the number of tags which can be applied to a resource. E.g. S3 only allows seven and data pipelines only allow 10 

This PR adds support only the number of required tags to be provided by the core tag function.