### PR TITLE
<feat> Enable cmdb cleanup

### DIFF
--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -1101,7 +1101,7 @@ function cleanup_cmdb_repo_to_v1_1_0() {
   local dry_run="$1";shift
 
   for source in "${!upgrade_v1_1_0_sources[@]}"; do
-    readarray -t source_dirs < <(find "${root_dir}" -mindepth 1 -maxdepth 1 -type d \
+    readarray -t source_dirs < <(find "${root_dir}" -mindepth 1 -maxdepth 2 -type d \
       -name "${source}" )
     for source_dir in "${source_dirs[@]}"; do
       info "Deleting ${source_dir} ..."
@@ -1312,7 +1312,7 @@ function upgrade_cmdb_repo_to_v1_3_1() {
               if [[ -n "${dry_run}" ]]; then
                 continue
               fi
-              
+
               if [[ "${move_file}" != 0 ]]; then
                 git_mv "${cf_file}" "${stack_dir}/${new_cf_file_name}"
               else
@@ -1429,7 +1429,7 @@ function cleanup_cmdb() {
   local dry_run="$1";shift
 
   local required_versions=(${versions})
-  [[ -z "${versions}" ]] && required_versions=("v1.0.0")
+  [[ -z "${versions}" ]] && required_versions=("v1.0.0" "v1.1.0")
 
   process_cmdb "${root_dir}" "cleanup" "${required_versions[*]}" ${dry_run}
 }

--- a/aws/setContext.sh
+++ b/aws/setContext.sh
@@ -44,6 +44,8 @@ if [[ "${GENERATION_NO_CMDB_CHECK}" != "true" ]]; then
     debug "Checking if cmdb upgrade needed ..."
     upgrade_cmdb "${GENERATION_DATA_DIR}" ||
         { fatal "CMDB upgrade failed."; exit 1; }
+    cleanup_cmdb "${GENERATION_DATA_DIR}" ||
+        { fatal "CMDB cleanup failed."; exit 1; }
 fi
 
 # Ensure the cache directory exists


### PR DESCRIPTION
Enable cmdb cleanup to be performed in addition to cmdb upgrade.

The cleanup code has been there for a while but was not invoked.

Cleanups are normally a ways behind their corresponding upgrades to give
time for the upgrade to percolate to all active projects. It is also
possible that cleanups will have been manually performed, in which case
the cleanup is a no-op.

The only potential issue is with a local copy of the repo where the current directory
is within one of the directories being removed. In this case, its best to run a template from the root
 which will fail but will process the cmdb upgrades/cleanup.