### PR TITLE
<fix>vpc resource output id differences

### DIFF
--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -24,8 +24,8 @@
             [#assign fnLgId = resources["lg"].Id ]
             [#assign fnLgName = resources["lg"].Name ]
 
-            [#assign vpcAccess = false ]
-            [#if solution.VPCAccess ]     
+            [#assign vpcAccess = solution.VPCAccess ]
+            [#if vpcAccess ]     
                 [#assign networkLink = tier.Network.Link!{} ]
 
                 [#assign networkLinkTarget = getLinkTarget(fn, networkLink ) ]
@@ -39,9 +39,6 @@
 
                 [#assign vpcId = networkResources["vpc"].Id ]
                 [#assign vpc = getExistingReference(vpcId)]
-
-                [#assign vpcAccess = solution.VPCAccess && vpc?has_content ]
-
             [/#if]
 
             [#assign fragment =

--- a/aws/templates/id/id_network.ftl
+++ b/aws/templates/id/id_network.ftl
@@ -196,11 +196,11 @@
 
     [#if legacyVpc ]
         [#local vpcId = formatVPCTemplateId() ]
-        [#local legacySegmentTopicId = formatSegmentSNSTopicId() ]
+        [#local vpcName = formatVPCName()]
         [#local legacyIGWId = formatVPCIGWTemplateId() ]
         [#local legacyIGWName = formatIGWName() ]
         [#local legacyIGWAttachementId = formatId(AWS_VPC_IGW_ATTACHMENT_TYPE) ]
-        [#local vpcName = formatVPCName()]
+        [#local legacySegmentTopicId = formatSegmentSNSTopicId() ]
     [#else]
         [#local vpcId = formatResourceId(AWS_VPC_RESOURCE_TYPE, core.Id)]
         [#local vpcName = core.FullName ]
@@ -278,7 +278,8 @@
         {
             "Resources" : {
                 "vpc" : {
-                    "Id" : vpcId,
+                    "Id" : legacyVpc?then(formatVPCId(), vpcId),
+                    "ResourceId" : vpcId,
                     "Name" : vpcName,
                     "Address": networkAddress + "/" + networkMask,
                     "Type" : AWS_VPC_RESOURCE_TYPE
@@ -310,9 +311,10 @@
                         "Type" : AWS_SNS_TOPIC_RESOURCE_TYPE
                     },
                     "legacyIGW" : {
-                            "Id" : legacyIGWId,
-                            "Name" : legacyIGWName,
-                            "Type" : AWS_VPC_IGW_RESOURCE_TYPE
+                        "Id" : legacyVpc?then(formatVPCIGWId(), legacyIGWId),
+                        "ResourceId" : legacyIGWId,
+                        "Name" : legacyIGWName,
+                        "Type" : AWS_VPC_IGW_RESOURCE_TYPE
                     },
                     "legacyIGWAttachement" : {
                         "Id" : legacyIGWAttachementId,

--- a/aws/templates/id/id_vpc.ftl
+++ b/aws/templates/id/id_vpc.ftl
@@ -111,14 +111,6 @@
         )]
 [/#function]
 
-[#function formatVPCFlowLogsId extensions...]
-    [#return formatDependentResourceId(
-        AWS_VPC_FLOWLOG_RESOURCE_TYPE,
-        formatSegmentResourceId(AWS_VPC_RESOURCE_TYPE),
-        extensions)]
-[/#function]
-
-[#-- Legacy functions reflecting inconsistencies in template id naming --]
 [#function formatVPCTemplateId]
     [#return
         getExistingReference(
@@ -135,6 +127,13 @@
                 AWS_VPC_IGW_RESOURCE_TYPE,
                 formatSegmentResourceId(AWS_VPC_IGW_RESOURCE_TYPE)
             )]
+[/#function]
+
+[#function formatVPCFlowLogsId extensions...]
+    [#return formatDependentResourceId(
+        AWS_VPC_FLOWLOG_RESOURCE_TYPE,
+        formatSegmentResourceId(AWS_VPC_RESOURCE_TYPE),
+        extensions)]
 [/#function]
 
 [#function formatSubnetId tier zone]

--- a/aws/templates/resource/resource_vpc.ftl
+++ b/aws/templates/resource/resource_vpc.ftl
@@ -223,14 +223,14 @@
 [#macro createVPC
             mode
             id
-            legacyVpc
             name
             cidr
             dnsSupport
-            dnsHostnames]
+            dnsHostnames
+            resourceId=""]
     [@cfResource
         mode=mode
-        id=id
+        id=resourceId!id
         type="AWS::EC2::VPC"
         properties=
             {
@@ -239,22 +239,21 @@
                 "EnableDnsHostnames" : dnsHostnames
             }
         tags=getCfTemplateCoreTags(name)
-        outputId=legacyVpc?then(
-                    formatVPCId(),
-                    id)
+        outputId=id
     /]
 [/#macro]
 
 [#macro createIGW
             mode
             id
-            name]
+            name
+            resourceId=""]
     [@cfResource
         mode=mode
-        id=id
+        id=resourceId!id
         type="AWS::EC2::InternetGateway"
         tags=getCfTemplateCoreTags(name)
-        outputId=formatVPCIGWId()
+        outputId=id
     /]
 [/#macro]
 

--- a/aws/templates/segment/segment_network.ftl
+++ b/aws/templates/segment/segment_network.ftl
@@ -11,6 +11,7 @@
         [#assign resources = occurrence.State.Resources ]
 
         [#assign vpcId = resources["vpc"].Id]
+        [#assign vpcResourceId = resources["vpc"].ResourceId]
         [#assign vpcName = resources["vpc"].Name]
         [#assign vpcCIDR = resources["vpc"].Address]
 
@@ -56,7 +57,7 @@
                 [@createVPCFlowLog
                     mode=listMode
                     id=flowLogsAllId
-                    vpcId=vpcId
+                    vpcId=vpcResourceId
                     roleId=flowLogsRoleId
                     logGroupName=flowLogsAllLogGroupName
                     trafficType="ALL"
@@ -79,8 +80,8 @@
             [@createVPC
                 mode=listMode
                 id=vpcId
+                resourceId=vpcResourceId
                 name=vpcName
-                legacyVpc=legacyVpc
                 cidr=vpcCIDR
                 dnsSupport=dnsSupport
                 dnsHostnames=dnsHostnames
@@ -90,6 +91,7 @@
         [#assign legacyIGWId = "" ]
         [#if (resources["legacyIGW"]!{})?has_content]
             [#assign legacyIGWId = resources["legacyIGW"].Id ]
+            [#assign legacyIGWResourceId = resources["leagcyIGW"].ResourceId]
             [#assign legacyIGWName = resources["legacyIGW"].Name]
             [#assign legacyIGWAttachmentId = resources["legacyIGWAttachement"].Id ]
 
@@ -97,12 +99,13 @@
                 [@createIGW
                     mode=listMode
                     id=legacyIGWId
+                    resourceid=igwResourceId
                     name=legacyIGWName
                 /]
                 [@createIGWAttachment
                     mode=listMode
                     id=legacyIGWAttachmentId
-                    vpcId=vpcId
+                    vpcId=vpcResourceId
                     igwId=legacyIGWId
                 /]
             [/#if]
@@ -157,7 +160,7 @@
                                     mode=listMode
                                     id=subnetId
                                     name=subnetName
-                                    vpcId=vpcId
+                                    vpcId=vpcResourceId
                                     tier=networkTier
                                     zone=zone
                                     cidr=subnetAddress
@@ -206,7 +209,7 @@
                                 mode=listMode
                                 id=routeTableId
                                 name=routeTableName
-                                vpcId=vpcId
+                                vpcId=vpcResourceId
                                 zone=zone
                             /]
 
@@ -242,7 +245,7 @@
                         mode=listMode
                         id=networkACLId
                         name=networkACLName
-                        vpcId=vpcId
+                        vpcId=vpcResourceId
                     /]
                     
                     [#list networkACLRules as id, rule ]


### PR DESCRIPTION
In some older vpc templates the resource Id is different from the output Id. 
Components looking up the network details of the vpc need to always know the output id and the resource Id only required for the vpc's template. 

This PR fixes the Id returned to components looking up the vpc and allows for the resource and output ids to be different.