### PR TITLE
<feat> ECS Fargate hosting

### DIFF
--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -745,11 +745,9 @@
                 [#assign fargateInvalidConfigMessage += [ "CPU quota is not valid ( must be divisible by 256 )" ] ] 
             [/#if]
 
-            [#-- && ((( _context.MaximumMemory!1 % 256 )?string["0.#"])?split(".")[1]) != "0" --]
             [#if !( _context.MaximumMemory?has_content )  ] 
-                [#local  memoryRemainder = ( _context.MaximumMemory!1 % 256 )?string["0.#"]]
                 [#assign fargateInvalidConfig = true ]
-                [#assign fargateInvalidConfigMessage += [ "Maximum memory must assigned and divisible by 256 it was ${memoryRemainder}" ]]  
+                [#assign fargateInvalidConfigMessage += [ "Maximum memory must be assigned" ]]  
             [/#if]
                 
             [#if (_context.Privileged )]

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -232,6 +232,12 @@
             ],
             "Attributes" : [
                 {
+                    "Names" : "Engine",
+                    "Type" : STRING_TYPE,
+                    "Values" : [ "ec2", "fargate" ],
+                    "Default" : "ec2"
+                },
+                {
                     "Names" : "Containers",
                     "Subobjects" : true,
                     "Children" : containerChildrenConfiguration
@@ -331,6 +337,12 @@
                 }
             ],
             "Attributes" : [
+                {
+                    "Names" : "Engine",
+                    "Type" : STRING_TYPE,
+                    "Values" : [ "ec2", "fargate" ],
+                    "Default" : "ec2"
+                },
                 {
                     "Names" : "Containers",
                     "Subobjects" : true,
@@ -567,7 +579,15 @@
                     "Id" : formatResourceId( AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE, core.Id ),
                     "Name" : core.FullName,
                     "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
-                }),
+                }) +
+            attributeIfContent(
+                "executionRole",
+                solution.Engine == "fargate",
+                {
+                    "Id" : formatDependentRoleId(taskId, "execution"),
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                }
+            ),
             "Attributes" : {
                 "Name" : core.Name
             },
@@ -640,6 +660,14 @@
                 solution.Schedules,
                 {
                     "Id" : formatDependentRoleId(taskId, "schedule"),
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                }
+            ) + 
+            attributeIfContent(
+                "executionRole",
+                solution.Engine == "fargate",
+                {
+                    "Id" : formatDependentRoleId(taskId, "execution"),
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
                 }
             ),


### PR DESCRIPTION
Adds support for using AWS Fargate for ECS tasks and scheduled. Fargate provides serverless container hosting within your own VPC 

This PR adds support for the fargate ECS engine, it is defined at the service or task level as you can have mixed ECS clusters. 

There are a few ECS capabilities which are not available in Fargate which are outlined in this guide
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html 

Notable requirements: 
- CPU/Memory requirements are fixed to multiples of 256 ( 256,512,1024 etc ) and allowed memory is based on the CPU allocation 
- No host path volume mounts - volumes can be created and mounted by they are ephemeral and limited to 4Gb in space 
- Network 
   - Container must run in awsvpc mode 
   - no network links are allowed
- Privileged mode not permitted 

Example of creating an Fargate based service 

```
                        "Services" : {  
                            "confluence" : {
                                "Engine" : "fargate",
                                "DeploymentUnits" : [ "confluence" ],
                                "Containers" : {
                                    "_confluence" : {
                                        "Version" : "6.15.1-ubuntu-18.04-adoptopenjdk8",
                                        "Cpu" : 256,
                                        "Memory" : 256
                                    }
                                }
                            },
                            "NetworkMode" : "awsvpc"
                        }
```