### PR TITLE
extend temp file creation template to support alpine mktemp

### DIFF
--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -44,7 +44,7 @@ function add_standard_pairs_to_stack() {
   local input_file="$1"; shift
   local output_file="$1"; shift
 
-  pushTempDir "${FUNCNAME[0]}_XXXX"
+  pushTempDir "${FUNCNAME[0]}_XXXXXX"
   local result_file="$(getTopTempDir)/add_standard_pairs_to_stack.json"
   local return_status
 
@@ -71,7 +71,7 @@ function create_pseudo_stack() {
   local file="$1"; shift
   local pairs=("$@")
 
-  pushTempDir "${FUNCNAME[0]}_XXXX"
+  pushTempDir "${FUNCNAME[0]}_XXXXXX"
   local tmp_file="$(getTopTempDir)/create_pseudo_stack.json"
   local return_status
 
@@ -120,7 +120,7 @@ function convertFilesToJSONObject() {
   local as_file="$1";shift
   local files=("$@")
 
-  pushTempDir "${FUNCNAME[0]}_XXXX"
+  pushTempDir "${FUNCNAME[0]}_XXXXXX"
   local tmp_dir="$(getTopTempDir)"
   local base_file="${tmp_dir}/base.json"
   local processed_files=("${base_file}")
@@ -140,7 +140,7 @@ function convertFilesToJSONObject() {
     local attribute="$( fileBase "${file}" | tr "-" "_" )"
 
     if [[ "${as_file}" == "true" ]]; then
-      source_file="$(getTempFile "asfile_${attribute,,}_XXXX.json" "${tmp_dir}")"
+      source_file="$(getTempFile "asfile_${attribute,,}_XXXXXX.json" "${tmp_dir}")"
       echo -n "{\"${attribute^^}\" : {\"Value\" : \"$(fileName "${file}")\", \"AsFile\" : \"${relative_file}\" }}" > "${source_file}" || return 1
     else
       case "$(fileExtension "${file}")" in
@@ -148,7 +148,7 @@ function convertFilesToJSONObject() {
           ;;
 
         escjson)
-          source_file="$(getTempFile "escjson_${attribute,,}_XXXX.json" "${tmp_dir}")"
+          source_file="$(getTempFile "escjson_${attribute,,}_XXXXXX.json" "${tmp_dir}")"
           runJQ \
             "{\"${attribute^^}\" : {\"Value\" : tojson, \"FromFile\" : \"${relative_file}\" }}" \
             "${file}" > "${source_file}" || return 1
@@ -156,7 +156,7 @@ function convertFilesToJSONObject() {
 
         *)
           # Assume raw input
-          source_file="$(getTempFile "raw_${attribute,,}_XXXX.json" "${tmp_dir}")"
+          source_file="$(getTempFile "raw_${attribute,,}_XXXXXX.json" "${tmp_dir}")"
           runJQ -sR \
             "{\"${attribute^^}\" : {\"Value\" : ., \"FromFile\" : \"${relative_file}\" }}" \
             "${file}" > "${source_file}" || return 1
@@ -166,7 +166,7 @@ function convertFilesToJSONObject() {
     fi
 
     local file_ancestors=("${prefixes[@]}" $(filePath "${file}" | tr "./" " ") )
-    local processed_file="$(getTempFile "processed_XXXX.json" "${tmp_dir}")"
+    local processed_file="$(getTempFile "processed_XXXXXX.json" "${tmp_dir}")"
     addJSONAncestorObjects "${source_file}" "${base_ancestors[@]}" $(join "-" "${file_ancestors[@]}" | tr "[:upper:]" "[:lower:]") > "${processed_file}" || return 1
     processed_files+=("${processed_file}")
   done
@@ -180,7 +180,7 @@ function assemble_settings() {
   local root_dir="${1:-${ROOT_DIR}}"; shift
   local result_file="${1:-${COMPOSITE_SETTINGS}}"; shift
 
-  pushTempDir "${FUNCNAME[0]}_XXXX"
+  pushTempDir "${FUNCNAME[0]}_XXXXXX"
   local tmp_dir="$(getTopTempDir)"
   local tmp_file_list=()
 
@@ -208,7 +208,7 @@ function assemble_settings() {
     debug "Processing ${account_dir} ..."
     pushd "${account_dir}" > /dev/null 2>&1 || continue
 
-    tmp_file="$( getTempFile "account_settings_XXXX.json" "${tmp_dir}")"
+    tmp_file="$( getTempFile "account_settings_XXXXXX.json" "${tmp_dir}")"
     readarray -t setting_files < <(find . -type f -name "*.json" )
     convertFilesToJSONObject "Settings Accounts" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
     tmp_file_list+=("${tmp_file}")
@@ -240,7 +240,7 @@ function assemble_settings() {
       -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
       -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "product_settings_XXXX.json" "${tmp_dir}")"
+      tmp_file="$( getTempFile "product_settings_XXXXXX.json" "${tmp_dir}")"
       convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
@@ -251,7 +251,7 @@ function assemble_settings() {
       -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
       -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "product_sensitive_XXXX.json" "${tmp_dir}")"
+      tmp_file="$( getTempFile "product_sensitive_XXXXXX.json" "${tmp_dir}")"
       convertFilesToJSONObject "Sensitive Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
@@ -262,7 +262,7 @@ function assemble_settings() {
       -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
       -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "product_builds_XXXX.json" "${tmp_dir}")"
+      tmp_file="$( getTempFile "product_builds_XXXXXX.json" "${tmp_dir}")"
       convertFilesToJSONObject "Builds Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
@@ -272,7 +272,7 @@ function assemble_settings() {
       \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
       -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "product_settings_asfile_XXXX.json" "${tmp_dir}")"
+      tmp_file="$( getTempFile "product_settings_asfile_XXXXXX.json" "${tmp_dir}")"
       convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "true" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
@@ -299,7 +299,7 @@ function assemble_settings() {
       -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
       -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "operations_settings_XXXX.json" "${tmp_dir}")"
+      tmp_file="$( getTempFile "operations_settings_XXXXXX.json" "${tmp_dir}")"
       convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
@@ -310,7 +310,7 @@ function assemble_settings() {
       -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
       -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "operations_sensitive_XXXX.json" "${tmp_dir}")"
+      tmp_file="$( getTempFile "operations_sensitive_XXXXXX.json" "${tmp_dir}")"
       convertFilesToJSONObject "Sensitive Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
@@ -320,7 +320,7 @@ function assemble_settings() {
       \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
       -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
     if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "operations_settings_asfile_XXXX.json" "${tmp_dir}")"
+      tmp_file="$( getTempFile "operations_settings_asfile_XXXXXX.json" "${tmp_dir}")"
       convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "true" "${setting_files[@]}" > "${tmp_file}" || return 1
       tmp_file_list+=("${tmp_file}")
     fi
@@ -339,7 +339,7 @@ function assemble_settings() {
 
 function assemble_composite_definitions() {
 
-  local tmp_file="$( getTempFile "definitions_XXXX" "${tmp_dir}" )"
+  local tmp_file="$( getTempFile "definitions_XXXXXX" "${tmp_dir}" )"
 
   # Gather the relevant definitions
   local restore_nullglob=$(shopt -p nullglob)
@@ -369,7 +369,7 @@ function assemble_composite_stack_outputs() {
   local restore_nullglob=$(shopt -p nullglob)
   shopt -s nullglob
 
-  pushTempDir "${FUNCNAME[0]}_XXXX"
+  pushTempDir "${FUNCNAME[0]}_XXXXXX"
   local tmp_dir="$(getTopTempDir)"
 
   local stack_array=()
@@ -436,7 +436,7 @@ function encrypt_file() {
   local input_file="$1"; shift
   local output_file="$1"; shift
 
-  pushTempDir "${FUNCNAME[0]}_XXXX"
+  pushTempDir "${FUNCNAME[0]}_XXXXXX"
   local tmp_dir="$(getTopTempDir)"
   local cmk=$(getCmk "${level}")
   local return_status
@@ -781,7 +781,7 @@ function upgrade_cmdb_repo_to_v1_0_0() {
   local root_dir="$1";shift
   local dry_run="$1";shift
 
-  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXX"
+  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXXXX"
   local tmp_dir="$(getTopTempDir)"
   local tmp_file
 
@@ -795,7 +795,7 @@ function upgrade_cmdb_repo_to_v1_0_0() {
     replacement_file="$(filePath "${legacy_file}")/build.json"
     [[ -f "${replacement_file}" ]] && continue
     info "Upgrading ${legacy_file} ..."
-    tmp_file="$(getTempFile "build_XXXX.json" "${tmp_dir}")"
+    tmp_file="$(getTempFile "build_XXXXXX.json" "${tmp_dir}")"
     upgrade_build_ref "${legacy_file}" "${tmp_file}" || { return_status=1; break; }
 
     if [[ -n "${dry_run}" ]]; then
@@ -814,7 +814,7 @@ function upgrade_cmdb_repo_to_v1_0_0() {
       replacement_file="$(filePath "${legacy_file}")/shared_build.json"
       [[ -f "${replacement_file}" ]] && continue
       info "Upgrading ${legacy_file} ..."
-      tmp_file="$(getTempFile "shared_XXXX.json" "${tmp_dir}")"
+      tmp_file="$(getTempFile "shared_XXXXXX.json" "${tmp_dir}")"
       upgrade_shared_build_ref "${legacy_file}" "${tmp_file}" || { return_status=1; break; }
 
       if [[ -n "${dry_run}" ]]; then
@@ -834,7 +834,7 @@ function upgrade_cmdb_repo_to_v1_0_0() {
       if [[ "$(jq ".Credentials | if .==null then [] else [1] end | length" < "${legacy_file}" )" -gt 0 ]]; then
         upgrade_needed="true"
         info "Upgrading ${legacy_file} ..."
-        tmp_file="$(getTempFile "credentials_XXXX.json" "${tmp_dir}")"
+        tmp_file="$(getTempFile "credentials_XXXXXX.json" "${tmp_dir}")"
         upgrade_credentials "${legacy_file}" "${tmp_file}" || { return_status=1; break; }
 
       if [[ -n "${dry_run}" ]]; then
@@ -856,7 +856,7 @@ function upgrade_cmdb_repo_to_v1_0_0() {
       [[ -f "${replacement_file}" ]] && continue
       upgrade_needed="true"
       info "Upgrading ${legacy_file} ..."
-      tmp_file="$(getTempFile "container_XXXX.json" "${tmp_dir}")"
+      tmp_file="$(getTempFile "container_XXXXXX.json" "${tmp_dir}")"
       cp "${legacy_file}" "${tmp_file}" || { return_status=1; break; }
 
       if [[ -n "${dry_run}" ]]; then
@@ -994,7 +994,7 @@ function upgrade_cmdb_repo_to_v1_1_0() {
   local root_dir="$1";shift
   local dry_run="$1";shift
 
-  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXX"
+  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXXXX"
   local tmp_dir="$(getTopTempDir)"
   local return_status=0
 
@@ -1118,7 +1118,7 @@ function upgrade_cmdb_repo_to_v1_2_0() {
   local root_dir="$1";shift
   local dry_run="$1";shift
 
-  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXX"
+  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXXXX"
   local tmp_dir="$(getTopTempDir)"
   local return_status=0
 
@@ -1147,7 +1147,7 @@ function upgrade_cmdb_repo_to_v1_3_0() {
   local root_dir="$1";shift
   local dry_run="$1";shift
 
-  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXX"
+  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXXXX"
   local tmp_dir="$(getTopTempDir)"
   local return_status=0
 
@@ -1253,7 +1253,7 @@ function upgrade_cmdb_repo_to_v1_3_1() {
   local root_dir="$1";shift
   local dry_run="$1";shift
 
-  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXX"
+  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXXXX"
   local tmp_dir="$(getTopTempDir)"
   local return_status=0
 
@@ -1352,7 +1352,7 @@ function process_cmdb() {
   # Find all the repos
   readarray -t cmdb_git_repos < <(find "${root_dir}" -type d -name ".git" | sort )
 
-  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXX"
+  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXXXX"
   local tmp_version_file="$(getTopTempDir)/new_version.json"
   local tmp_result_file="$(getTopTempDir)/new_cmdb.json"
 

--- a/aws/createExtendedSwaggerSpecification.sh
+++ b/aws/createExtendedSwaggerSpecification.sh
@@ -5,7 +5,7 @@ trap '[[ (-z "${GENERATION_DEBUG}") && (-n "${tmpdir}") ]] && rm -rf "${tmpdir}"
 . "${GENERATION_DIR}/common.sh"
 
 # Create a temporary directory for this run
-pushTempDir "cot_gw_XXXX"
+pushTempDir "cot_gw_XXXXXX"
 export GENERATION_TMPDIR="$(getTopTempDir)"
 debug "TMPDIR=${GENERATION_TMPDIR}"
 

--- a/aws/createReference.sh
+++ b/aws/createReference.sh
@@ -8,7 +8,7 @@ trap '. ${GENERATION_DIR}/cleanupContext.sh' EXIT SIGHUP SIGINT SIGTERM
 REFERENCE_OUTPUT_DIR_DEFAULT="${GENERATION_BASE_DIR}/dist/reference/"
 
 # Create a dir for some temporary files
-dockerstagedir="$(getTempDir "cota_docker_XXXX" "${DOCKER_STAGE_DIR}")"
+dockerstagedir="$(getTempDir "cota_docker_XXXXXX" "${DOCKER_STAGE_DIR}")"
 chmod a+rwx "${dockerstagedir}"
 
 function usage() {
@@ -163,7 +163,7 @@ function process_template() {
   args+=("-v" "region=ap-southeast-2")
 
   # Directory for temporary files
-  pushTempDir "create_template_XXXX"
+  pushTempDir "create_template_XXXXXX"
   local tmp_dir="$(getTopTempDir)"
 
   # Perform each pass
@@ -244,7 +244,7 @@ function main() {
 
   options "$@" || return $?
 
-  pushTempDir "create_template_XXXX"
+  pushTempDir "create_template_XXXXXX"
   tmp_dir="$(getTopTempDir)"
   
   info "Starting work on ${REFERENCE_TYPE} Reference"

--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -113,7 +113,7 @@ function get_swagger_definition_file() {
   local accountNumber="$1"; shift
   local region="$1"; shift
 
-  pushTempDir "${FUNCNAME[0]}_XXXX"
+  pushTempDir "${FUNCNAME[0]}_XXXXXX"
   local swagger_file_dir="$(getTopTempDir)"
 
   # Name definitions based on the component
@@ -379,7 +379,7 @@ function process_template() {
   args+=("-v" "deploymentMode=${DEPLOYMENT_MODE}")
 
   # Directory for temporary files
-  pushTempDir "create_template_XXXX"
+  pushTempDir "create_template_XXXXXX"
   local tmp_dir="$(getTopTempDir)"
 
   # Directory where we gather the results
@@ -562,7 +562,7 @@ function main() {
 
   options "$@" || return $?
 
-  pushTempDir "create_template_XXXX"
+  pushTempDir "create_template_XXXXXX"
   tmp_dir="$(getTopTempDir)"
   tmpdir="${tmp_dir}"
 

--- a/aws/manageStack.sh
+++ b/aws/manageStack.sh
@@ -481,7 +481,7 @@ function main() {
 
   options "$@" || return $?
 
-  pushTempDir "manage_stack_XXXX"
+  pushTempDir "manage_stack_XXXXXX"
   tmp_dir="$(getTopTempDir)"
   tmpdir="${tmp_dir}"
   potential_change_file="${tmp_dir}/potential_changes"

--- a/aws/setContext.sh
+++ b/aws/setContext.sh
@@ -26,7 +26,7 @@ debug "--- starting setContext.sh ---\n"
 
 # Create a temporary directory for this run
 if [[ -z "${GENERATION_TMPDIR}" ]]; then
-  pushTempDir "cot_XXXX"
+  pushTempDir "cot_XXXXXX"
   export GENERATION_TMPDIR="$( getTopTempDir )"
 fi
 debug "TMPDIR=${GENERATION_TMPDIR}"
@@ -299,19 +299,19 @@ if [[ -n "${CHECK_AWS_SESSION_TOKEN}" ]]; then export AWS_SESSION_TOKEN="${CHECK
 # bug in python
 if [[ ((-z "${AWS_ACCESS_KEY_ID}") || (-z "${AWS_SECRET_ACCESS_KEY}")) ]]; then
     if [[ -n "${ACCOUNT}" ]]; then
-        aws configure list --profile "${ACCOUNT}" > $(getTempFile "account_profile_status_XXXX.txt") 2>&1
+        aws configure list --profile "${ACCOUNT}" > $(getTempFile "account_profile_status_XXXXXX.txt") 2>&1
         if [[ $? -eq 0 ]]; then
             export AWS_DEFAULT_PROFILE="${ACCOUNT}"
         fi
     fi
     if [[ -n "${AID}" ]]; then
-        aws configure list --profile "${AID}" > $(getTempFile "id_profile_status_XXXX.txt") 2>&1
+        aws configure list --profile "${AID}" > $(getTempFile "id_profile_status_XXXXXX.txt") 2>&1
         if [[ $? -eq 0 ]]; then
             export AWS_DEFAULT_PROFILE="${AID}"
         fi
     fi
     if [[ -n "${AWSID}" ]]; then
-        aws configure list --profile "${AWSID}" > $(getTempFile "awsid_profile_status_XXXX.txt") 2>&1
+        aws configure list --profile "${AWSID}" > $(getTempFile "awsid_profile_status_XXXXXX.txt") 2>&1
         if [[ $? -eq 0 ]]; then
             export AWS_DEFAULT_PROFILE="${AWSID}"
         fi

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -533,7 +533,7 @@ function getTempDir() {
   local template="$1"; shift
   local tmp_dir="$1"; shift
 
-  [[ -z "${template}" ]] && template="XXXX"
+  [[ -z "${template}" ]] && template="XXXXXX"
   [[ -z "${tmp_dir}" ]] && tmp_dir="$(getTempRootDir)"
 
   [[ -n "${tmp_dir}" ]] &&
@@ -569,7 +569,7 @@ function getTempFile() {
   local template="$1"; shift
   local tmp_dir="$1"; shift
 
-  [[ -z "${template}" ]] && template="XXXX"
+  [[ -z "${template}" ]] && template="XXXXXX"
   [[ -z "${tmp_dir}" ]] && tmp_dir="$(getTempRootDir)"
 
   [[ -n "${tmp_dir}" ]] &&
@@ -605,11 +605,11 @@ function runJQ() {
   for argument in "${arguments[@]}"; do
     if [[ -f "${argument}" ]]; then
       if [[ "${file_seen}" != "true" ]]; then
-        pushTempDir "${FUNCNAME[0]}_XXXX"
+        pushTempDir "${FUNCNAME[0]}_XXXXXX"
         tmp_dir="$(getTopTempDir)"
         file_seen="true"
       fi
-      file="$( getTempFile "XXXX" "${tmp_dir}" )"
+      file="$( getTempFile "XXXXXX" "${tmp_dir}" )"
       cp "${argument}" "${file}" > /dev/null
       modified_arguments+=("./$(fileName "${file}" )")
     else
@@ -682,7 +682,7 @@ function decrypt_kms_string() {
   local region="$1"; shift
   local value="$1"; shift
 
-  pushTempDir "${FUNCNAME[0]}_XXXX"
+  pushTempDir "${FUNCNAME[0]}_XXXXXX"
   local tmp_file="$(getTopTempDir)/value"
   local return_status
 
@@ -884,7 +884,7 @@ function cleanup_elbv2_rules() {
   local region="$1"; shift
   local listenerarn="$1"; shift
 
-  pushTempDir "elbv2_listener_cleanup_XXXX"
+  pushTempDir "elbv2_listener_cleanup_XXXXXX"
   local tmp_file="$(getTopTempDir)/cleanup.sh"
 
   all_listener_rules="$(aws --region "${region}" elbv2 describe-rules --listener-arn "${listenerarn}" --query 'Rules[?!IsDefault].RuleArn' --output json )"
@@ -910,7 +910,7 @@ function isBucketAccessible() {
   local bucket="$1"; shift
   local prefix="$1"; shift
 
-  local result_file="$(getTopTempDir)/is_bucket_accessible_XXXX.txt"
+  local result_file="$(getTopTempDir)/is_bucket_accessible_XXXXXX.txt"
 
   aws --region ${region} s3 ls "s3://${bucket}/${prefix}${prefix:+/}" > "${result_file}" 2>&1
 }
@@ -938,7 +938,7 @@ function syncFilesToBucket() {
 
   # Does the bucket/prefix exist?
   if isBucketAccessible "${region}" "${bucket}"; then
-    pushTempDir "${FUNCNAME[0]}_XXXX"
+    pushTempDir "${FUNCNAME[0]}_XXXXXX"
     local tmp_dir="$(getTopTempDir)"
     local return_status
 
@@ -1052,7 +1052,7 @@ function cleanup_sns_platformapps() {
   local mobile_notifier_name="$1"; shift
   local expected_platform_arns="$1"; shift
 
-  pushTempDir "${mobile_notifier_name}_cleanup_XXXX"
+  pushTempDir "${mobile_notifier_name}_cleanup_XXXXXX"
   local tmp_file="$(getTopTempDir)/cleanup.sh"
 
   all_platform_apps="$(aws --region "${region}" sns list-platform-applications )"
@@ -1182,9 +1182,9 @@ function update_ssm_document() {
 function update_oai_credentials() {
   local region="$1"; shift
   local name="$1"; shift
-  local result_file="${1:-$( getTempFile update_oai_XXXX.json)}"; shift
+  local result_file="${1:-$( getTempFile update_oai_XXXXXX.json)}"; shift
 
-  local oai_list_file="$( getTempFile oai_list_XXXX.json)"
+  local oai_list_file="$( getTempFile oai_list_XXXXXX.json)"
   local oai_id=
 
   # Check for existing identity
@@ -1210,7 +1210,7 @@ function delete_oai_credentials() {
   local region="$1"; shift
   local name="$1"; shift
 
-  local oai_delete_file="$( getTempFile oai_delete_XXXX.json)"
+  local oai_delete_file="$( getTempFile oai_delete_XXXXXX.json)"
   local oai_id=
   local oai_etag=
 
@@ -1543,7 +1543,7 @@ function invalidate_distribution() {
 function release_enis() {
     local region="$1"; shift
     local requester_id="$1"; shift
-    local eni_list_file="$( getTempFile eni_list_XXXX.json)"
+    local eni_list_file="$( getTempFile eni_list_XXXXXX.json)"
 
     aws --region "${region}" ec2 describe-network-interfaces --filters Name=requester-id,Values="*${requester_id}" > "${eni_list_file}" || return $?
 


### PR DESCRIPTION
When trying to create a smaller image using alpine linux I found that mktemp wasn't working as expected. 

It turns out alpine linux uses the busybox version of mktemp which requires a different template length as a minimum requirement. Since it shouldn't be a big deal to make the template bigger for other distributions this should be a minor change