### PR TITLE
Disable multiAZ for back up restore

### DIFF
--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -305,6 +305,7 @@
 
             [#switch alternative ]
                 [#case "replace1" ]
+                    [#assign multiAZ = false]
                     [#assign rdsFullName=formatName(rdsFullName, "backup") ]
                     [#if rdsManualSnapshot?has_content ]
                         [#assign snapshotId = rdsManualSnapshot ]
@@ -317,7 +318,6 @@
                 [#break]
 
                 [#case "replace2"]
-                    [#assign multiAZ = false]
                     [#if rdsManualSnapshot?has_content ]
                         [#assign snapshotId = rdsManualSnapshot ]
                     [#else]


### PR DESCRIPTION
Fix for RDS restore process so that when the backup instance is created multiAZ is not enabled