### PR TITLE
<fix>mobileapp use S3 Url instead of S3 Website

### DIFF
--- a/aws/templates/id/id_mobileapp.ftl
+++ b/aws/templates/id/id_mobileapp.ftl
@@ -93,7 +93,7 @@
                     [#if link.Id?lower_case?starts_with("ota") ]
                         [#local otaBucket = linkTargetAttributes["NAME"]]
                         [#local otaPrefix = core.RelativePath ]
-                        [#local otaURL = formatRelativePath(linkTargetAttributes["WEBSITE_URL"], otaPrefix )]
+                        [#local otaURL = formatRelativePath("https://", linkTargetAttributes["INTERNAL_FQDN"], otaPrefix )]
                     [/#if]
                     [#break]
             [/#switch]


### PR DESCRIPTION
Since all urls are absolute in the expo app configuration we don't need to use an S3 Website and can use the standard https url for S3 access 