### PR TITLE
Extend Alerts support to more resources

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -451,7 +451,9 @@
                             [@createCountAlarm
                                 mode=listMode
                                 id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
-                                name=alert.Severity?upper_case + "-" + monitoredResource.Name!core.ShortFullName + "-" + alert.Name
+                                severity=alert.Severity
+                                resourceName=monitoredResource.Name!core.ShortFullName
+                                alertName=alert.Name
                                 actions=[
                                     getReference(formatSegmentSNSTopicId())
                                 ]

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -376,7 +376,9 @@
                                 [@createCountAlarm
                                     mode=listMode
                                     id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
-                                    name=alert.Severity?upper_case + "-" + monitoredResource.Name!core.ShortFullName + "-" + alert.Name
+                                    severity=alert.Severity
+                                    resourceName=monitoredResource.Name!core.ShortFullName
+                                    alertName=alert.Name
                                     actions=[
                                         getReference(formatSegmentSNSTopicId())
                                     ]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -2365,7 +2365,13 @@ behaviour.
                             "Name" : name,
                             "Value" : getReference(otherResource.Id, value.Property)
                         }]]   
-                        [#break]                
+                        [#break]      
+                    [#case "PseudoOutput" ]
+                        [#local occurrenceDimensions += [{
+                            "Name" : name,
+                            "Value" : { "Ref" : value }
+                        }]]
+                        [#break]          
                 [/#switch]
             [/#list]
         [/#list]

--- a/aws/templates/id/id_cache.ftl
+++ b/aws/templates/id/id_cache.ftl
@@ -68,6 +68,11 @@
                             "Default" : "replace"
                         }
                     ]
+                },
+                {
+                    "Names" : "Alerts",
+                    "Subobjects" : true,
+                    "Children" : alertChildrenConfiguration
                 }
             ]
         }
@@ -84,7 +89,8 @@
                 "cache" : {
                     "Id" : id,
                     "Name" : core.FullName,
-                    "Type" : AWS_CACHE_RESOURCE_TYPE
+                    "Type" : AWS_CACHE_RESOURCE_TYPE,
+                    "Monitored" : true
                 },
                 "subnetGroup" : {
                     "Id" : formatResourceId(AWS_CACHE_SUBNET_GROUP_RESOURCE_TYPE, core.Id),

--- a/aws/templates/id/id_es.ftl
+++ b/aws/templates/id/id_es.ftl
@@ -77,6 +77,11 @@
                 {
                     "Names" : "Profiles",
                     "Children" : profileChildConfiguration
+                },
+                {
+                    "Names" : "Alerts",
+                    "Subobjects" : true,
+                    "Children" : alertChildrenConfiguration
                 }
             ]
         }
@@ -95,7 +100,8 @@
                 "es" : { 
                     "Id" : esId,
                     "Name" : core.Name,
-                    "Type" : AWS_ES_RESOURCE_TYPE
+                    "Type" : AWS_ES_RESOURCE_TYPE,
+                    "Monitored" : true
                 },
                 "servicerole" : {
                     "Id" : formatDependentRoleId(esId),

--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -143,6 +143,11 @@
                             "Default" : "restore"
                         }
                     ]
+                },
+                {
+                    "Names" : "Alerts",
+                    "Subobjects" : true,
+                    "Children" : alertChildrenConfiguration
                 }
             ]
     }
@@ -180,7 +185,8 @@
                 "db" : {
                     "Id" : id,
                     "Name" : core.FullName,
-                    "Type" : AWS_RDS_RESOURCE_TYPE
+                    "Type" : AWS_RDS_RESOURCE_TYPE,
+                    "Monitored" : true
                 },
                 "subnetGroup" : {
                     "Id" : formatResourceId(AWS_RDS_SUBNET_GROUP_RESOURCE_TYPE, core.Id),

--- a/aws/templates/resource/resource_cache.ftl
+++ b/aws/templates/resource/resource_cache.ftl
@@ -32,3 +32,16 @@
     }
 ]
 
+[#assign metricAttributes +=
+    {
+        AWS_CACHE_RESOURCE_TYPE : {
+            "Namespace" : "AWS/ElastiCache",
+            "Dimensions" : {
+                "CacheClusterId" : {
+                    "Output" : "" 
+                }
+            }
+        }
+    }
+]
+

--- a/aws/templates/resource/resource_cw.ftl
+++ b/aws/templates/resource/resource_cw.ftl
@@ -250,7 +250,10 @@
     /]
 [/#macro]
 
-[#macro createCountAlarm mode id name
+[#macro createCountAlarm mode id 
+            severity
+            resourceName
+            alertName
             actions
             metric
             namespace
@@ -273,7 +276,7 @@
                 "ActionsEnabled" : true,
                 "AlarmActions" : actions,
                 "AlarmDescription" : description?has_content?then(description,name),
-                "AlarmName" : name,
+                "AlarmName" : severity?upper_case + "-" + resourceName + "-" + alertName,
                 "ComparisonOperator" : operator,
                 "EvaluationPeriods" : evaluationPeriods,
                 "MetricName" : metric,

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -49,15 +49,21 @@
             "Namespace" : "AWS/ECS",
             "Dimensions" : {
                 "ClusterName" : {
-                    "Output" : "ref" 
+                    "Output" : REFERENCE_ATTRIBUTE_TYPE 
                 }
             }
         },
         AWS_ECS_SERVICE_RESOURCE_TYPE : {
             "Namespace" : "AWS/ECS",
             "Dimensions" : {
+                "ClusterName" : {
+                    "OtherOutput" : {
+                        "Id" : "cluster",
+                        "Property" : ""
+                    } 
+                },
                 "ServiceName" : {
-                    "Output" : "name"
+                    "Output" : NAME_ATTRIBUTE_TYPE
                 }
             }
         }

--- a/aws/templates/resource/resource_es.ftl
+++ b/aws/templates/resource/resource_es.ftl
@@ -19,6 +19,21 @@
     }
 ]
 
+[#assign metricAttributes +=
+    {
+        AWS_ES_RESOURCE_TYPE : {
+            "Namespace" : "AWS/ES",
+            "Dimensions" : {
+                "DomainName" : {
+                    "Output" : ""
+                },
+                "ClientId" : {
+                    "PseudoOutput" : "AWS::AccountId"
+                }
+            }
+        }
+    }
+]
 
 [#function formatESDomainArn esId indexPath=["*"] region={ "Ref" : "AWS::Region" } account={ "Ref" : "AWS::AccountId" } ]
     [#return

--- a/aws/templates/resource/resource_lb.ftl
+++ b/aws/templates/resource/resource_lb.ftl
@@ -10,6 +10,9 @@
         },
         DNS_ATTRIBUTE_TYPE : {
             "Attribute" : "DNSName"
+        },
+        NAME_ATTRIBUTE_TYPE : {
+            "Attribute" : "LoadBalancerFullName"
         }
     }
 ]
@@ -54,9 +57,41 @@
     {
         AWS_LB_RESOURCE_TYPE : LB_OUTPUT_MAPPINGS,
         AWS_ALB_RESOURCE_TYPE : LB_OUTPUT_MAPPINGS,
+        AWS_LB_CLASSIC_RESOURCE_TYPE : LB_OUTPUT_MAPPINGS,
+        AWS_LB_APPLICATION_RESOURCE_TYPE : LB_OUTPUT_MAPPINGS,
+        AWS_LB_NETWORK_RESOURCE_TYPE : LB_OUTPUT_MAPPINGS,
         AWS_ALB_LISTENER_RESOURCE_TYPE : ALB_LISTENER_OUTPUT_MAPPINGS,
         AWS_ALB_LISTENER_RULE_RESOURCE_TYPE : ALB_LISTENER_RULE_OUTPUT_MAPPINGS,
         AWS_ALB_TARGET_GROUP_RESOURCE_TYPE : ALB_TARGET_GROUP_OUTPUT_MAPPINGS
+    }
+]
+
+[#assign metricAttributes +=
+    {
+        AWS_LB_CLASSIC_RESOURCE_TYPE : {
+            "Namespace" : "AWS/ELB",
+            "Dimensions" : {
+                "LoadBalancerName" : {
+                    "Output" : "" 
+                }
+            }
+        },
+        AWS_LB_APPLICATION_RESOURCE_TYPE : {
+            "Namespace" : "AWS/ApplicationELB",
+            "Dimensions" : {
+                "LoadBalancer" : {
+                    "Output" : NAME_ATTRIBUTE_TYPE
+                }
+            }
+        },
+        AWS_LB_NETWORK_RESOURCE_TYPE : {
+            "Namespace" : "AWS/NetworkELB",
+            "Dimensions" : {
+                "LoadBalancer" : {
+                    "Output" : NAME_ATTRIBUTE_TYPE
+                }
+            }
+        }
     }
 ]
 
@@ -397,7 +432,12 @@
                 name,
                 tier,
                 component)
-        outputs=LB_OUTPUT_MAPPINGS
+        outputs=LB_OUTPUT_MAPPINGS + 
+                    {
+                        NAME_ATTRIBUTE_TYPE : {
+                            "UseRef" : true
+                        }
+                    }
         dependencies=dependencies
     /]
 [/#macro]

--- a/aws/templates/resource/resource_rds.ftl
+++ b/aws/templates/resource/resource_rds.ftl
@@ -22,6 +22,19 @@
     }
 ]
 
+[#assign metricAttributes +=
+    {
+        AWS_RDS_RESOURCE_TYPE : {
+            "Namespace" : "AWS/RDS",
+            "Dimensions" : {
+                "DBInstanceIdentifier" : {
+                    "Output" : "" 
+                }
+            }
+        }
+    }
+]
+
 [#macro createRDSInstance mode id name 
     engine
     engineVersion

--- a/aws/templates/solution/solution_ElasticSearch.ftl
+++ b/aws/templates/solution/solution_ElasticSearch.ftl
@@ -204,6 +204,42 @@
         [#-- "DomainName" : "${productName}-${segmentId}-${tierId}-${componentId}", --]
         [#if deploymentSubsetRequired("es", true)]
 
+            [#list solution.Alerts?values as alert ]
+
+                [#assign monitoredResources = getMonitoredResources(resources, alert.Resource)]
+                [#list monitoredResources as name,monitoredResource ]
+
+                    [@cfDebug listMode monitoredResource false /]
+
+                    [#switch alert.Comparison ]
+                        [#case "Threshold" ]
+                            [@createCountAlarm
+                                mode=listMode
+                                id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
+                                severity=alert.Severity
+                                resourceName=monitoredResource.Name!core.ShortFullName
+                                alertName=alert.Name
+                                actions=[
+                                    getReference(formatSegmentSNSTopicId())
+                                ]
+                                metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
+                                namespace=getResourceMetricNamespace(monitoredResource.Type)
+                                description=alert.Description!alert.Name
+                                threshold=alert.Threshold
+                                statistic=alert.Statistic
+                                evaluationPeriods=alert.Periods
+                                period=alert.Time
+                                operator=alert.Operator
+                                reportOK=alert.ReportOk
+                                missingData=alert.MissingData
+                                dimensions=getResourceMetricDimensions(monitoredResource, resources)
+                                dependencies=monitoredResource.Id
+                            /]
+                        [#break]
+                    [/#switch]
+                [/#list]
+            [/#list]
+
             [@cfResource
                 mode=listMode
                 id=esId

--- a/aws/templates/solution/solution_cache.ftl
+++ b/aws/templates/solution/solution_cache.ftl
@@ -80,6 +80,43 @@
             (getExistingReference(cacheId)?has_content) ]
 
         [#if deploymentSubsetRequired("cache", true)]
+
+            [#list solution.Alerts?values as alert ]
+
+                [#assign monitoredResources = getMonitoredResources(resources, alert.Resource)]
+                [#list monitoredResources as name,monitoredResource ]
+
+                    [@cfDebug listMode monitoredResource false /]
+
+                    [#switch alert.Comparison ]
+                        [#case "Threshold" ]
+                            [@createCountAlarm
+                                mode=listMode
+                                id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
+                                severity=alert.Severity
+                                resourceName=monitoredResource.Name!core.ShortFullName
+                                alertName=alert.Name
+                                actions=[
+                                    getReference(formatSegmentSNSTopicId())
+                                ]
+                                metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
+                                namespace=getResourceMetricNamespace(monitoredResource.Type)
+                                description=alert.Description!alert.Name
+                                threshold=alert.Threshold
+                                statistic=alert.Statistic
+                                evaluationPeriods=alert.Periods
+                                period=alert.Time
+                                operator=alert.Operator
+                                reportOK=alert.ReportOk
+                                missingData=alert.MissingData
+                                dimensions=getResourceMetricDimensions(monitoredResource, resources)
+                                dependencies=monitoredResource.Id
+                            /]
+                        [#break]
+                    [/#switch]
+                [/#list]
+            [/#list]
+
             [@createDependentSecurityGroup
                 mode=listMode
                 tier=tier

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -211,7 +211,9 @@
                             [@createCountAlarm
                                 mode=listMode
                                 id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
-                                name=alert.Severity?upper_case + "-" + monitoredResource.Name!core.ShortFullName + "-" + alert.Name
+                                severity=alert.Severity
+                                resourceName=monitoredResource.Name!core.ShortFullName
+                                alertName=alert.Name
                                 actions=[
                                     getReference(formatSegmentSNSTopicId())
                                 ]
@@ -233,9 +235,13 @@
                 [/#list]
             [/#list]
 
-            [#assign maxSize = processorProfile.MaxPerZone]
-            [#if multiAZ]
-                [#assign maxSize = maxSize * zones?size]
+            [#if processorProfile.MaxCount?has_content]
+                [#assign maxSize = processorProfile.MaxCount ]
+            [#else]
+                [#assign maxSize = processorProfile.MaxPerZone]
+                [#if multiAZ]
+                    [#assign maxSize = maxSize * zones?size]
+                [/#if]
             [/#if]
 
             [@createECSCluster

--- a/aws/templates/solution/solution_mobilenotifier.ftl
+++ b/aws/templates/solution/solution_mobilenotifier.ftl
@@ -162,7 +162,9 @@
                                 [@createCountAlarm
                                     mode=listMode
                                     id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
-                                    name=alert.Severity?upper_case + "-" + monitoredResource.Name!core.ShortFullName + "-" + alert.Name
+                                    severity=alert.Severity
+                                    resourceName=monitoredResource.Name!core.ShortFullName
+                                    alertName=alert.Name
                                     actions=[
                                         getReference(formatSegmentSNSTopicId())
                                     ]

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -198,6 +198,43 @@
         [/#if]
 
         [#if deploymentSubsetRequired("rds", true)]
+
+            [#list solution.Alerts?values as alert ]
+
+                [#assign monitoredResources = getMonitoredResources(resources, alert.Resource)]
+                [#list monitoredResources as name,monitoredResource ]
+
+                    [@cfDebug listMode monitoredResource false /]
+
+                    [#switch alert.Comparison ]
+                        [#case "Threshold" ]
+                            [@createCountAlarm
+                                mode=listMode
+                                id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
+                                severity=alert.Severity
+                                resourceName=monitoredResource.Name!core.ShortFullName
+                                alertName=alert.Name
+                                actions=[
+                                    getReference(formatSegmentSNSTopicId())
+                                ]
+                                metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
+                                namespace=getResourceMetricNamespace(monitoredResource.Type)
+                                description=alert.Description!alert.Name
+                                threshold=alert.Threshold
+                                statistic=alert.Statistic
+                                evaluationPeriods=alert.Periods
+                                period=alert.Time
+                                operator=alert.Operator
+                                reportOK=alert.ReportOk
+                                missingData=alert.MissingData
+                                dimensions=getResourceMetricDimensions(monitoredResource, resources)
+                                dependencies=monitoredResource.Id
+                            /]
+                        [#break]
+                    [/#switch]
+                [/#list]
+            [/#list]
+
             [@createDependentComponentSecurityGroup
                 mode=listMode
                 tier=tier

--- a/aws/templates/solution/solution_sqs.ftl
+++ b/aws/templates/solution/solution_sqs.ftl
@@ -55,7 +55,9 @@
                         [@createCountAlarm
                             mode=listMode
                             id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
-                            name=alert.Severity?upper_case + "-" + monitoredResource.Name!core.ShortFullName + "-" + alert.Name
+                            severity=alert.Severity
+                            resourceName=monitoredResource.Name!core.ShortFullName
+                            alertName=alert.Name
                             actions=[
                                 getReference(formatSegmentSNSTopicId())
                             ]


### PR DESCRIPTION
- Adds Alert support for the following components/resources
   - RDS Component 
       - RDS Instance
   - Cache 
      - Cache Cluster 
   - Elastic Search 
      - Elastic search domain 
   - LB 
      - Load balancer - Classic
      - Load balancer - Network
      - Load balancer - Application 
- Fixes ECS dimension to include the cluster name 
- Fixed minor bug in ECS cluster when a fixed Maximum Count is used instead of Region based count
- Move alarm naming in to shared macro to standardise the naming of alarms 
- Adds Cloudformation Pseudo outputs ( https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html ) to possible attributes for dimensions 