### PR TITLE
Adds support for persistent data volumes on ECS

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -847,6 +847,10 @@ behaviour.
             [#case DATAPIPELINE_COMPONENT_TYPE ]
                 [#local result = getDataPipelineState(occurrence)]
                 [#break]
+            
+            [#case DATAVOLUME_COMPONENT_TYPE ]
+                [#local result = getDataVolumeState(occurrence)]
+                [#break]
 
             [#case EC2_COMPONENT_TYPE]
                 [#local result = getEC2State(occurrence)]

--- a/aws/templates/id/id_datavolume.ftl
+++ b/aws/templates/id/id_datavolume.ftl
@@ -1,0 +1,102 @@
+[#-- Datavolume --]
+
+[#-- Components --]
+[#assign DATAVOLUME_COMPONENT_TYPE = "datavolume" ]
+
+[#assign componentConfiguration +=
+    {
+        DATAVOLUME_COMPONENT_TYPE  : {
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "A persistant disk volume independent of compute"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Names" : "Engine",
+                    "Type" : STRING_TYPE,
+                    "Values" : [ "ebs" ],
+                    "Default" : "ebs"
+                },
+                {
+                    "Names" : "Encrypted",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Names" : "Size",
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 20
+                },
+                {
+                    "Names" : "VolumeType",
+                    "Type" : STRING_TYPE,
+                    "Default" : "gp2",
+                    "Values" : [ "standard", "io1", "gp2", "sc1", "st1" ]
+                },
+                {
+                    "Names" : "ProvisionedIops",
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 100
+                },
+                {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
+                }
+            ]
+        }
+    }]
+
+[#function getDataVolumeState occurrence]
+
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#if multiAZ!false ]
+        [#local resourceZones = zones ]
+    [#else]
+        [#local resourceZones = [ zones[0] ] ]
+    [/#if]
+
+    [#local zoneResources = {} ]
+
+    [#list resourceZones as zone ]
+        [#local dataVolumeId = formatResourceId(AWS_EC2_EBS_RESOURCE_TYPE, core.Id, zone.Id )]
+        [#local zoneResources += 
+            {
+                zone.Id : {
+                    "ebsVolume" : {
+                        "Id" : dataVolumeId,
+                        "Name" : core.FullName,
+                        "Type" : AWS_EC2_EBS_RESOURCE_TYPE
+                    }
+                }
+            }
+        ]
+    [/#list]
+
+    [#return
+        {
+            "Resources" : {
+                "manualSnapshot" : {
+                    "Id" : formatResourceId( AWS_EC2_EBS_MANUAL_SNAPSHOT_RESOURCE_TYPE, core.Id),
+                    "Type" : AWS_EC2_EBS_MANUAL_SNAPSHOT_RESOURCE_TYPE
+                },
+                "Zones" : zoneResources
+            },
+            "Attributes" : {
+                "VOLUME_NAME" : core.FullName,
+                "ENGINE" : solution.Engine
+            }
+        }
+    ]
+[/#function]

--- a/aws/templates/id/id_ec2.ftl
+++ b/aws/templates/id/id_ec2.ftl
@@ -8,6 +8,10 @@
 [#assign AWS_EC2_NETWORK_INTERFACE_RESOURCE_TYPE = "eni" ]
 [#assign AWS_EC2_KEYPAIR_RESOURCE_TYPE = "keypair" ]
 
+[#assign AWS_EC2_EBS_RESOURCE_TYPE = "ebs" ]
+[#assign AWS_EC2_EBS_ATTACHMENT_RESOURCE_TYPE = "ebsAttachment" ]
+[#assign AWS_EC2_EBS_MANUAL_SNAPSHOT_RESOURCE_TYPE = "manualsnapshot" ]
+
 [#function formatEC2InstanceId tier component extensions...]
     [#return formatComponentResourceId(
                 AWS_EC2_INSTANCE_RESOURCE_TYPE,

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -137,6 +137,12 @@
                     "Default" : "awslogs"
                 },
                 {
+                    "Names" : "VolumeDrivers",
+                    "Type" : ARRAY_OF_STRING_TYPE,
+                    "Values" : [ "ebs" ],
+                    "Default" : []
+                },
+                {
                     "Names" : "ClusterLogGroup",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : true

--- a/aws/templates/policy/policy_ec2.ftl
+++ b/aws/templates/policy/policy_ec2.ftl
@@ -146,3 +146,32 @@
         ]
     ]
 [/#function]
+
+[#function ec2EBSVolumeUpdatePermission ]
+    [#return 
+        [
+            getPolicyStatement(
+                [
+                    "ec2:AttachVolume",
+                    "ec2:CreateVolume",
+                    "ec2:CreateSnapshot",
+                    "ec2:CreateTags",
+                    "ec2:DeleteVolume",
+                    "ec2:DeleteSnapshot",
+                    "ec2:DescribeAvailabilityZones",
+                    "ec2:DescribeInstances",
+                    "ec2:DescribeVolumes",
+                    "ec2:DescribeVolumeAttribute",
+                    "ec2:DescribeVolumeStatus",
+                    "ec2:DescribeSnapshots",
+                    "ec2:CopySnapshot",
+                    "ec2:DescribeSnapshotAttribute",
+                    "ec2:DetachVolume",
+                    "ec2:ModifySnapshotAttribute",
+                    "ec2:ModifyVolumeAttribute",
+                    "ec2:DescribeTags"
+                ]
+            )
+        ]
+    ]
+[/#function]

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -95,6 +95,29 @@
                     }
                 ]
             ]
+
+            [#local dockerVolumeConfiguration = {} +
+                volume.PersistVolume?then(
+                    { 
+                        "Scope" : "shared",
+                        "Autoprovision", volume.AutoProvision
+                    },
+                    {}
+                ) + 
+                (volume.Driver != "local")?then(
+                    {
+                        "Driver" : volume.Driver
+                    },
+                    {}
+                ) + 
+                (volume.DriverOpts?has_content)?then(
+                    {
+                        "DriverOpts" : volume.DriverOpts
+                    },
+                    {}
+                )
+            ]
+
             [#local volumes +=
                 [
                     {
@@ -106,12 +129,8 @@
                         {"SourcePath" : volume.HostPath!""}) + 
                     attributeIfTrue(
                         "DockerVolumeConfiguration",
-                        volume.PersistVolume,
-                        {
-                            "Scope" : "shared",
-                            "Autoprovision": true,
-                            "Driver": "local" 
-                        }
+                        dockerVolumeConfiguration?has_content,
+                        dockerVolumeConfiguration
                     )
                 ]
             ]

--- a/aws/templates/solution/solution_datavolume.ftl
+++ b/aws/templates/solution/solution_datavolume.ftl
@@ -1,0 +1,70 @@
+[#-- DATAVOLUME --]
+
+[#if componentType == DATAVOLUME_COMPONENT_TYPE  ]
+
+    [#list requiredOccurrences(
+            getOccurrences(tier, component),
+            deploymentUnit) as occurrence]
+
+        [@cfDebug listMode occurrence false /]
+
+        [#assign core = occurrence.Core]
+        [#assign solution = occurrence.Configuration.Solution]
+        [#assign resources = occurrence.State.Resources]
+
+        [#assign manualSnapshotId = resources["manualSnapshot"].Id]
+        [#assign manualSnapshotName = getExistingReference(manualSnapshotId, NAME_ATTRIBUTE_TYPE)]
+
+        [#list resources["Zones"] as zoneId, zoneResources ]
+            [#assign volumeId = zoneResources["ebsVolume"].Id ]
+            [#assign volumeName = zoneResources["ebsVolume"].Name ]
+
+            [#assign volumeTags = getCfTemplateCoreTags(
+                                        volumeName,
+                                        tier,
+                                        component,
+                                        "",
+                                        false)]
+            
+            [#assign resourceZone = {}]
+            [#list zones as zone ]
+                [#if zoneId == zone.Id ]
+                    [#assign resourceZone = zone ]
+                [/#if]
+            [/#list]
+
+            [#if deploymentSubsetRequired(DATAVOLUME_COMPONENT_TYPE, true)]
+                [@createEBSVolume 
+                    mode=listMode
+                    id=volumeId
+                    tags=volumeTags
+                    size=solution.Size
+                    volumeType=solution.VolumeType
+                    encrypted=solution.Encrypted
+                    provisionedIops=solution.ProvisionedIops
+                    zone=resourceZone
+                    snapshotId=manualSnapshotName
+                /]
+            [/#if]
+        [/#list]
+
+        [#if deploymentSubsetRequired("epilogue", false)]
+            [@cfScript
+                mode=listMode
+                content=
+                [
+                    "case $\{STACK_OPERATION} in",
+                    "  create|update)"
+                ] +    
+                pseudoStackOutputScript(
+                    "Manual Snapshot",
+                    { manualSnapshotId : "" }
+                ) +
+                [            
+                    "       ;;",
+                    "       esac"
+                ]
+            /]
+        [/#if]
+    [/#list]
+[/#if]


### PR DESCRIPTION
Adds support for persistent data volumes which are managed as a seperate component from compute services. The new component is know as a datavolume and initially supports creating standalone EBS volumes

Also adds the ability to use datavolumes in ECS containers directly through the rexray ebs volume plugin. The plugin manages the mounting and unmounting of an EBS volume to an underlying docker host and then looks after passing the disk through to a container. Configuration has mostly been taken from ( https://aws.amazon.com/blogs/compute/amazon-ecs-and-docker-volume-drivers-amazon-ebs/ ) 

To configure a data volume on a container requires 2 steps 
- Creating a link from the container to the data volume 
- Create a new volume in the fragment file which references the id of the link you created

Both the data volume and ECS service must be deployed to the same AZ for data consistency. Data volumes will deploy an EBS volume across each AZ configured but rexray will only mount the AZ local disk to an AZ local container. 