### PR TITLE
Enable cross zone lb for network lb

### DIFF
--- a/aws/templates/resource/resource_lb.ftl
+++ b/aws/templates/resource/resource_lb.ftl
@@ -130,7 +130,8 @@
                     "Key" : "load_balancing.cross_zone.enabled",
                     "Value" : true
                 }
-            ]
+            ],
+            []
         )
     ]
 

--- a/aws/templates/resource/resource_lb.ftl
+++ b/aws/templates/resource/resource_lb.ftl
@@ -123,6 +123,14 @@
                 }
             ],
             []
+        ) + 
+        ( type == "network" )?then(
+            [
+                {
+                    "Key" : "load_balancing.cross_zone.enabled",
+                    "Value" : true
+                }
+            ]
         )
     ]
 


### PR DESCRIPTION
Cross zone load balancing is disabled for network lb's by default.  This enables it for all network load balancers.