### PR TITLE
Fix alert name

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -452,7 +452,7 @@
                                 mode=listMode
                                 id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
                                 severity=alert.Severity
-                                resourceName=monitoredResource.Name!core.ShortFullName
+                                resourceName=core.FullName
                                 alertName=alert.Name
                                 actions=[
                                     getReference(formatSegmentSNSTopicId())

--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -431,7 +431,7 @@
                                     mode=listMode
                                     id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
                                     severity=alert.Severity
-                                    resourceName=monitoredResource.Name!core.ShortFullName
+                                    resourceName=core.FullName
                                     alertName=alert.Name
                                     actions=[
                                         getReference(formatSegmentSNSTopicId())

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -377,7 +377,7 @@
                                     mode=listMode
                                     id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
                                     severity=alert.Severity
-                                    resourceName=monitoredResource.Name!core.ShortFullName
+                                    resourceName=core.FullName
                                     alertName=alert.Name
                                     actions=[
                                         getReference(formatSegmentSNSTopicId())

--- a/aws/templates/id/id_es.ftl
+++ b/aws/templates/id/id_es.ftl
@@ -99,7 +99,7 @@
             "Resources" : {
                 "es" : { 
                     "Id" : esId,
-                    "Name" : core.Name,
+                    "Name" : core.ShortFullName,
                     "Type" : AWS_ES_RESOURCE_TYPE,
                     "Monitored" : true
                 },

--- a/aws/templates/solution/solution_ElasticSearch.ftl
+++ b/aws/templates/solution/solution_ElasticSearch.ftl
@@ -217,7 +217,7 @@
                                 mode=listMode
                                 id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
                                 severity=alert.Severity
-                                resourceName=monitoredResource.Name!core.ShortFullName
+                                resourceName=core.FullName
                                 alertName=alert.Name
                                 actions=[
                                     getReference(formatSegmentSNSTopicId())

--- a/aws/templates/solution/solution_cache.ftl
+++ b/aws/templates/solution/solution_cache.ftl
@@ -94,7 +94,7 @@
                                 mode=listMode
                                 id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
                                 severity=alert.Severity
-                                resourceName=monitoredResource.Name!core.ShortFullName
+                                resourceName=core.FullName
                                 alertName=alert.Name
                                 actions=[
                                     getReference(formatSegmentSNSTopicId())

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -212,7 +212,7 @@
                                 mode=listMode
                                 id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
                                 severity=alert.Severity
-                                resourceName=monitoredResource.Name!core.ShortFullName
+                                resourceName=core.FullName
                                 alertName=alert.Name
                                 actions=[
                                     getReference(formatSegmentSNSTopicId())

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -71,7 +71,7 @@
                                 mode=listMode
                                 id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
                                 severity=alert.Severity
-                                resourceName=monitoredResource.Name!core.ShortFullName
+                                resourceName=core.FullName
                                 alertName=alert.Name
                                 actions=[
                                     getReference(formatSegmentSNSTopicId())

--- a/aws/templates/solution/solution_mobilenotifier.ftl
+++ b/aws/templates/solution/solution_mobilenotifier.ftl
@@ -163,7 +163,7 @@
                                     mode=listMode
                                     id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
                                     severity=alert.Severity
-                                    resourceName=monitoredResource.Name!core.ShortFullName
+                                    resourceName=core.FullName
                                     alertName=alert.Name
                                     actions=[
                                         getReference(formatSegmentSNSTopicId())

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -212,7 +212,7 @@
                                 mode=listMode
                                 id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
                                 severity=alert.Severity
-                                resourceName=monitoredResource.Name!core.ShortFullName
+                                resourceName=core.FullName
                                 alertName=alert.Name
                                 actions=[
                                     getReference(formatSegmentSNSTopicId())

--- a/aws/templates/solution/solution_sqs.ftl
+++ b/aws/templates/solution/solution_sqs.ftl
@@ -56,7 +56,7 @@
                             mode=listMode
                             id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
                             severity=alert.Severity
-                            resourceName=monitoredResource.Name!core.ShortFullName
+                            resourceName=core.FullName
                             alertName=alert.Name
                             actions=[
                                 getReference(formatSegmentSNSTopicId())


### PR DESCRIPTION
Update alert names to be the Full Name instead of based on the resource name. 

This provides consistent naming in the alert names to make forwarding of alerts easier. 

This does mean that when two monitored resources are defined there will need to be a filter on the resource