### PR TITLE
default multiAZ config if not found

### DIFF
--- a/aws/templates/id/id_networkgateway.ftl
+++ b/aws/templates/id/id_networkgateway.ftl
@@ -96,7 +96,7 @@
     [#local resources = {} ]
     [#local zoneResources = {}]
 
-    [#if multiAZ ]
+    [#if multiAZ!false ]
         [#local resourceZones = zones ]
     [#else]
         [#local resourceZones = [ zones[0] ]]
@@ -204,7 +204,7 @@
     [#local parentSolution = parent.Configuration.Solution ]
     [#local engine = parentSolution.Engine ]
     
-    [#if multiAZ || engine == "vpcendpoint" ]
+    [#if multiAZ!false || engine == "vpcendpoint" ]
         [#local resourceZones = zones ]
     [#else]
         [#local resourceZones = [zones[0]] ]


### PR DESCRIPTION
Workaround for component based multiAZ configuration on get occurrence states