### PR TITLE
Update management of integrator credentials

### DIFF
--- a/aws/integrator/manageCredentials.sh
+++ b/aws/integrator/manageCredentials.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-                                                                                        
+
 [[ -n "${GENERATION_DEBUG}" ]] && set ${GENERATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${GENERATION_DIR}/common.sh"
 
 # Defaults
-CREDENTIAL_NAME_DEFAULT="root+aws"
+CREDENTIAL_PATH_DEFAULT="root+aws"
 CREDENTIAL_TYPE_DEFAULT="Login"
 
 function usage() {
@@ -13,15 +13,15 @@ function usage() {
 
 Manage tenant/account credentials
 
-Usage: $(basename $0) -t TENANT -a ACCOUNT -n CREDENTIAL_NAME -y CREDENTIAL_TYPE -i CREDENTIAL_ID -s CREDENTIAL_SECRET -e CREDENTIAL_EMAIL
+Usage: $(basename $0) -t TENANT -a TENANT_ACCOUNT -n CREDENTIAL_PATH -y CREDENTIAL_TYPE -i CREDENTIAL_ID -s CREDENTIAL_SECRET -e CREDENTIAL_EMAIL
 
 where
 
-(o) -a ACCOUNT              is the tenant account name
+(o) -a TENANT_ACCOUNT       is the tenant account name
 (o) -e CREDENTIAL_EMAIL     is the email associated with the credential (not encrypted)
     -h                      shows this text
 (o) -i CREDENTIAL_ID        of credential (i.e. Username/Client Key/Access Key value) - not encrypted
-(m) -n CREDENTIAL_NAME      for the set of values (id, secret, email)
+(m) -n CREDENTIAL_PATH      for the set of values (id, secret, email)
 (o) -s CREDENTIAL_SECRET    of credential (i.e. Password/Secret Key value) - encrypted
 (m) -t TENANT               is the tenant name
 (m) -y CREDENTIAL_TYPE      of credential
@@ -30,7 +30,7 @@ where
 
 DEFAULTS:
 
-CREDENTIAL_NAME = ${CREDENTIAL_NAME_DEFAULT} (account only)
+CREDENTIAL_PATH = ${CREDENTIAL_PATH_DEFAULT} (account only)
 CREDENTIAL_TYPE = ${CREDENTIAL_TYPE_DEFAULT}
 
 NOTES:
@@ -39,7 +39,6 @@ NOTES:
 2. Omit the account to manage tenant credentials
 3. Provided values (if any) are updated
 4. Current values are displayed
-5. Common CREDENTIAL_NAME values are "Login" for interactive credentials and "API" for AWS access keys
 
 EOF
     exit
@@ -49,7 +48,7 @@ EOF
 while getopts ":a:e:hi:n:s:t:y:" opt; do
     case $opt in
         a)
-            ACCOUNT="${OPTARG}"
+            TENANT_ACCOUNT="${OPTARG}"
             ;;
         e)
             export CREDENTIAL_EMAIL="${OPTARG}"
@@ -61,7 +60,7 @@ while getopts ":a:e:hi:n:s:t:y:" opt; do
             export CREDENTIAL_ID="${OPTARG}"
             ;;
         n)
-            export CREDENTIAL_NAME="${OPTARG}"
+            export CREDENTIAL_PATH="${OPTARG}"
             ;;
         s)
             export CREDENTIAL_SECRET="${OPTARG}"
@@ -82,9 +81,9 @@ while getopts ":a:e:hi:n:s:t:y:" opt; do
 done
 
 # Apply defaults
-if [[ -n "${ACCOUNT}" ]]; then
-    CRYPTO_FILE_PATH="tenants/${TENANT}/accounts/${ACCOUNT}"
-    export CREDENTIAL_NAME="${CREDENTIAL_NAME:-${CREDENTIAL_NAME_DEFAULT}}"
+if [[ -n "${TENANT_ACCOUNT}" ]]; then
+    CRYPTO_FILE_PATH="tenants/${TENANT}/accounts/${TENANT_ACCOUNT}"
+    export CREDENTIAL_PATH="${CREDENTIAL_PATH:-${CREDENTIAL_PATH_DEFAULT}}"
 else
     CRYPTO_FILE_PATH="tenants/${TENANT}"
 fi
@@ -93,7 +92,7 @@ export CREDENTIAL_TYPE="${CREDENTIAL_TYPE:-${CREDENTIAL_TYPE_DEFAULT}}"
 
 # Ensure mandatory arguments have been provided
 [[ (-z "${TENANT}") ||
-    (-z "${CREDENTIAL_NAME}") ||
+    (-z "${CREDENTIAL_PATH}") ||
     (-z "${CREDENTIAL_TYPE}") ]] && fatalMandatory
 
 # Ensure we are in the integrator tree

--- a/aws/manageCrypto.sh
+++ b/aws/manageCrypto.sh
@@ -169,8 +169,15 @@ done
 if [[ (-n "${JSON_PATH}") ]]; then
     [[ -z "${TARGET_FILE}" ]] && fatal "Can't locate target file"
 
+    # Handle dash in attribute name
+    PATH_PARTS=(${JSON_PATH//./ })
+    ESCAPED_JSON_PATH="."
+    for PATH_PART in "${PATH_PARTS[@]}"; do
+        ESCAPED_JSON_PATH="${ESCAPED_JSON_PATH}[\"${PATH_PART}\"]"
+    done
+
     # Default cipherdata to that in the element
-    JSON_TEXT=$(jq -r "${JSON_PATH} | select (.!=null)" < "${TARGET_FILE}")
+    JSON_TEXT=$(jq -r "${ESCAPED_JSON_PATH} | select (.!=null)" < "${TARGET_FILE}")
     CRYPTO_TEXT="${CRYPTO_TEXT:-$JSON_TEXT}"
 
     [[ (("${CRYPTO_OPERATION}" == "encrypt") && (-z "${CRYPTO_TEXT}")) ]] &&


### PR DESCRIPTION
Script for managing integrator credentials was out of date. The underlying routines now require a JSON path to be provided.

There was also an issue in that some of the telstra tenant credentials included dashes, which were being treated as negatives by JQ, so had to be appropriately escaped.