### PR TITLE
<feat> Add automated snapshots with SSM Automation

### DIFF
--- a/aws/templates/id/id_ssm.ftl
+++ b/aws/templates/id/id_ssm.ftl
@@ -1,4 +1,7 @@
 [#-- SSM --]
 
 [#-- Resources --]
-[#assign SSM_DOCUMENT_RESOURCE_TYPE = "ssmDocument"]
+[#assign AWS_SSM_DOCUMENT_RESOURCE_TYPE = "ssmDocument"]
+[#assign AWS_SSM_MAINTENANCE_WINDOW_RESOURCE_TYPE = "ssmMaintenanceWindow" ]
+[#assign AWS_SSM_MAINTENANCE_WINDOW_TARGET_RESOURCE_TYPE = "ssmWindowTarget" ]
+[#assign AWS_SSM_MAINTENANCE_WINDOW_TASK_RESOURCE_TYPE = "ssmWindowTask" ]

--- a/aws/templates/policy/policy_ec2.ftl
+++ b/aws/templates/policy/policy_ec2.ftl
@@ -148,6 +148,28 @@
 [/#function]
 
 
+[#function ec2EBSVolumeSnapshotAllPermission ]
+    [#return 
+        [
+            getPolicyStatement(
+                [
+                    "ec2:CopySnapshot",
+                    "ec2:CreateSnapshot",
+                    "ec2:DescribeSnapshots",
+                    "ec2:DeleteSnapshot",
+                    "ec2:DescribeSnapshotAttribute",
+                    "ec2:ModifySnapshotAttribute",
+                    "ec2:ResetSnapshotAttribute",
+                    "ec2:DescribeVolumes",
+                    "ec2:DescribeVolumeStatus",
+                    "ec2:DescribeVolumeAttribute",
+                    "ec2:DescribeVolumesModifications"
+                ]
+            )
+        ]
+    ]
+[/#function]
+
 [#function ec2EBSVolumeReadPermission ]
     [#return 
         [

--- a/aws/templates/policy/policy_lambda.ftl
+++ b/aws/templates/policy/policy_lambda.ftl
@@ -7,3 +7,19 @@
         ]
     ]
 [/#function]
+
+[#function lambdaSSMAutomationPermission ]
+    [#return
+        [
+            getPolicyStatement(
+                [
+                    "lambda:InvokeFunction",
+                    "lambda:GetFunction",
+                    "lambda:CreateFunction",
+                    "lambda:ListFunctions",
+                    "lambda:DeleteFunction"
+                ]
+            )
+        ]
+    ]
+[/#function]

--- a/aws/templates/resource/resource_ssm.ftl
+++ b/aws/templates/resource/resource_ssm.ftl
@@ -125,14 +125,14 @@
 [#macro createSSMMaintenanceWindowTask mode id 
     name
     targets
-    maxErrors
-    maxConcurrency
     serviceRoleId
     windowId
     taskId
     taskType
     taskParameters
     priority=10
+    maxErrors=0
+    maxConcurrency=1
     dependencies=""
 ]
 

--- a/aws/templates/solution/solution_datavolume.ftl
+++ b/aws/templates/solution/solution_datavolume.ftl
@@ -69,8 +69,7 @@
                         id=snapshotCreateTaskId
                         name=snapshotCreateTaskName
                         targets=ssmWindowTargets
-                        maxErrors=0
-                        maxConcurrency=1
+                        priority=10
                         serviceRoleId=maintenanceServiceRoleId
                         windowId=maintenanceWindowId
                         taskId="AWS-CreateSnapshot"
@@ -92,8 +91,7 @@
                         id=snapshotDeleteTaskId
                         name=snapshotDeleteTaskName
                         targets=ssmWindowTargets
-                        maxErrors=0
-                        maxConcurrency=1
+                        priority=20
                         serviceRoleId=maintenanceServiceRoleId
                         windowId=maintenanceWindowId
                         taskId="AWS-DeleteEbsVolumeSnapshots"


### PR DESCRIPTION
Adds the ability to automatically backup datavolumes through AWS SSM Automation Documents 

AWS SSM Automation allows you to run Documents which can be used to perform tasks within an AWS environment. They can make calls to the AWS API, create cloudformation templates, invoke lambdas and run commands on Ec2 instances 

Combined with maintenance windows you can schedule a collection of tasks to be run against a collection of ec2 instances based on tags, or just run them against non ec2 resources

For data volumes we use two documents provided by AWS, 
  - AWS-CreateSnapshot - This makes a call directly to the Ec2 Api to create the snapshot
  - AWS-DeleteEbsVolumeSnapshots - Creates a lambda using cfn which lists the current snapshots and removes any older than the retention period

This method also lays the ground work for #101 which uses maintenance windows and tasks