### PR TITLE
Ecs task volume configuration

### DIFF
--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -243,7 +243,7 @@
     [/#if]
 [/#macro]
 
-[#macro Volume name containerPath hostPath="" readOnly=false]
+[#macro Volume name containerPath hostPath="" readOnly=false persist=false ]
     [#if (fragmentListMode!"") == "model"]
         [#assign _context +=
             {
@@ -253,7 +253,11 @@
                         name : {
                             "ContainerPath" : containerPath,
                             "HostPath" : hostPath,
-                            "ReadOnly" : readOnly
+                            "ReadOnly" : readOnly,
+                            "PersistVolume" : persist?is_string?then(
+                                                persist?boolean,
+                                                persist
+                            )
                         }
                     }
             }

--- a/aws/templates/fragment/fragment_codeontap.ftl
+++ b/aws/templates/fragment/fragment_codeontap.ftl
@@ -3,10 +3,13 @@
 
     [#assign settings = _context.DefaultEnvironment]
 
-    [#assign dockerStageDir = settings["DOCKER_STAGE_DIR"]!"/tmp" ]
-    [#assign dockerHostDaemon = settings["DOCKER_HOST_DAEMON"]!"/var/run/docker.sock" ]
-    [#assign jenkinsAgentImage = settings["DOCKER_AGENT_IMAGE"]!"gen3-jenkins-slave"]
-
+    [#assign dockerStageDir = settings["DOCKER_STAGE_DIR"]!"/tmp/docker-build" ]
+    [#assign dockerHostDaemon = settings["DOCKER_HOST_DAEMON"]!"/var/run/docker.sock"]
+    [#assign jenkinsAgentImage = settings["DOCKER_AGENT_IMAGE"]!"gen3"]
+    [#assign agentWorkDir = settings["AGENT_WORK_DIR"]!"/home/jenkins" ]
+    [#assign persistWorkDir = settings["AGENT_WORK_DIR_PERSIST"]!false ]
+    [#assign agentTmpVolume = settings["AGENT_TMP_VOLUME"]!"/tmp" ]
+    
     [@Attributes image=jenkinsAgentImage /]
     
     [@DefaultLinkVariables enabled=false /]
@@ -18,27 +21,66 @@
         "DOCKER_STAGE_DIR" : dockerStageDir
     }/]
 
-    [@Volume "dockerDaemon" "/var/run/docker.sock" dockerHostDaemon  /]
-    [@Volume "dockerStage" dockerStageDir dockerStageDir /]
-
-    [#-- Validate that the appropriate settings have been provided for the container to work --]
-    [#if settings["CODEONTAPVOLUME"]?has_content ]
-        [@Volume "codeontap" "/var/opt/codeontap/" settings["CODEONTAPVOLUME"] /]
-    [/#if]  
-
-    [#if settings["AWSPROFILEVOLUME"]?has_content ]
-        [#assign awsProfilePath = "/var/opt/awsprofile/" ]
-
-        [@Volume "awsprofile" awsProfilePath settings["AWSPROFILEVOLUME"] /]
-        [@Variable "AWS_CONFIG_FILE" awsProfilePath + "config" /]
-    [/#if]
-
-    [#if settings["AWS_AUTOMATION_POLICIES"]?has_content ]
-        [@ManagedPolicy settings["AWS_AUTOMATION_POLICIES"]?split(",") /]
-    [#else]
-        [@Policy
-            globalAdministratorAccess()
+    [@Volume 
+        name="dockerDaemon" 
+        containerPath="/var/run/docker.sock" 
+        hostPath=dockerHostDaemon  
+    /]
+    [@Volume 
+        name="dockerStage" 
+        containerPath=dockerStageDir 
+        hostPath=dockerStageDir 
+    /]
+    
+    [#-- Attach volumes to Jenkins Agent home dir to increase performance  --]
+    [@Volume 
+        name="agentWorkDir"
+        containerPath=agentWorkDir
+        persist=persistWorkDir
+        /]
+    
+    [#if agentTmpVolume?has_content ]
+        [@Volume
+            name="agentTmpDir"
+            containerPath=agentTmpVolume
         /]
     [/#if]
 
+    [#-- Validate that the appropriate settings have been provided for the container to work --]
+    [#if settings["CODEONTAPVOLUME"]?has_content ]
+        [@Volume 
+            name="codeontap" 
+            containerPath="/var/opt/codeontap/" 
+            hostPath=settings["CODEONTAPVOLUME"] 
+            readOnly=true     
+        /]
+    [/#if]  
+
+    [#if settings["AWS_AUTOMATION_POLICIES"]?has_content ]
+        [@ManagedPolicy settings["AWS_AUTOMATION_POLICIES"]?split(",") /]
+    [/#if]
+
+    [#break]
+
+[#case "_jenkinsecs" ] 
+    [#assign settings = _context.DefaultEnvironment]
+
+    [#-- The docker stage dir is used to provide a staging location for docker in docker based builds which use the host docker instance --]
+    [#assign dockerStageDirs = 
+            (settings["DOCKER_STAGE_DIR"])?has_content?then(
+                    asArray(settings["DOCKER_STAGE_DIR"]),
+                    settings["DOCKER_STAGE_DIRS"]?has_content?then(
+                        asArray( (settings["DOCKER_STAGE_DIRS"]?split(",") )),
+                        [ "/tmp/docker-build" ]
+                    )
+            )]
+    
+    [#list dockerStageDirs as dockerStageDir]
+        [@Directory
+            path=dockerStageDir
+            mode="775"
+            owner="1000"
+            group="1000"
+        /]
+    [/#list]
     [#break]

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -103,7 +103,16 @@
                     attributeIfTrue(
                         "Host",
                         volume.HostPath?has_content,
-                        {"SourcePath" : volume.HostPath!""})
+                        {"SourcePath" : volume.HostPath!""}) + 
+                    attributeIfTrue(
+                        "DockerVolumeConfiguration",
+                        volume.PersistVolume,
+                        {
+                            "Scope" : "shared",
+                            "autoprovision": true,
+                            "driver": "local" 
+                        }
+                    )
                 ]
             ]
         [/#list]

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -109,8 +109,8 @@
                         volume.PersistVolume,
                         {
                             "Scope" : "shared",
-                            "autoprovision": true,
-                            "driver": "local" 
+                            "Autoprovision": true,
+                            "Driver": "local" 
                         }
                     )
                 ]


### PR DESCRIPTION
Adds support for persisting docker volumes for a given task

This creates a docker volume which is created when the first instance of the the task is initiated. This volume is then kept on the ECS instance which ran it and when a new instance of the tasks is created the same volume is used if the task can be placed on the instance. 

This PR also adds updates to the codeontap agent fragment to uses this persistence technique for the agent home volume