### PR TITLE
Fix sms Sending permission

### DIFF
--- a/aws/templates/policy/policy_sns.ftl
+++ b/aws/templates/policy/policy_sns.ftl
@@ -46,13 +46,7 @@
     [#return 
         getPolicyStatement(
             "sns:Publish",
-            "*",
-            "",
-            {
-                "StringEquals":{
-                    "sns:Protocol" : "sms" 
-                }
-            }
+            "*"
         )
     ]
 [/#function]


### PR DESCRIPTION
SMS publishing doesn't have an ARN can be controlled through IAM conditions. 