### PR TITLE
<fix>localnet lookup for services which run in VPCs

### DIFF
--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -77,7 +77,7 @@
                 [/#if]
                 [#assign links += lbLink]
             [#else]
-                [#assign portCIDRs = getGroupCIDRs(port.IPAddressGroups) ]
+                [#assign portCIDRs = getGroupCIDRs(port.IPAddressGroups, true, occurrence) ]
                 [#if portCIDRs?has_content]
                     [#assign ingressRules +=
                         [{
@@ -246,7 +246,7 @@
 
             [#if deploymentSubsetRequired(COMPUTECLUSTER_COMPONENT_TYPE, true)]
 
-                [#assign securityGroupCIDRs = getGroupCIDRs(sourceIPAddressGroups)]
+                [#assign securityGroupCIDRs = getGroupCIDRs(sourceIPAddressGroups, true, occurrence)]
                 [#list securityGroupCIDRs as cidr ]
 
                     [@createSecurityGroupIngress

--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -189,7 +189,7 @@
 
                                 [#assign dependencies += [targetId] ]
 
-                                [#assign securityGroupCIDRs = getGroupCIDRs(sourceIPAddressGroups)]
+                                [#assign securityGroupCIDRs = getGroupCIDRs(sourceIPAddressGroups, true, subOccurrence)]
                                 [#list securityGroupCIDRs as cidr ]
                                     
                                     [@createSecurityGroupIngress

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -545,7 +545,7 @@
 
             [#if port.IPAddressGroups?has_content]
                 [#if solution.NetworkMode == "awsvpc" || !port.LB.Configured ]
-                    [#list getGroupCIDRs(port.IPAddressGroups ) as cidr]
+                    [#list getGroupCIDRs(port.IPAddressGroups, true, task ) as cidr]
                         [#local ingressRules += [ {
                             "port" : port.DynamicHostPort?then(0,contentIfContent(
                                                                             port.Container!"",

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -260,9 +260,9 @@
             taskId 
             loadBalancers
             engine 
-            networkMode="" 
-            subnets=[] 
-            securityGroups=[] 
+            networkMode=""
+            subnets=[]
+            securityGroups=[]
             roleId="" 
             placement={}
             dependencies=""

--- a/aws/templates/segment/segment_gateway.ftl
+++ b/aws/templates/segment/segment_gateway.ftl
@@ -170,7 +170,7 @@
 
                 [#-- Determine the IP whitelisting required --]
                 [#assign destinationIPAddressGroups = solution.IPAddressGroups ]
-                [#assign cidrs = getGroupCIDRs(destinationIPAddressGroups)]
+                [#assign cidrs = getGroupCIDRs(destinationIPAddressGroups, true, subOccurrence)]
 
                 [#assign routeTableIds = []]
                 

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -842,8 +842,8 @@
                     [#local networkCIDR = occurrence.Configuration.Solution.Address.CIDR ]
                 [#else] 
                     [#local occurrenceTier = getTier(occurrence.Core.Tier.Id) ]
-                    [#local network = getLinkTarget(occurrence, occurrenceTier.Network.Link, false ) ]
-                    [#local networkCIDR = (network.Configuration.Solution.Address.CIDR)!"" ]
+                    [#local network = getLinkTarget(occurrence, occurrenceTier.Network.Link, false )]
+                    [#local networkCIDR = (network.Configuration.Solution.Address.CIDR)!"COTException: local network configuration not found" ]
                 [/#if]
 
                 [#return
@@ -854,6 +854,13 @@
                     "CIDR" : [ networkCIDR ]
                 } ]
             [#else]
+                [#return
+                    {
+                        "Id" : groupId,
+                        "IsOpen" : true,
+                        "CIDR" : []
+                    }]
+
                 [@cfException 
                     mode=listMode
                     description="Local network details required"

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -75,7 +75,7 @@
                 [/#if]
                 [#assign links += lbLink]
             [#else]
-                [#assign portCIDRs = getGroupCIDRs(port.IPAddressGroups) ]
+                [#assign portCIDRs = getGroupCIDRs(port.IPAddressGroups, true, occurrence) ]
                 [#if portCIDRs?has_content]
                     [#assign ingressRules +=
                         [{
@@ -206,7 +206,7 @@
 
             [#if deploymentSubsetRequired(EC2_COMPONENT_TYPE, true)] 
 
-                [#assign securityGroupCIDRs = getGroupCIDRs(sourceIPAddressGroups)]
+                [#assign securityGroupCIDRs = getGroupCIDRs(sourceIPAddressGroups, true, occurrence)]
                 [#list securityGroupCIDRs as cidr ]
                     
                     [@createSecurityGroupIngress

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -150,7 +150,7 @@
             [#if !solution.IPAddressGroups?seq_contains("_localnet") && !publicRouteTable ]
                 [#assign portIpAddressGroups += [ "_localnet"] ]
             [/#if]
-            [#assign cidrs = getGroupCIDRs(portIpAddressGroups)]
+            [#assign cidrs = getGroupCIDRs(portIpAddressGroups, true, subOccurrence)]
             [#assign securityGroupId = resources["sg"].Id]
             [#assign securityGroupName = resources["sg"].Name]
 


### PR DESCRIPTION
when using _localnet in IPAddressGroups lookups we need to provide the occurrence to the getIPAddress groups function so that it can do a link lookup on the network for the tier. 

This PR updates the error response when the network cannot be found and also adds occurrence support to resources which live in vpcs.