### PR TITLE
<feat> mobile app settings

### DIFF
--- a/aws/runExpoAppPublish.sh
+++ b/aws/runExpoAppPublish.sh
@@ -47,8 +47,6 @@ function env_setup() {
     brew cask install \
         fastlane || return $?
     
-    export PATH="$HOME/.fastlane/bin:$PATH"
-
     # Make sure we have required software installed 
     pip3 install \
         qrcode[pil] \
@@ -142,6 +140,9 @@ function main() {
     env_setup || return $?
   fi
 
+   # make sure fastlane is on path
+   export PATH="$HOME/.fastlane/bin:$PATH"
+
   # Ensure mandatory arguments have been provided
   [[ -z "${DEPLOYMENT_UNIT}" ]] && fatalMandatory
 
@@ -156,60 +157,63 @@ function main() {
   fi
 
   # The source of the prepared code repository zip
-  EXPO_SRC_BUCKET="$( jq -r '.Occurrence.State.Attributes.CODE_SRC_BUCKET' < "${BUILD_BLUEPRINT}" )"
-  EXPO_SRC_PREFIX="$( jq -r '.Occurrence.State.Attributes.CODE_SRC_PREFIX' < "${BUILD_BLUEPRINT}" )"
+  SRC_BUCKET="$( jq -r '.Occurrence.State.Attributes.CODE_SRC_BUCKET' < "${BUILD_BLUEPRINT}" )"
+  SRC_PREFIX="$( jq -r '.Occurrence.State.Attributes.CODE_SRC_PREFIX' < "${BUILD_BLUEPRINT}" )"
 
-  # The staging location of credential data
-  EXPO_CREDENTIALS_BUCKET="$( jq -r '.Occurrence.Configuration.Settings.Core.OPSDATA_BUCKET.Value' < "${BUILD_BLUEPRINT}" )"
-  EXPO_CREDNTIALS_PREFIX="$( jq -r '.Occurrence.Configuration.Settings.Core.CREDENTIALS_PREFIX.Value' < "${BUILD_BLUEPRINT}" )"
+  # Operations data - Credentials, config etc.
+  OPSDATA_BUCKET="$( jq -r '.Occurrence.Configuration.Settings.Core.OPSDATA_BUCKET.Value' < "${BUILD_BLUEPRINT}" )"
+  CREDENTIALS_PREFIX="$( jq -r '.Occurrence.Configuration.Settings.Core.CREDENTIALS_PREFIX.Value' < "${BUILD_BLUEPRINT}" )"
+  CONFIG_FILE="$( jq -r '.Occurrence.State.Attributes.CONFIG_FILE' < "${BUILD_BLUEPRINT}" )"
 
-  EXPO_APPDATA_BUCKET="$( jq -r '.Occurrence.Configuration.Settings.Core.APPDATA_BUCKET.Value' < "${BUILD_BLUEPRINT}" )"
+  APPDATA_BUCKET="$( jq -r '.Occurrence.Configuration.Settings.Core.APPDATA_BUCKET.Value' < "${BUILD_BLUEPRINT}" )"
   EXPO_APPDATA_PREFIX="$( jq -r '.Occurrence.Configuration.Settings.Core.APPDATA_PREFIX.Value' < "${BUILD_BLUEPRINT}" )"
 
   # Where the public artefacts will be published to
-  EXPO_PUBLIC_BUCKET="$( jq -r '.Occurrence.State.Attributes.OTA_ARTEFACT_BUCKET' <"${BUILD_BLUEPRINT}" )"
-  EXPO_PUBLIC_PREFIX="$( jq -r '.Occurrence.State.Attributes.OTA_ARTEFACT_PREFIX' <"${BUILD_BLUEPRINT}" )"
-  EXPO_PUBLIC_URL="$( jq -r '.Occurrence.State.Attributes.OTA_ARTEFACT_URL' <"${BUILD_BLUEPRINT}" )"
+  PUBLIC_BUCKET="$( jq -r '.Occurrence.State.Attributes.OTA_ARTEFACT_BUCKET' <"${BUILD_BLUEPRINT}" )"
+  PUBLIC_PREFIX="$( jq -r '.Occurrence.State.Attributes.OTA_ARTEFACT_PREFIX' <"${BUILD_BLUEPRINT}" )"
+  PUBLIC_URL="$( jq -r '.Occurrence.State.Attributes.OTA_ARTEFACT_URL' <"${BUILD_BLUEPRINT}" )"
 
-  EXPO_BUILD_FORMAT_LIST="$( jq -r '.Occurrence.State.Attributes.APP_BUILD_FORMATS' <"${BUILD_BLUEPRINT}" )"
-  arrayFromList EXPO_BUILD_FORMATS "${EXPO_BUILD_FORMAT_LIST}"
+  BUILD_FORMAT_LIST="$( jq -r '.Occurrence.State.Attributes.APP_BUILD_FORMATS' <"${BUILD_BLUEPRINT}" )"
+  arrayFromList BUILD_FORMATS "${BUILD_FORMAT_LIST}"
 
-  EXPO_RELEASE_CHANNEL="$( jq -r '.Occurrence.State.Attributes.RELEASE_CHANNEL' <"${BUILD_BLUEPRINT}" )"
+  BUILD_REFERENCE="$( jq -r '.Occurrence.Configuration.Settings.Build.BUILD_REFERENCE.Value' <"${BUILD_BLUEPRINT}" )"
+  BUILD_NUMBER="$(date +"%Y%m%d.1%H%M%S")"
+  RELEASE_CHANNEL="$( jq -r '.Occurrence.State.Attributes.RELEASE_CHANNEL' <"${BUILD_BLUEPRINT}" )"
 
-  EXPO_BUILD_REFERENCE="$( jq -r '.Occurrence.Configuration.Settings.Build.BUILD_REFERENCE.Value' <"${BUILD_BLUEPRINT}" )"
-  EXPO_BUILD_NUMBER="$(date +"%Y%m%d.1%H%M%S")"
- 
   arrayFromList EXPO_QR_BUILD_FORMATS "${QR_BUILD_FORMATS}"
 
   BUILD_BINARY="false"
 
   # Make sure we are in the build source directory
+  BINARY_PATH="${AUTOMATION_DATA_DIR}/binary"
+  SRC_PATH="${AUTOMATION_DATA_DIR}/src"
+  OPS_PATH="${AUTOMATION_DATA_DIR}/ops"
+  REPORTS_PATH="${AUTOMATION_DATA_DIR}/reports"
 
-  EXPO_BINARY_PATH="${AUTOMATION_DATA_DIR}/binary"
-  EXPO_SRC_PATH="${AUTOMATION_DATA_DIR}/src"
-  EXPO_CREDS_PATH="${AUTOMATION_DATA_DIR}/creds"
-  EXPO_REPORTS_PATH="${AUTOMATION_DATA_DIR}/reports"
+  mkdir -p "${BINARY_PATH}"
+  mkdir -p "${SRC_PATH}"
+  mkdir -p "${OPS_PATH}"
+  mkdir -p "${REPORTS_PATH}"
 
-  mkdir -p "${EXPO_BINARY_PATH}"
-  mkdir -p "${EXPO_SRC_PATH}"
-  mkdir -p "${EXPO_CREDS_PATH}"
-  mkdir -p "${EXPO_REPORTS_PATH}"
-
-  TURTLE_EXTRA_BUILD_ARGS="--release-channel ${EXPO_RELEASE_CHANNEL}"
+  TURTLE_EXTRA_BUILD_ARGS="--release-channel ${RELEASE_CHANNEL}"
 
   # Prepare the code build environment
-  info "Getting source code from from s3://${EXPO_SRC_BUCKET}/${EXPO_SRC_PREFIX}/scripts.zip"
-  aws --region "${AWS_REGION}" s3 cp "s3://${EXPO_SRC_BUCKET}/${EXPO_SRC_PREFIX}/scripts.zip" "${tmpdir}/scripts.zip" || return $?
+  info "Getting source code from from s3://${SRC_BUCKET}/${SRC_PREFIX}/scripts.zip"
+  aws --region "${AWS_REGION}" s3 cp "s3://${SRC_BUCKET}/${SRC_PREFIX}/scripts.zip" "${tmpdir}/scripts.zip" || return $?
   
-  unzip -q "${tmpdir}/scripts.zip" -d "${EXPO_SRC_PATH}" || return $?
+  unzip -q "${tmpdir}/scripts.zip" -d "${SRC_PATH}" || return $?
 
-  cd "${EXPO_SRC_PATH}"
+  cd "${SRC_PATH}"
   yarn install --production=false
 
   # decrypt secrets from credentials store
-  info "Getting credentials from s3://${EXPO_CREDENTIALS_BUCKET}/${EXPO_CREDNTIALS_PREFIX}"
-  aws --region "${AWS_REGION}" s3 sync "s3://${EXPO_CREDENTIALS_BUCKET}/${EXPO_CREDNTIALS_PREFIX}" "${EXPO_CREDS_PATH}" || return $?
-  find "${EXPO_CREDS_PATH}" -name \*.kms -exec decrypt_kms_file "${AWS_REGION}" "{}" \;
+  info "Getting credentials from s3://${OPSDATA_BUCKET}/${CREDENTIALS_PREFIX}"
+  aws --region "${AWS_REGION}" s3 sync "s3://${OPSDATA_BUCKET}/${CREDENTIALS_PREFIX}" "${OPS_PATH}" || return $?
+  find "${OPS_PATH}" -name \*.kms -exec decrypt_kms_file "${AWS_REGION}" "{}" \;
+
+  # get config file 
+  info "Gettting configuration file from s3://${OPSDATA_BUCKET}/${CONFIG_FILE}"
+  aws --region "${AWS_REGION}" s3 cp "s3://${OPSDATA_BUCKET}/${CONFIG_FILE}" "${OPS_PATH}/config.json" || return $?
 
   # get the version of the expo SDK which is required 
   EXPO_SDK_VERSION="$(jq -r '.expo.sdkVersion' < ./app.json)"
@@ -217,14 +221,14 @@ function main() {
   EXPO_CURRENT_APP_VERSION="${EXPO_APP_VERSION}"
 
   # Determine Binary Build status
-  EXPO_CURRENT_SDK_BUILD="$(aws s3api list-objects-v2 --bucket "${EXPO_PUBLIC_BUCKET}" --prefix "${EXPO_PUBLIC_PREFIX}/packages/${EXPO_SDK_VERSION}" --query "join(',', Contents[*].Key)" --output text)"
+  EXPO_CURRENT_SDK_BUILD="$(aws s3api list-objects-v2 --bucket "${PUBLIC_BUCKET}" --prefix "${PUBLIC_PREFIX}/packages/${EXPO_SDK_VERSION}" --query "join(',', Contents[*].Key)" --output text)"
   arrayFromList EXPO_CURRENT_SDK_FILES "${EXPO_CURRENT_SDK_BUILD}"
 
   # Determine if App Version has been incremented 
   if [[ -n "${EXPO_CURRENT_SDK_BUILD}" ]]; then 
     for sdk_file in "${EXPO_CURRENT_SDK_FILES[@]}" ; do
-        if [[ "${sdk_file}" == */${EXPO_BUILD_FORMATS[0]}-index.json ]]; then
-            aws --region "${AWS_REGION}" s3 cp "s3://${EXPO_PUBLIC_BUCKET}/${sdk_file}" "${AUTOMATION_DATA_DIR}/current-app-manifest.json"
+        if [[ "${sdk_file}" == */${BUILD_FORMATS[0]}-index.json ]]; then
+            aws --region "${AWS_REGION}" s3 cp "s3://${PUBLIC_BUCKET}/${sdk_file}" "${AUTOMATION_DATA_DIR}/current-app-manifest.json"
         fi
     done
 
@@ -238,26 +242,25 @@ function main() {
   fi
 
   # Update the app.json with build context information - Also ensure we always have a unique IOS build number
-  jq --arg build_reference "${EXPO_BUILD_REFERENCE}" '.expo.extra.build_reference=$build_reference' <  "./app.json" > "${tmpdir}/build_reference-app.json"
-  jq --arg build_number "${EXPO_BUILD_NUMBER}" '.expo.ios.buildNumber=$build_number' < "${tmpdir}/build_reference-app.json" > "${tmpdir}/build_number-app.json"
-  mv "${tmpdir}/build_number-app.json" "./app.json"
+  jq --slurpfile envConfig "${OPS_PATH}/config.json" '.expo.extra.build_reference=env.BUILD_REFERENCE | .expo.ios.buildNumber=env.BUILD_NUMBER | .expo.extra= .expo.extra + $envConfig' <  "./app.json" > "${tmpdir}/environment-app.json"  
+  mv "${tmpdir}/environment-app.json" "./app.json"
 
   # Create a build for the SDK
   info "Creating an OTA for this version of the SDK"
-  expo export --public-url "${EXPO_PUBLIC_URL}" --output-dir "${EXPO_SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}"  || return $?
-  aws --region "${AWS_REGION}" s3 sync --delete "${EXPO_SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}" "s3://${EXPO_PUBLIC_BUCKET}/${EXPO_PUBLIC_PREFIX}/packages/${EXPO_SDK_VERSION}" || return $?
+  expo export --public-url "${PUBLIC_URL}" --output-dir "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}"  || return $?
+  aws --region "${AWS_REGION}" s3 sync --delete "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}" "s3://${PUBLIC_BUCKET}/${PUBLIC_PREFIX}/packages/${EXPO_SDK_VERSION}" || return $?
 
   # Merge all existing SDK packages into a master distribution
-  aws --region "${AWS_REGION}" s3 cp --recursive --exclude "${EXPO_SDK_VERSION}/*" "s3://${EXPO_PUBLIC_BUCKET}/${EXPO_PUBLIC_PREFIX}/packages/" "${EXPO_SRC_PATH}/app/dist/packages/"
+  aws --region "${AWS_REGION}" s3 cp --recursive --exclude "${EXPO_SDK_VERSION}/*" "s3://${PUBLIC_BUCKET}/${PUBLIC_PREFIX}/packages/" "${SRC_PATH}/app/dist/packages/"
   EXPO_EXPORT_MERGE_ARGUMENTS=""
-  for dir in ${EXPO_SRC_PATH}/app/dist/packages/*/ ; do
+  for dir in ${SRC_PATH}/app/dist/packages/*/ ; do
     EXPO_EXPORT_MERGE_ARGUMENTS="${EXPO_EXPORT_MERGE_ARGUMENTS} --merge-src-dir "${dir}""
   done
 
   # Create master export 
   info "Creating master OTA artefact with Extra Dirs: ${EXPO_EXPORT_MERGE_ARGUMENTS}"
-  expo export --public-url "${EXPO_PUBLIC_URL}" --output-dir "${EXPO_SRC_PATH}/app/dist/master/" ${EXPO_EXPORT_MERGE_ARGUMENTS}  || return $?
-  aws --region "${AWS_REGION}" s3 sync "${EXPO_SRC_PATH}/app/dist/master/" "s3://${EXPO_PUBLIC_BUCKET}/${EXPO_PUBLIC_PREFIX}" || return $? 
+  expo export --public-url "${PUBLIC_URL}" --output-dir "${SRC_PATH}/app/dist/master/" ${EXPO_EXPORT_MERGE_ARGUMENTS}  || return $?
+  aws --region "${AWS_REGION}" s3 sync "${SRC_PATH}/app/dist/master/" "s3://${PUBLIC_BUCKET}/${PUBLIC_PREFIX}" || return $? 
 
   DETAILED_HTML_QR_MESSAGE="<h4>Expo Client App QR Codes</h4> <p>Use these codes to load the app through the Expo Client</p>"
 
@@ -266,35 +269,35 @@ function main() {
     DETAILED_HTML_BINARY_MESSAGE="${DETAILED_HTML_BINARY_MESSAGE} <p> No binary builds were generated for this publish </p>"
   fi
 
-  for build_format in "${EXPO_BUILD_FORMATS[@]}"; do
+  for build_format in "${BUILD_FORMATS[@]}"; do
 
-      EXPO_BINARY_FILE_PREFIX="${build_format}"
+      BINARY_FILE_PREFIX="${build_format}"
       case "${build_format}" in
         "android")
-            EXPO_BINARY_FILE_EXTENSION="apk"
-            EXPO_ANDROID_KEYSTORE_ALIAS="$( jq -r '.Occurrence.Configuration.Environment.Sensitive.EXPO_ANDROID_KEYSTORE_ALIAS' < "${BUILD_BLUEPRINT}" )"
+            BINARY_FILE_EXTENSION="apk"
+            ANDROID_KEYSTORE_ALIAS="$( jq -r '.Occurrence.Configuration.Environment.Sensitive.ANDROID_KEYSTORE_ALIAS' < "${BUILD_BLUEPRINT}" )"
 
-            EXPO_ANDROID_KEYSTORE_PASSWORD="$( jq -r '.Occurrence.Configuration.Environment.Sensitive.EXPO_ANDROID_KEYSTORE_PASSWORD' < "${BUILD_BLUEPRINT}" )"
-            EXPO_ANDROID_KEYSTORE_PASSWORD="$( decrypt_kms_string "${AWS_REGION}" "${EXPO_ANDROID_KEYSTORE_PASSWORD#"base64:"}")"
+            ANDROID_KEYSTORE_PASSWORD="$( jq -r '.Occurrence.Configuration.Environment.Sensitive.ANDROID_KEYSTORE_PASSWORD' < "${BUILD_BLUEPRINT}" )"
+            ANDROID_KEYSTORE_PASSWORD="$( decrypt_kms_string "${AWS_REGION}" "${ANDROID_KEYSTORE_PASSWORD#"base64:"}")"
             
-            EXPO_ANDROID_KEY_PASSWORD="$( jq -r '.Occurrence.Configuration.Environment.Sensitive.EXPO_ANDROID_KEY_PASSWORD' < "${BUILD_BLUEPRINT}" )"
-            EXPO_ANDROID_KEY_PASSWORD="$( decrypt_kms_string "${AWS_REGION}" "${EXPO_ANDROID_KEY_PASSWORD#"base64:"}")"
+            ANDROID_KEY_PASSWORD="$( jq -r '.Occurrence.Configuration.Environment.Sensitive.ANDROID_KEY_PASSWORD' < "${BUILD_BLUEPRINT}" )"
+            ANDROID_KEY_PASSWORD="$( decrypt_kms_string "${AWS_REGION}" "${ANDROID_KEY_PASSWORD#"base64:"}")"
 
-            EXPO_ANDROID_KEYSTORE_FILE="${EXPO_CREDS_PATH}/expo_android_keystore.jks"
+            ANDROID_KEYSTORE_FILE="${OPS_PATH}/expo_android_keystore.jks"
 
-            TURTLE_EXTRA_BUILD_ARGS="${TURTLE_EXTRA_BUILD_ARGS} --keystore-path ${EXPO_ANDROID_KEYSTORE_FILE} --keystore-alias ${EXPO_ANDROID_KEYSTORE_ALIAS}"
+            TURTLE_EXTRA_BUILD_ARGS="${TURTLE_EXTRA_BUILD_ARGS} --keystore-path ${ANDROID_KEYSTORE_FILE} --keystore-alias ${ANDROID_KEYSTORE_ALIAS}"
             ;;
         "ios")
-            EXPO_BINARY_FILE_EXTENSION="ipa"
-            EXPO_IOS_DIST_APPLE_ID="$( jq -r '.Occurrence.Configuration.Environment.Sensitive.EXPO_IOS_DIST_APPLE_ID' < "${BUILD_BLUEPRINT}" )"
+            BINARY_FILE_EXTENSION="ipa"
+            IOS_DIST_APPLE_ID="$( jq -r '.Occurrence.Configuration.Environment.Sensitive.IOS_DIST_APPLE_ID' < "${BUILD_BLUEPRINT}" )"
 
-            EXPO_IOS_DIST_P12_PASSWORD="$( jq -r '.Occurrence.Configuration.Environment.Sensitive.EXPO_IOS_DIST_P12_PASSWORD' < "${BUILD_BLUEPRINT}" )"
-            export EXPO_IOS_DIST_P12_PASSWORD="$( decrypt_kms_string "${AWS_REGION}" "${EXPO_IOS_DIST_P12_PASSWORD#"base64:"}")"
+            IOS_DIST_P12_PASSWORD="$( jq -r '.Occurrence.Configuration.Environment.Sensitive.IOS_DIST_P12_PASSWORD' < "${BUILD_BLUEPRINT}" )"
+            export IOS_DIST_P12_PASSWORD="$( decrypt_kms_string "${AWS_REGION}" "${IOS_DIST_P12_PASSWORD#"base64:"}")"
             
-            EXPO_IOS_DIST_PROVISIONING_PROFILE="${EXPO_CREDS_PATH}/expo_ios_profile.mobileprovision"
-            EXPO_IOS_DIST_P12_FILE="${EXPO_CREDS_PATH}/expo_ios_distribution.p12"
+            IOS_DIST_PROVISIONING_PROFILE="${OPS_PATH}/expo_ios_profile.mobileprovision"
+            EXPO_IOS_DIST_P12_FILE="${OPS_PATH}/expo_ios_distribution.p12"
 
-            TURTLE_EXTRA_BUILD_ARGS="${TURTLE_EXTRA_BUILD_ARGS} --team-id ${EXPO_IOS_DIST_APPLE_ID} --dist-p12-path ${EXPO_IOS_DIST_P12_FILE} --provisioning-profile-path ${EXPO_IOS_DIST_PROVISIONING_PROFILE}"
+            TURTLE_EXTRA_BUILD_ARGS="${TURTLE_EXTRA_BUILD_ARGS} --team-id ${IOS_DIST_APPLE_ID} --dist-p12-path ${EXPO_IOS_DIST_P12_FILE} --provisioning-profile-path ${IOS_DIST_PROVISIONING_PROFILE}"
             ;;
         "*")
             echo "Unkown build format" && return 128
@@ -304,20 +307,20 @@ function main() {
       if [[ "${BUILD_BINARY}" == "true" ]]; then 
 
         info "Building App Binary for ${build_format}"
-        EXPO_BINARY_FILE_NAME="${EXPO_BINARY_FILE_PREFIX}-${EXPO_APP_VERSION}-${EXPO_BUILD_NUMBER}.${EXPO_BINARY_FILE_EXTENSION}"
-        EXPO_BINARY_FILE_PATH="${EXPO_BINARY_PATH}/${EXPO_BINARY_FILE_NAME}"
+        EXPO_BINARY_FILE_NAME="${BINARY_FILE_PREFIX}-${EXPO_APP_VERSION}-${BUILD_NUMBER}.${BINARY_FILE_EXTENSION}"
+        EXPO_BINARY_FILE_PATH="${BINARY_PATH}/${EXPO_BINARY_FILE_NAME}"
 
         # Setup Turtle
         turtle setup:"${build_format}" --sdk-version "${EXPO_SDK_VERSION}" || return $?
 
         # Build using turtle
-        turtle build:"${build_format}" --public-url "${EXPO_PUBLIC_URL}/${build_format}-index.json" --output "${EXPO_BINARY_FILE_PATH}" ${TURTLE_EXTRA_BUILD_ARGS} "${EXPO_SRC_PATH}" || return $?
+        turtle build:"${build_format}" --public-url "${PUBLIC_URL}/${build_format}-index.json" --output "${EXPO_BINARY_FILE_PATH}" ${TURTLE_EXTRA_BUILD_ARGS} "${SRC_PATH}" || return $?
 
         if [[ -f "${EXPO_BINARY_FILE_PATH}" ]]; then 
 
-            aws --region "${AWS_REGION}" s3 sync --exclude "*" --include "${EXPO_BINARY_FILE_PREFIX}*" "${EXPO_BINARY_PATH}" "s3://${EXPO_APPDATA_BUCKET}/${EXPO_APPDATA_PREFIX}/" || return $?
-            EXPO_BINARY_PRESIGNED_URL="$(aws --region "${AWS_REGION}" s3 presign --expires-in "${BINARY_EXPIRATION}" "s3://${EXPO_APPDATA_BUCKET}/${EXPO_APPDATA_PREFIX}/${EXPO_BINARY_FILE_NAME}" )"
-            DETAILED_HTML_BINARY_MESSAGE="${DETAILED_HTML_BINARY_MESSAGE}<p><strong>${build_format}</strong> <a href="${EXPO_BINARY_PRESIGNED_URL}">${build_format} - ${EXPO_APP_VERSION} - ${EXPO_BUILD_NUMBER}</a>" 
+            aws --region "${AWS_REGION}" s3 sync --exclude "*" --include "${BINARY_FILE_PREFIX}*" "${BINARY_PATH}" "s3://${APPDATA_BUCKET}/${EXPO_APPDATA_PREFIX}/" || return $?
+            EXPO_BINARY_PRESIGNED_URL="$(aws --region "${AWS_REGION}" s3 presign --expires-in "${BINARY_EXPIRATION}" "s3://${APPDATA_BUCKET}/${EXPO_APPDATA_PREFIX}/${EXPO_BINARY_FILE_NAME}" )"
+            DETAILED_HTML_BINARY_MESSAGE="${DETAILED_HTML_BINARY_MESSAGE}<p><strong>${build_format}</strong> <a href="${EXPO_BINARY_PRESIGNED_URL}">${build_format} - ${EXPO_APP_VERSION} - ${BUILD_NUMBER}</a>" 
 
         fi
       else 
@@ -331,23 +334,23 @@ function main() {
        #Generate EXPO QR Code 
       EXPO_QR_FILE_PREFIX="${qr_build_format}"
       EXPO_QR_FILE_NAME="${EXPO_QR_FILE_PREFIX}-qr.png"
-      EXPO_QR_FILE_PATH="${EXPO_REPORTS_PATH}/${EXPO_QR_FILE_NAME}"
+      EXPO_QR_FILE_PATH="${REPORTS_PATH}/${EXPO_QR_FILE_NAME}"
 
-      qr "${EXPO_PUBLIC_URL/http/exp}/${qr_build_format}-index.json?release-channel=${EXPO_RELEASE_CHANNEL}" > "${EXPO_QR_FILE_PATH}" || return $?
+      qr "${PUBLIC_URL/http/exp}/${qr_build_format}-index.json?release-channel=${RELEASE_CHANNEL}" > "${EXPO_QR_FILE_PATH}" || return $?
 
       DETAILED_HTML_QR_MESSAGE="${DETAILED_HTML_QR_MESSAGE}<p><strong>${qr_build_format}</strong> <br> <img src=\"./${EXPO_QR_FILE_NAME}\" alt=\"EXPO QR Code\" width=\"200px\" /></p>"
   
   done
 
-  DETAILED_HTML="<html><body> <h4>Expo Mobile App Publish</h4> <p> A new Expo mobile app publish has completed </p> <ul> <li><strong>Public URL</strong> ${EXPO_PUBLIC_URL}</li> <li><strong>Release Channel</strong> ${EXPO_RELEASE_CHANNEL}</li><li><strong>SDK Version</strong> ${EXPO_SDK_VERSION}</li><li><strong>App Version</strong> ${EXPO_APP_VERSION}</li><li><strong>Build Number</strong> ${EXPO_BUILD_NUMBER}</li><li><strong>Code Commit</strong> ${EXPO_BUILD_REFERENCE}</li></ul> ${DETAILED_HTML_QR_MESSAGE} ${DETAILED_HTML_BINARY_MESSAGE} </body></html>" 
-  echo "${DETAILED_HTML}" > "${EXPO_REPORTS_PATH}/build-report.html"
+  DETAILED_HTML="<html><body> <h4>Expo Mobile App Publish</h4> <p> A new Expo mobile app publish has completed </p> <ul> <li><strong>Public URL</strong> ${PUBLIC_URL}</li> <li><strong>Release Channel</strong> ${RELEASE_CHANNEL}</li><li><strong>SDK Version</strong> ${EXPO_SDK_VERSION}</li><li><strong>App Version</strong> ${EXPO_APP_VERSION}</li><li><strong>Build Number</strong> ${BUILD_NUMBER}</li><li><strong>Code Commit</strong> ${BUILD_REFERENCE}</li></ul> ${DETAILED_HTML_QR_MESSAGE} ${DETAILED_HTML_BINARY_MESSAGE} </body></html>" 
+  echo "${DETAILED_HTML}" > "${REPORTS_PATH}/build-report.html"
 
-  aws --region "${AWS_REGION}" s3 sync "${EXPO_REPORTS_PATH}/" "s3://${EXPO_PUBLIC_BUCKET}/${EXPO_PUBLIC_PREFIX}/reports/" || return $?
+  aws --region "${AWS_REGION}" s3 sync "${REPORTS_PATH}/" "s3://${PUBLIC_BUCKET}/${PUBLIC_PREFIX}/reports/" || return $?
 
   if [[ "${BUILD_BINARY}" == "true" ]]; then 
-    DETAIL_MESSAGE="${DETAIL_MESSAGE} *Expo Publish Complete* - *NEW BINARIES CREATED* -  More details available <${EXPO_PUBLIC_URL}/reports/build-report.html|Here>"
+    DETAIL_MESSAGE="${DETAIL_MESSAGE} *Expo Publish Complete* - *NEW BINARIES CREATED* -  More details available <${PUBLIC_URL}/reports/build-report.html|Here>"
   else
-    DETAIL_MESSAGE="${DETAIL_MESSAGE} *Expo Publish Complete* - More details available <${EXPO_PUBLIC_URL}/reports/build-report.html|Here>"
+    DETAIL_MESSAGE="${DETAIL_MESSAGE} *Expo Publish Complete* - More details available <${PUBLIC_URL}/reports/build-report.html|Here>"
   fi 
 
   echo "DETAIL_MESSAGE=${DETAIL_MESSAGE}" >> ${AUTOMATION_DATA_DIR}/context.properties

--- a/aws/templates/application/application_mobileapp.ftl
+++ b/aws/templates/application/application_mobileapp.ftl
@@ -10,9 +10,47 @@
         [#assign core = occurrence.Core ]
         [#assign solution = occurrence.Configuration.Solution ]
         [#assign resources = occurrence.State.Resources ]
-        [#assign links = solution.Links ]
 
         [#assign mobileAppId = resources["mobileapp"].Id]
+
+        [#assign configFilePath = formatRelativePath(
+                                    getOccurrenceSettingValue(occurrence, "SETTINGS_PREFIX"),
+                                    "config" )]
+        [#assign configFileName = "config_" + runId + ".json" ]
+
+        [#assign fragment =
+                contentIfContent(solution.Fragment, getComponentId(core.Component)) ]
+
+        [#assign contextLinks = getLinkTargets(occurrence) ]
+        [#assign _context =
+            {
+                "Id" : fragment,
+                "Name" : fragment,
+                "Instance" : core.Instance.Id,
+                "Version" : core.Version.Id,
+                "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks),
+                "Environment" : {},
+                "Links" : contextLinks,
+                "DefaultCoreVariables" : false,
+                "DefaultEnvironmentVariables" : false,
+                "DefaultLinkVariables" : false
+            }
+        ]
+        
+        [#-- Add in fragment specifics including override of defaults --]
+        [#assign fragmentListMode = "model"]
+        [#assign fragmentId = formatFragmentId(_context)]
+        [#assign containerId = fragmentId]
+        [#include fragmentList?ensure_starts_with("/")]
+
+        [#assign finalAsFileEnvironment = getFinalEnvironment(occurrence, _context, { "AsFile" : true }) ]
+
+        [#if deploymentSubsetRequired("config", false)]
+            [@cfConfig
+                mode=listMode
+                content=finalAsFileEnvironment.Environment
+            /]
+        [/#if]
 
         [#if deploymentSubsetRequired("prologue", false)]
             [#-- Copy any asFiles needed by the task --]
@@ -30,6 +68,21 @@
                             getOccurrenceSettingValue(occurrence, "SETTINGS_PREFIX")
                         ) /]
             [/#if]
+
+            [@cfScript
+                mode=listMode
+                content=
+                    getLocalFileScript(
+                        "configFiles",
+                        "$\{CONFIG}",
+                        configFileName
+                    ) +
+                    syncFilesToBucketScript(
+                        "configFiles",
+                        regionId,
+                        operationsBucket,
+                        configFilePath
+                    ) /]
         [/#if]
 
         [#if deploymentSubsetRequired("epilogue", false)]
@@ -42,7 +95,10 @@
                 ] +    
                 pseudoStackOutputScript(
                     "Mobile App",
-                    { mobileAppId : mobileAppId }
+                    { 
+                        mobileAppId : mobileAppId,
+                        formatId(mobileAppId, "configFile") : formatRelativePath(configFilePath, configFileName)
+                    }
                 ) +
                 [            
                     "       ;;",

--- a/aws/templates/id/id_mobileapp.ftl
+++ b/aws/templates/id/id_mobileapp.ftl
@@ -117,7 +117,7 @@
                 "OTA_ARTEFACT_BUCKET" : otaBucket,
                 "OTA_ARTEFACT_PREFIX" : otaPrefix,
                 "OTA_ARTEFACT_URL" : otaURL,
-                "CONFIG_FILE" : getExistingReference(formatId(id, configFile))!""
+                "CONFIG_FILE" : getExistingReference(formatId(id, "configFile"))
             }
         }
     ]

--- a/aws/templates/id/id_mobileapp.ftl
+++ b/aws/templates/id/id_mobileapp.ftl
@@ -40,6 +40,11 @@
                     "Type" : ARRAY_OF_STRING_TYPE,
                     "Default" : [ "ios", "android" ],
                     "Values" : [ "ios", "android" ]
+                },
+                {
+                    "Names" : ["Fragment", "Container"],
+                    "Type" : STRING_TYPE,
+                    "Default" : ""
                 }
             ]
         }
@@ -111,7 +116,8 @@
                 "CODE_SRC_PREFIX" : codeSrcPrefix,
                 "OTA_ARTEFACT_BUCKET" : otaBucket,
                 "OTA_ARTEFACT_PREFIX" : otaPrefix,
-                "OTA_ARTEFACT_URL" : otaURL
+                "OTA_ARTEFACT_URL" : otaURL,
+                "CONFIG_FILE" : getExistingReference(formatId(id, configFile))!""
             }
         }
     ]


### PR DESCRIPTION
Adds the ability to provide settings through to a mobile app. Using fragments and settings environment specific configuration can be provided to an expo app. 

The settings are added to the expo app manifest file under the extra section. Based on https://docs.expo.io/versions/latest/workflow/configuration/#extra 