### PR TITLE
<feat>Userpool Hosted UI own domain name

### DIFF
--- a/aws/templates/application/application_mobileapp.ftl
+++ b/aws/templates/application/application_mobileapp.ftl
@@ -16,7 +16,7 @@
         [#assign configFilePath = formatRelativePath(
                                     getOccurrenceSettingValue(occurrence, "SETTINGS_PREFIX"),
                                     "config" )]
-        [#assign configFileName = "config_" + runId + ".json" ]
+        [#assign configFileName = "config.json" ]
 
         [#assign fragment =
                 contentIfContent(solution.Fragment, getComponentId(core.Component)) ]
@@ -43,7 +43,7 @@
         [#assign containerId = fragmentId]
         [#include fragmentList?ensure_starts_with("/")]
 
-        [#assign finalAsFileEnvironment = getFinalEnvironment(occurrence, _context, { "AsFile" : true }) ]
+        [#assign finalAsFileEnvironment = getFinalEnvironment(occurrence, _context) ]
 
         [#if deploymentSubsetRequired("config", false)]
             [@cfConfig

--- a/aws/templates/id/id_userpool.ftl
+++ b/aws/templates/id/id_userpool.ftl
@@ -142,6 +142,16 @@
                             "Default" : true
                         }
                     ]
+                },
+                {
+                    "Names" : "HostedUI",
+                    "Description" : "Provsion a managed endpoint for login and oauth endpoints",
+                    "Children" : [
+                        {
+                            "Names" : "Certificate",
+                            "Children" : certificateChildConfiguration
+                        }
+                    ]
                 }
             ],
             "Components" : [
@@ -242,25 +252,45 @@
         ]
     [#else]
 
-        [#assign userPoolId = formatResourceId(AWS_COGNITO_USERPOOL_RESOURCE_TYPE, core.Id)]
-        [#assign userPoolName = formatSegmentFullName(core.Name)]
-
-        [#assign userPoolDomainId = formatResourceId(AWS_COGNITO_USERPOOL_DOMAIN_RESOURCE_TYPE, core.Id)]
-        [#assign userPoolDomainName = formatName("auth", core.ShortFullName, segmentSeed)]
-
-        [#assign defaultUserPoolClientId = formatResourceId(AWS_COGNITO_USERPOOL_CLIENT_RESOURCE_TYPE, core.Id) ]
-        [#assign defaultUserPoolClientName = formatSegmentFullName(core.Name)]
-        [#assign defaultUserPoolClientRequired = solution.DefaultClient ]
+        [#local userPoolId = formatResourceId(AWS_COGNITO_USERPOOL_RESOURCE_TYPE, core.Id)]
+        [#local userPoolName = formatSegmentFullName(core.Name)]
         
-        [#assign identityPoolId = formatResourceId(AWS_COGNITO_IDENTITYPOOL_RESOURCE_TYPE, core.Id)]
-        [#assign identityPoolName = formatSegmentFullName(core.Name)?replace("-","X")]
+        [#local defaultUserPoolClientId = formatResourceId(AWS_COGNITO_USERPOOL_CLIENT_RESOURCE_TYPE, core.Id) ]
+        [#local defaultUserPoolClientName = formatSegmentFullName(core.Name)]
+        [#local defaultUserPoolClientRequired = solution.DefaultClient ]
+        
+        [#local identityPoolId = formatResourceId(AWS_COGNITO_IDENTITYPOOL_RESOURCE_TYPE, core.Id)]
+        [#local identityPoolName = formatSegmentFullName(core.Name)?replace("-","X")]
 
-        [#assign identityPoolRoleMappingId = formatDependentResourceId(AWS_COGNITO_IDENTITYPOOL_ROLEMAPPING_RESOURCE_TYPE, identityPoolId)]
+        [#local identityPoolRoleMappingId = formatDependentResourceId(AWS_COGNITO_IDENTITYPOOL_ROLEMAPPING_RESOURCE_TYPE, identityPoolId)]
 
-        [#assign userPoolRoleId = formatComponentRoleId(core.Tier, core.Component)]
+        [#local userPoolRoleId = formatComponentRoleId(core.Tier, core.Component)]
 
-        [#assign identityPoolUnAuthRoleId = formatDependentRoleId(identityPoolId,USERPOOL_COMPONENT_ROLE_UNAUTH_EXTENSTION )]
-        [#assign identityPoolAuthRoleId = formatDependentRoleId(identityPoolId,USERPOOL_COMPONENT_ROLE_AUTH_EXTENSTION )]
+        [#local identityPoolUnAuthRoleId = formatDependentRoleId(identityPoolId,USERPOOL_COMPONENT_ROLE_UNAUTH_EXTENSTION )]
+        [#local identityPoolAuthRoleId = formatDependentRoleId(identityPoolId,USERPOOL_COMPONENT_ROLE_AUTH_EXTENSTION )]
+
+        [#local userPoolDomainId = formatResourceId(AWS_COGNITO_USERPOOL_DOMAIN_RESOURCE_TYPE, core.Id)]
+        [#local certificatePresent = isPresent(solution.HostedUI.Certificate) ]
+        [#local userPoolDomainName = formatName("auth", core.ShortFullName, segmentSeed)]
+        [#local userPoolBaseUrl = "https://" + formatDomainName(userPoolDomainName, "auth", region, "amazoncognito.com") + "/" ]
+
+        [#local region = getExistingReference(userPoolId, REGION_ATTRIBUTE_TYPE)!regionId ]
+
+        [#local certificateArn = ""]
+        [#if certificatePresent ]
+            [#local certificateObject = getCertificateObject(solution.HostedUI.Certificate!"", segmentQualifiers)]
+            [#local certificateDomains = getCertificateDomains(certificateObject) ]
+            [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
+            [#local hostName = getHostName(certificateObject, occurrence) ]
+            [#local userPoolCustomDomainName = formatDomainName(hostName, primaryDomainObject)]
+            [#local userPoolCustomBaseUrl = "https://" + userPoolDomainName + "/" ] 
+
+            [#local certificateId = formatDomainCertificateId(certificateObject, userPoolDomainName)]
+            [#local certificateArn = (getExistingReference(certificateId, ARN_ATTRIBUTE_TYPE, "us-east-1" )?has_content)?then(
+                                            getExistingReference(certificateId, ARN_ATTRIBUTE_TYPE, "us-east-1" ),
+                                            "COTException: ACM Certificate required in us-east-1"
+                                    )]
+        [/#if]
 
         [#return
             {
@@ -306,12 +336,25 @@
                         }
                     },
                     {}
+                ) +
+                certificatePresent?then(
+                    {
+                        "customdomain" : {
+                            "Id" : formatId(userPoolDomainId, "custom"),
+                            "Name" : userPoolCustomDomainName,
+                            "CertificateArn" : certificateArn,
+                            "Type" : AWS_COGNITO_USERPOOL_DOMAIN_RESOURCE_TYPE
+                        }
+                    },
+                    {}
                 ),
                 "Attributes" : {
                     "AUTHORIZATION_HEADER" : occurrence.Configuration.Solution.AuthorizationHeader,
                     "USER_POOL" : getExistingReference(userPoolId),
                     "IDENTITY_POOL" : getExistingReference(identityPoolId),
-                    "REGION" : getExistingReference(userPoolId, REGION_ATTRIBUTE_TYPE)!regionId
+                    "REGION" : region,
+                    "UI_INTERNAL_BASE_URL" : userPoolBaseUrl,
+                    "UI_BASE_URL" : userPoolCustomBaseUrl!userPoolBaseUrl
                 } + 
                 defaultUserPoolClientRequired?then(
                     {

--- a/aws/templates/id/id_userpool.ftl
+++ b/aws/templates/id/id_userpool.ftl
@@ -33,6 +33,11 @@
                     "Type" : "Note",
                     "Value" : "Make sure to plan your schema before initial deployment. Updating shema attributes causes a replaccement of the userpool",
                     "Severity" : "warning"
+                },
+                {
+                    "Type" : "Note",
+                    "Value" : "Please read https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-add-custom-domain.html before enabling custom domains on userpool hosted UI. An A Record is required in your base domain",
+                    "Severity" : "warning"
                 }
             ],
             "Attributes" : [

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -76,7 +76,11 @@
         {
             "Names" : [ "Branch" ],
             "Type" : STRING_TYPE
-        }
+        },
+        {
+            "Names" : [ "Client" ],
+            "Type" : STRING_TYPE
+        },
         {
             "Names" : "Instance",
             "Type" : STRING_TYPE

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -323,6 +323,7 @@
                     [#switch linkTargetCore.Type]
 
                         [#case USERPOOL_COMPONENT_TYPE]
+                        [#case USERPOOL_CLIENT_COMPONENT_TYPE]
                         [#case "external" ]
                             [#assign cognitoIntegration = true ]
                             [#assign listenerForwardRule = false ]


### PR DESCRIPTION
Adds support for custom domain names on hosted UI. This adds the existing certificate support to hosted UI's in userpools. 

A couple of manual requirements need to be met before this can be enabled on a userpool
1. You will need an ACM based certificate provisioned for your products domain in the `us-east-1` region. The hosted UI is a cloudfront distribution and cloudfront requires certificates in us-east-1. This will need to be stored as a segment output file like we do for cloudfront
2. As per https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-add-custom-domain.html an A record needs to be present in the base of your domain. I.e. if you have `auth.something.com` for the hosted UI you need to have an A record with any value setup on `something.com` DNS domain. This seems to be for validation purposes. I've tested with a record of 127.0.0.1 so it looks like its just for DNS validation 

This is an optional feature and by default a Hosted UI will be provisioned using the `auth. <region>.amazoncognito.com` domain provided by AWS.