### PR TITLE
<refactor> Remove getDescendent and setDescendent Functions

### DIFF
--- a/aws/templates/base.ftl
+++ b/aws/templates/base.ftl
@@ -253,41 +253,6 @@
 [#macro toJSON obj escaped=false]
     ${getJSON(obj, escaped)}[/#macro]
 
-[#function getDescendent object default path...]
-    [#local descendent=object]
-    [#list asFlattenedArray(path) as part]
-        [#if descendent[part]??]
-            [#local descendent=descendent[part] ]
-        [#else]
-            [#return default]
-        [/#if]
-    [/#list]
-
-    [#return descendent]
-[/#function]
-
-[#function setDescendent object descendent id path...]
-  [#local effectivePath = asFlattenedArray(path) ]
-    [#if effectivePath?has_content]
-      [#return
-        object +
-        {
-          effectivePath?first :
-            setDescendent(
-              object[effectivePath?first]!{},
-              descendent,
-              id,
-              (effectivePath?size == 1)?then([],effectivePath[1..]))
-        }
-      ]
-    [#else]
-      [#if object[id]?? && object[id]?is_hash]
-          [#return object + { id : object[id] + descendent } ]
-      [/#if]
-      [#return object + { id : descendent } ]
-    [/#if]
-[/#function]
-
 [#function mergeObjects current new]
     [#local result = current]
     [#list new as key,value]

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -77,11 +77,14 @@
 
 [#function addVariableToContext context name value]
     [#return
-        setDescendent(
+        mergeObjects(
             context,
-            asSerialisableString(value),
-            formatSettingName(name)
-            "Environment") ]
+            {
+                "Environment" : {
+                    formatSettingName(name) : asSerialisableString(value)
+                }
+            }
+        ) ]
 [/#function]
 
 [#macro Variable name value]
@@ -244,7 +247,7 @@
 [/#macro]
 
 [#macro Volume name="" containerPath="" hostPath="" readOnly=false persist=false volumeLinkId="" driverOpts={} autoProvision=false ]
-    
+
     [#if volumeLinkId?has_content ]
         [#local volumeName = _context.DataVolumes[volumeLinkId].Name ]
         [#local volumeEngine = _context.DataVolumes[volumeLinkId].Engine ]
@@ -698,12 +701,12 @@
             [#assign linkTargetConfiguration = linkTarget.Configuration ]
             [#assign linkTargetResources = linkTarget.State.Resources ]
             [#assign linkTargetAttributes = linkTarget.State.Attributes ]
-            
+
             [#switch linkTargetCore.Type]
                 [#case DATAVOLUME_COMPONENT_TYPE]
 
                     [#assign dataVolumeEngine = linkTargetAttributes["ENGINE"] ]
-                    
+
                     [#if ! ( ecs.Configuration.Solution.VolumeDrivers?seq_contains(dataVolumeEngine)) ]
                             [@cfException
                                 mode=listMode
@@ -739,30 +742,30 @@
         [#if solution.Engine == "fargate" ]
             [#assign fargateInvalidConfig = false ]
             [#assign fargateInvalidConfigMessage = [] ]
-            
+
             [#if !( [ 256, 512, 1024, 2048, 4096 ]?seq_contains(_context.Cpu) )  ]
                 [#assign fargateInvalidConfig = true ]
-                [#assign fargateInvalidConfigMessage += [ "CPU quota is not valid ( must be divisible by 256 )" ] ] 
+                [#assign fargateInvalidConfigMessage += [ "CPU quota is not valid ( must be divisible by 256 )" ] ]
             [/#if]
 
-            [#if !( _context.MaximumMemory?has_content )  ] 
+            [#if !( _context.MaximumMemory?has_content )  ]
                 [#assign fargateInvalidConfig = true ]
-                [#assign fargateInvalidConfigMessage += [ "Maximum memory must be assigned" ]]  
+                [#assign fargateInvalidConfigMessage += [ "Maximum memory must be assigned" ]]
             [/#if]
-                
+
             [#if (_context.Privileged )]
                 [#assign fargateInvalidConfig = true ]
-                [#assign fargateInvalidConfigMessage += [ "Cannot run in priviledged mode" ] ] 
+                [#assign fargateInvalidConfigMessage += [ "Cannot run in priviledged mode" ] ]
             [/#if]
 
             [#if _context.ContainerNetworkLinks!{}?has_content ]
                 [#assign fargateInvalidConfig = true ]
-                [#assign fargateInvalidConfigMessage += [ "Cannot use Network Links" ] ] 
+                [#assign fargateInvalidConfigMessage += [ "Cannot use Network Links" ] ]
             [/#if]
 
             [#if (_context.Hosts!{})?has_content ]
                 [#assign fargateInvalidConfig = true ]
-                [#assign fargateInvalidConfigMessage += [ "Cannot add host entries" ] ] 
+                [#assign fargateInvalidConfigMessage += [ "Cannot add host entries" ] ]
             [/#if]
 
             [#list _context.Volumes!{} as name,volume ]
@@ -770,7 +773,7 @@
                     [#assign fargateInvalidConfig = true ]
                     [#assign fargateInvalidConfigMessage += [ "Can only use the local driver and cannot reference host - volume ${name}" ] ]
                 [/#if]
-            [/#list] 
+            [/#list]
 
             [#if fargateInvalidConfig ]
                 [@cfException


### PR DESCRIPTION
getDescendent is better implemented using standard freemarker fallback behaviour e.g. (a.b.c)!"default".

setDescendent has been superceded by mergeObjects(). The latter is easier to understand and clearer in code because the call shows that portion of the object that will be added/replaced.