### PR TITLE
Remove agent startupdelay

### DIFF
--- a/aws/templates/fragment/fragment_codeontap.ftl
+++ b/aws/templates/fragment/fragment_codeontap.ftl
@@ -5,8 +5,9 @@
 
     [#assign dockerStageDir = settings["DOCKER_STAGE_DIR"]!"/tmp" ]
     [#assign dockerHostDaemon = settings["DOCKER_HOST_DAEMON"]!"/var/run/docker.sock" ]
+    [#assign jenkinsAgentImage = settings["DOCKER_AGENT_IMAGE"]!"gen3-jenkins-agent"]
 
-    [@Attributes image="gen3-jenkins-agent" /]
+    [@Attributes image=jenkinsAgentImage /]
     
     [@DefaultLinkVariables enabled=false /]
     [@DefaultCoreVariables enabled=false /]

--- a/aws/templates/fragment/fragment_codeontap.ftl
+++ b/aws/templates/fragment/fragment_codeontap.ftl
@@ -6,7 +6,7 @@
     [#assign dockerStageDir = settings["DOCKER_STAGE_DIR"]!"/tmp" ]
     [#assign dockerHostDaemon = settings["DOCKER_HOST_DAEMON"]!"/var/run/docker.sock" ]
 
-    [@Attributes image="gen3-jenkins-slave" /]
+    [@Attributes image="gen3-jenkins-agent" /]
     
     [@DefaultLinkVariables enabled=false /]
     [@DefaultCoreVariables enabled=false /]

--- a/aws/templates/fragment/fragment_codeontap.ftl
+++ b/aws/templates/fragment/fragment_codeontap.ftl
@@ -5,7 +5,7 @@
 
     [#assign dockerStageDir = settings["DOCKER_STAGE_DIR"]!"/tmp" ]
     [#assign dockerHostDaemon = settings["DOCKER_HOST_DAEMON"]!"/var/run/docker.sock" ]
-    [#assign jenkinsAgentImage = settings["DOCKER_AGENT_IMAGE"]!"gen3-jenkins-agent"]
+    [#assign jenkinsAgentImage = settings["DOCKER_AGENT_IMAGE"]!"gen3-jenkins-slave"]
 
     [@Attributes image=jenkinsAgentImage /]
     

--- a/aws/templates/fragment/fragment_jenkins.ftl
+++ b/aws/templates/fragment/fragment_jenkins.ftl
@@ -19,7 +19,10 @@
                 "-Xmx${maxMemory}M",
                 "-Xms${intialHeapSize}M",
                 "-Dhudson.slaves.ChannelPinger.pingIntervalSeconds=${pingInterval}",
-                "-Dhudson.slaves.ChannelPinger.pingTimeoutSeconds=${pingTimeout}"
+                "-Dhudson.slaves.ChannelPinger.pingTimeoutSeconds=${pingTimeout}",
+                "-Dhudson.slaves.NodeProvisioner.initialDelay=0",
+                "-Dhudson.slaves.NodeProvisioner.MARGIN=50",
+                "-Dhudson.slaves.NodeProvisioner.MARGIN0=0.85"
     ]]
 
     [#assign javaExtraOpts = (settings["JAVA_EXTRA_OPTS"]!"")?split(" ")]


### PR DESCRIPTION
Removes a startup delay for dynamic agents. In jenkins this is a default behaviour for on demand agents which are persistent. Jenkins will wait a little bit to see if one of the other agents finishes a job and then starts the process of requesting a new instance. 

For container based jobs which only perform one task this is not a desirable feature and so it has been disabled as part of our container deployment.