### PR TITLE
update path details to make them cleaner in lb ports

### DIFF
--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -279,8 +279,6 @@
     [#local defaultTargetGroupId = formatResourceId(AWS_ALB_TARGET_GROUP_RESOURCE_TYPE, "default", parentCore.Id, sourcePort ) ]
     [#local defaultTargetGroupName = formatName("default", parentCore.FullName, sourcePort )]
 
-    [#local path = (solution.Path == "default")?then("", solution.Path) ]
-
     [#local domainRedirectRules = {} ]
     [#if (sourcePort.Certificate)!false ]
         [#local certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers, sourcePort.Id, sourcePort.Name) ]
@@ -308,6 +306,16 @@
         [#local scheme ="http" ]
     [/#if]
 
+    [#local path = ""]
+
+    [#if solution.Path != "default" ]
+        [#if (solution.Path)?ends_with("*") ]
+            [#local path = solution.Path?remove_ending("*")?ensure_ends_with("/") ]
+        [#else]
+            [#local path = solution.Path ]
+        [/#if]
+    [/#if]
+    
     [#local url = scheme + "://" + fqdn  ]
     [#local internalUrl = scheme + "://" + internalFqdn ]
 

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -131,7 +131,11 @@
                     [#if solution.Path == "default" ]
                         [#assign path = "*"]
                     [#else]
-                        [#assign path = solution.Path ]
+                        [#if solution.Path?ends_with("/")]
+                            [#assign path = solution.Path?ensure_ends_with("*")]
+                        [#else]
+                            [#assign path = solution.Path ]
+                        [/#if]
                     [/#if]
                     [#break]
 


### PR DESCRIPTION
AWS ALB uses wild card filters for paths in ALB conditions, however this doesn't work when a component links to the loadbalancer port/path. 

This PR makes the path nicer when being passed to components which link to the LB and also replaces path with wildcard when provisioning an ALB