### PR TITLE
minor fixes for network refactor

### DIFF
--- a/aws/templates/resource/resource_efs.ftl
+++ b/aws/templates/resource/resource_efs.ftl
@@ -50,14 +50,17 @@
     /]
 [/#macro]
 
-[#macro createEFSMountTarget mode id efsId subnetId securityGroups dependencies="" ]
+[#macro createEFSMountTarget mode id efsId subnet securityGroups dependencies="" ]
     [@cfResource
         mode=mode
         id=id
         type="AWS::EFS::MountTarget"
         properties=
             {
-                "SubnetId" : getReference(subnetId),
+                "SubnetId" : subnet?is_enumerable?then(
+                                subnet[0],
+                                subnet
+                ),
                 "FileSystemId" : getReference(efsId),
                 "SecurityGroups": getReferences(securityGroups)
             }

--- a/aws/templates/segment/segment_bastion.ftl
+++ b/aws/templates/segment/segment_bastion.ftl
@@ -48,7 +48,7 @@
 
         [#assign vpcId = networkResources["vpc"].Id ]
 
-        [#assign routeTableLinkTarget = getLinkTarget(occurrence, networkLink + { "RouteTable" : tier.Network.RouteTable })]
+        [#assign routeTableLinkTarget = getLinkTarget(occurrence, networkLink + { "RouteTable" : tier.Network.RouteTable }, false)]
         [#assign routeTableConfiguration = routeTableLinkTarget.Configuration.Solution ]
         [#assign publicRouteTable = routeTableConfiguration.Public ]
 

--- a/aws/templates/segment/segment_gateway.ftl
+++ b/aws/templates/segment/segment_gateway.ftl
@@ -201,8 +201,6 @@
                                     [#assign zoneRouteTableId = zoneRouteTableResources["routeTable"].Id]
                                     [#assign routeTableIds += [ zoneRouteTableId ]]
 
-                                    
-
                                         [#if deploymentSubsetRequired(NETWORK_GATEWAY_COMPONENT_TYPE, true)]
 
                                         [#switch gwSolution.Engine ]

--- a/aws/templates/solution/solution_efs.ftl
+++ b/aws/templates/solution/solution_efs.ftl
@@ -70,7 +70,7 @@
                 [@createEFSMountTarget
                     mode=listMode
                     id=zoneEfsMountTargetId
-                    subnetId=getSubnets(tier, networkResources, zone.Id)
+                    subnet=getSubnets(tier, networkResources, zone.Id, true, false)
                     efsId=efsId
                     securityGroups=efsSecurityGroupId
                     dependencies=[efsId,efsSecurityGroupId]


### PR DESCRIPTION
- EFS: Fix subnet lookup to use results of getSubnets
- Bastion: Allow nondeployed route tables to get around initial migration issues in IAM pass