### PR TITLE
<refactor> Remove legacy container (now known as segment) support

### DIFF
--- a/aws/templates/id/id_baseline.ftl
+++ b/aws/templates/id/id_baseline.ftl
@@ -94,7 +94,7 @@
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
-                { 
+                {
                     "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
@@ -132,7 +132,7 @@
                     "Value" : segmentSeedValue,
                     "Type" : SEED_RESOURCE_TYPE
                 }
-            } + 
+            } +
             (!legacyVpc)?then(
                 {
                     "segmentSNSTopic" : {
@@ -168,7 +168,7 @@
 
     [#local bucketId = formatSegmentResourceId(AWS_S3_RESOURCE_TYPE, core.SubComponent.Id ) ]
     [#local bucketName = formatSegmentBucketName( segmentSeed, core.SubComponent.Id )]]
-    
+
     [#switch core.SubComponent.Id ]
         [#case "appdata" ]
             [#local bucketName = formatSegmentBucketName(segmentSeed, "data") ]
@@ -186,7 +186,7 @@
             [/#if]
             [#break]
     [/#switch]
-    
+
     [#local bucketPolicyId = formatDependentBucketPolicyId(bucketId)]
 
     [#local result =
@@ -230,8 +230,7 @@
         migrateToResourceId(
             formatSegmentS3Id("ops"),
             formatSegmentS3Id("operations"),
-            formatSegmentS3Id("logs"),
-            formatContainerS3Id("logs")
+            formatSegmentS3Id("logs")
         )]
 [/#function]
 
@@ -240,7 +239,6 @@
         migrateToResourceId(
             formatSegmentS3Id("data"),
             formatSegmentS3Id("application"),
-            formatSegmentS3Id("backups"),
-            formatContainerS3Id("backups")
+            formatSegmentS3Id("backups")
         )]
 [/#function]

--- a/aws/templates/id/id_s3.ftl
+++ b/aws/templates/id/id_s3.ftl
@@ -10,14 +10,6 @@
             ids)]
 [/#function]
 
-[#-- TODO: Remove when use of "container" is removed --]
-[#function formatContainerS3Id type extensions...]
-    [#return formatContainerResourceId(
-                AWS_S3_RESOURCE_TYPE,
-                type,
-                extensions)]
-[/#function]
-
 [#function formatSegmentS3Id type extensions...]
     [#return formatSegmentResourceId(
                 AWS_S3_RESOURCE_TYPE,
@@ -109,7 +101,7 @@
                         }
                     ]
                 },
-                { 
+                {
                     "Names" : "Website",
                     "Children" : [
                         {
@@ -193,7 +185,7 @@
             ]
         }
     }]
-    
+
 [#function getS3State occurrence]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]

--- a/aws/templates/id/start.ftl
+++ b/aws/templates/id/start.ftl
@@ -47,15 +47,6 @@
             extensions) ]
 [/#function]
 
-[#-- TODO: Remove when use of "container" is removed --]
-[#function formatContainerResourceId type extensions...]
-    [#return
-        formatResourceId(
-            type,
-            "container",
-            extensions) ]
-[/#function]
-
 [#function formatSegmentResourceId type extensions...]
     [#return
         formatResourceId(


### PR DESCRIPTION
As all known projects have now been deployed using the terminology of
"segments" rather than "containers", the legacy code supporting the old
terminology can be removed.

Technically this is a breaking change but as no project is now using it,
we will treat it as a minor change.