### PR TITLE
<fix> skip network lookups for segment iam

### DIFF
--- a/aws/templates/segment/segment_bastion.ftl
+++ b/aws/templates/segment/segment_bastion.ftl
@@ -34,23 +34,24 @@
                 [#break]
         [/#switch]
       
-        [#assign networkLink = tier.Network.Link!{} ]
+        [#if deploymentSubsetRequired("bastion", true) ]
+            [#assign networkLink = tier.Network.Link!{} ]
+            [#assign networkLinkTarget = getLinkTarget(occurrence, networkLink ) ]
+            
+            [#if ! networkLinkTarget?has_content ]
+                [@cfException listMode "Network could not be found" networkLink /]
+                [#break]
+            [/#if]
 
-        [#assign networkLinkTarget = getLinkTarget(occurrence, networkLink ) ]
-        
-        [#if ! networkLinkTarget?has_content ]
-            [@cfException listMode "Network could not be found" networkLink /]
-            [#break]
+            [#assign networkConfiguration = networkLinkTarget.Configuration.Solution]
+            [#assign networkResources = networkLinkTarget.State.Resources ]
+
+            [#assign vpcId = networkResources["vpc"].Id ]
+
+            [#assign routeTableLinkTarget = getLinkTarget(occurrence, networkLink + { "RouteTable" : tier.Network.RouteTable }, false)]
+            [#assign routeTableConfiguration = routeTableLinkTarget.Configuration.Solution ]
+            [#assign publicRouteTable = routeTableConfiguration.Public ]
         [/#if]
-
-        [#assign networkConfiguration = networkLinkTarget.Configuration.Solution]
-        [#assign networkResources = networkLinkTarget.State.Resources ]
-
-        [#assign vpcId = networkResources["vpc"].Id ]
-
-        [#assign routeTableLinkTarget = getLinkTarget(occurrence, networkLink + { "RouteTable" : tier.Network.RouteTable }, false)]
-        [#assign routeTableConfiguration = routeTableLinkTarget.Configuration.Solution ]
-        [#assign publicRouteTable = routeTableConfiguration.Public ]
 
         [#assign storageProfile = getStorage(tier, component, BASTION_COMPONENT_TYPE)]
         [#assign logFileProfile = getLogFileProfile(tier, component, BASTION_COMPONENT_TYPE)]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -816,8 +816,8 @@
                     [#local networkCIDR = occurrence.Configuration.Solution.Address.CIDR ]
                 [#else] 
                     [#local occurrenceTier = getTier(occurrence.Core.Tier.Id) ]
-                    [#local network = getLinkTarget(occurrence, occurrenceTier.Network.Link ) ]
-                    [#local networkCIDR = network.State.Resources["vpc"].Address]
+                    [#local network = getLinkTarget(occurrence, occurrenceTier.Network.Link, false ) ]
+                    [#local networkCIDR = (network.Configuration.Solution.Address.CIDR)!"" ]
                 [/#if]
 
                 [#return


### PR DESCRIPTION
Minor fix for the bastion component to only perform network lookups during the bastion deploymentSubset. 

During the IAM pass the network isn't available so it fails to look it up