### PR TITLE
<feat> RDS Template policy processing management

### DIFF
--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -108,6 +108,18 @@
                             "Type" : BOOLEAN_TYPE,
                             "Description" : "Delete automated snapshots when the instance is deleted",
                             "Default" : true
+                        },
+                        {
+                            "Names" : "DeletionPolicy",
+                            "Type" : STRING_TYPE,
+                            "Values" : [ "Snapshot", "Delete", "Retain" ],
+                            "Default" : "Snapshot"
+                        },
+                        {
+                            "Names" : "UpdateReplacePolicy",
+                            "Type" : STRING_TYPE,
+                            "Values" : [ "Snapshot", "Delete", "Retain" ],
+                            "Default" : "Snapshot"
                         }
                     ]
                 },

--- a/aws/templates/resource/resource_rds.ftl
+++ b/aws/templates/resource/resource_rds.ftl
@@ -58,11 +58,15 @@
     outputId=""
     autoMinorVersionUpgrade=true
     deleteAutomatedBackups=true
+    deletionPolicy="Snapshot"
+    updateReplacePolicy="Snapshot"
 ]
     [@cfResource 
     mode=listMode
     id=rdsId
     type="AWS::RDS::DBInstance"
+    deletionPolicy=deletionPolicy
+    updateReplacePolicy=updateReplacePolicy
     properties=
         {
             "Engine": engine,

--- a/aws/templates/resource/start.ftl
+++ b/aws/templates/resource/start.ftl
@@ -395,6 +395,7 @@
             dependencies=[]
             metadata={}
             deletionPolicy=""
+            updateReplacePolicy=""
             updatePolicy={}
             creationPolicy={}]
 
@@ -420,6 +421,7 @@
                             properties + attributeIfContent("Tags", tags)) +
                         attributeIfContent("DependsOn", localDependencies) +
                         attributeIfContent("DeletionPolicy", deletionPolicy) +
+                        attributeIfContent("UpdateReplacePolicy", updateReplacePolicy) +
                         attributeIfContent("UpdatePolicy", updatePolicy) +
                         attributeIfContent("CreationPolicy", creationPolicy)
                 }

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -112,6 +112,9 @@
         [#assign rdsManualSnapshot = getExistingReference(formatDependentRDSManualSnapshotId(rdsId), NAME_ATTRIBUTE_TYPE)]
         [#assign rdsLastSnapshot = getExistingReference(rdsId, LASTRESTORE_ATTRIBUTE_TYPE )]
 
+        [#assign deletionPolicy = solution.Backup.DeletionPolicy]
+        [#assign updateReplacePolicy = solution.Backup.UpdateReplacePolicy]
+
         [#assign segmentKMSKey = getReference(formatSegmentCMKId(), ARN_ATTRIBUTE_TYPE)]
 
         [#assign rdsPreDeploySnapshotId = formatName(
@@ -321,6 +324,8 @@
             [#switch alternative ]
                 [#case "replace1" ]
                     [#assign multiAZ = false]
+                    [#assign deletionPolicy = "Delete" ]
+                    [#assign updateReplacePolicy = "Delete" ]
                     [#assign rdsFullName=formatName(rdsFullName, "backup") ]
                     [#if rdsManualSnapshot?has_content ]
                         [#assign snapshotId = rdsManualSnapshot ]
@@ -374,6 +379,8 @@
                         securityGroupId=getReference(rdsSecurityGroupId)
                         autoMinorVersionUpgrade = solution.AutoMinorVersionUpgrade!RDSAutoMinorVersionUpgrade
                         deleteAutomatedBackups = solution.Backup.DeleteAutoBackups
+                        deletionPolicy=deletionPolicy
+                        updateReplacePolicy=updateReplacePolicy
                     /]
             [/#if]
         [/#if]


### PR DESCRIPTION
Adds the ability to define the deletion and Updatereplace policies on RDS instances. These policies define what to do when cloudformation deletes a resource or the resource is replaced as part of an update 

In RDS this defaults to `Snapshot` which will create a snapshot of the RDS instance before removing it. In some cases this is required, for example if you have a database which easy to recreate then you can disable this functionality

Also disables the snapshotting during RDS instance replacement template processing