### PR TITLE
<refactor> Force removal of "containerId" use

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -48,8 +48,7 @@
         [#if solution.Fragment?has_content ]
             [#assign fragmentListMode = "model"]
             [#assign fragmentId = formatFragmentId(_context)]
-            [#assign containerId = fragmentId]
-            [#include fragmentList?ensure_starts_with("/")]
+             [#include fragmentList?ensure_starts_with("/")]
         [/#if]
 
         [#assign stageVariables += getFinalEnvironment(occurrence, _context).Environment ]

--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -28,7 +28,7 @@
         [#assign bootstrapProfile = getBootstrapProfile(tier, component, "ComputeCluster")]
         [#assign storageProfile = getStorage(tier, component, "ComputeCluster")]
         [#assign processorProfile = getProcessor(tier, component, "ComputeCluster")]
-    
+
         [#assign networkLink = tier.Network.Link!{} ]
 
         [#assign networkLinkTarget = getLinkTarget(occurrence, networkLink ) ]
@@ -47,7 +47,7 @@
         [#assign routeTableConfiguration = routeTableLinkTarget.Configuration.Solution ]
         [#assign publicRouteTable = routeTableConfiguration.Public ]
 
-        [#assign computeAutoScaleGroupTags =                     
+        [#assign computeAutoScaleGroupTags =
                 getCfTemplateCoreTags(
                         computeClusterAutoScaleGroupName,
                         tier,
@@ -134,7 +134,6 @@
         [#-- Add in fragment specifics including override of defaults --]
         [#assign fragmentListMode = "model"]
         [#assign fragmentId = formatFragmentId(_context)]
-        [#assign containerId = fragmentId]
         [#include fragmentList?ensure_starts_with("/")]
 
         [#assign environmentVariables += getFinalEnvironment(occurrence, _context).Environment ]
@@ -334,7 +333,7 @@
                                                 "WaitForSignal" : (solution.UseInitAsService != true)
                                         }]
 
-            [@createEc2AutoScaleGroup 
+            [@createEc2AutoScaleGroup
                 mode=listMode
                 id=computeClusterAutoScaleGroupId
                 tier=tier

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -25,7 +25,7 @@
             [#assign fnLgName = resources["lg"].Name ]
 
             [#assign vpcAccess = solution.VPCAccess ]
-            [#if vpcAccess ]     
+            [#if vpcAccess ]
                 [#assign networkLink = tier.Network.Link!{} ]
 
                 [#assign networkLinkTarget = getLinkTarget(fn, networkLink ) ]
@@ -129,7 +129,6 @@
             [#-- Add in fragment specifics including override of defaults --]
             [#assign fragmentListMode = "model"]
             [#assign fragmentId = formatFragmentId(_context)]
-            [#assign containerId = fragmentId]
             [#include fragmentList?ensure_starts_with("/")]
 
             [#-- clear all environment variables for EDGE deployments --]
@@ -237,7 +236,7 @@
                         tier=tier
                         component=component
                         resourceId=fnId
-                        resourceName=formatName("lambda", fnName) 
+                        resourceName=formatName("lambda", fnName)
                         vpcId=vpcId/]
                 [/#if]
 

--- a/aws/templates/application/application_mobileapp.ftl
+++ b/aws/templates/application/application_mobileapp.ftl
@@ -36,11 +36,10 @@
                 "DefaultLinkVariables" : false
             }
         ]
-        
+
         [#-- Add in fragment specifics including override of defaults --]
         [#assign fragmentListMode = "model"]
         [#assign fragmentId = formatFragmentId(_context)]
-        [#assign containerId = fragmentId]
         [#include fragmentList?ensure_starts_with("/")]
 
         [#assign finalAsFileEnvironment = getFinalEnvironment(occurrence, _context) ]
@@ -92,15 +91,15 @@
                 [
                     "case $\{STACK_OPERATION} in",
                     "  create|update)"
-                ] +    
+                ] +
                 pseudoStackOutputScript(
                     "Mobile App",
-                    { 
+                    {
                         mobileAppId : mobileAppId,
                         formatId(mobileAppId, "configFile") : formatRelativePath(configFilePath, configFileName)
                     }
                 ) +
-                [            
+                [
                     "       ;;",
                     "       esac"
                 ]

--- a/aws/templates/application/application_spa.ftl
+++ b/aws/templates/application/application_spa.ftl
@@ -35,7 +35,6 @@
         [#-- Add in container specifics including override of defaults --]
         [#assign fragmentListMode = "model"]
         [#assign fragmentId = formatFragmentId(_context)]
-        [#assign containerId = fragmentId]
         [#include fragmentList?ensure_starts_with("/")]
 
         [#assign _context += getFinalEnvironment(occurrence, _context) ]

--- a/aws/templates/application/application_user.ftl
+++ b/aws/templates/application/application_user.ftl
@@ -65,7 +65,6 @@
         [#if solution.Fragment?has_content ]
             [#assign fragmentListMode = "model"]
             [#assign fragmentId = formatFragmentId(_context)]
-            [#assign containerId = fragmentId]
             [#include fragmentList?ensure_starts_with("/")]
         [/#if]
 
@@ -82,7 +81,7 @@
                     "   \"" + userName + "\" || return $?",
                     "   ;;",
                     "esac"
-                ] 
+                ]
             /]
         [/#if]
 
@@ -196,13 +195,13 @@
                     ] +
                     pseudoStackOutputScript(
                         "IAM User AccessKey",
-                        { 
+                        {
                             formatId(userId, "username") : "$\{access_key_array[0]}",
                             formatId(userId, "password") : "$\{encrypted_secret_key}",
                             formatId(userId, "key") : "$\{encrypted_smtp_password}"
                         },
                         "creds-system"
-                    ) + 
+                    ) +
                     [
                         "}",
                         "generate_iam_accesskey || return $?"
@@ -228,11 +227,11 @@
                     ] +
                     pseudoStackOutputScript(
                         "IAM User Password",
-                        { 
+                        {
                             formatId(userId, "generatedpassword") : "$\{encrypted_user_password}"
                         },
                         "creds-console"
-                    ) + 
+                    ) +
                     [
                         "}",
                         "generate_user_password || return $?"

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -244,7 +244,7 @@
 [/#macro]
 
 [#macro Volume name="" containerPath="" hostPath="" readOnly=false persist=false volumeLinkId="" driverOpts={} autoProvision=false ]
-    
+
     [#if volumeLinkId?has_content ]
         [#local volumeName = _context.DataVolumes[volumeLinkId].Name ]
         [#local volumeEngine = _context.DataVolumes[volumeLinkId].Engine ]
@@ -698,12 +698,12 @@
             [#assign linkTargetConfiguration = linkTarget.Configuration ]
             [#assign linkTargetResources = linkTarget.State.Resources ]
             [#assign linkTargetAttributes = linkTarget.State.Attributes ]
-            
+
             [#switch linkTargetCore.Type]
                 [#case DATAVOLUME_COMPONENT_TYPE]
 
                     [#assign dataVolumeEngine = linkTargetAttributes["ENGINE"] ]
-                    
+
                     [#if ! ( ecs.Configuration.Solution.VolumeDrivers?seq_contains(dataVolumeEngine)) ]
                             [@cfException
                                 mode=listMode
@@ -730,7 +730,6 @@
         [#-- Add in fragment specifics including override of defaults --]
         [#assign fragmentListMode = "model"]
         [#assign fragmentId = formatFragmentId(_context)]
-        [#assign containerId = fragmentId]
         [#include fragmentList]
 
         [#assign _context += getFinalEnvironment(task, _context) ]
@@ -739,30 +738,30 @@
         [#if solution.Engine == "fargate" ]
             [#assign fargateInvalidConfig = false ]
             [#assign fargateInvalidConfigMessage = [] ]
-            
+
             [#if !( [ 256, 512, 1024, 2048, 4096 ]?seq_contains(_context.Cpu) )  ]
                 [#assign fargateInvalidConfig = true ]
-                [#assign fargateInvalidConfigMessage += [ "CPU quota is not valid ( must be divisible by 256 )" ] ] 
+                [#assign fargateInvalidConfigMessage += [ "CPU quota is not valid ( must be divisible by 256 )" ] ]
             [/#if]
 
-            [#if !( _context.MaximumMemory?has_content )  ] 
+            [#if !( _context.MaximumMemory?has_content )  ]
                 [#assign fargateInvalidConfig = true ]
-                [#assign fargateInvalidConfigMessage += [ "Maximum memory must be assigned" ]]  
+                [#assign fargateInvalidConfigMessage += [ "Maximum memory must be assigned" ]]
             [/#if]
-                
+
             [#if (_context.Privileged )]
                 [#assign fargateInvalidConfig = true ]
-                [#assign fargateInvalidConfigMessage += [ "Cannot run in priviledged mode" ] ] 
+                [#assign fargateInvalidConfigMessage += [ "Cannot run in priviledged mode" ] ]
             [/#if]
 
             [#if _context.ContainerNetworkLinks!{}?has_content ]
                 [#assign fargateInvalidConfig = true ]
-                [#assign fargateInvalidConfigMessage += [ "Cannot use Network Links" ] ] 
+                [#assign fargateInvalidConfigMessage += [ "Cannot use Network Links" ] ]
             [/#if]
 
             [#if (_context.Hosts!{})?has_content ]
                 [#assign fargateInvalidConfig = true ]
-                [#assign fargateInvalidConfigMessage += [ "Cannot add host entries" ] ] 
+                [#assign fargateInvalidConfigMessage += [ "Cannot add host entries" ] ]
             [/#if]
 
             [#list _context.Volumes!{} as name,volume ]
@@ -770,7 +769,7 @@
                     [#assign fargateInvalidConfig = true ]
                     [#assign fargateInvalidConfigMessage += [ "Can only use the local driver and cannot reference host - volume ${name}" ] ]
                 [/#if]
-            [/#list] 
+            [/#list]
 
             [#if fargateInvalidConfig ]
                 [@cfException

--- a/aws/templates/segment/segment_bastion.ftl
+++ b/aws/templates/segment/segment_bastion.ftl
@@ -33,11 +33,11 @@
                 [#assign imageId = regionObject.AMIs.Centos.EC2]
                 [#break]
         [/#switch]
-      
+
         [#if deploymentSubsetRequired("bastion", true) ]
             [#assign networkLink = tier.Network.Link!{} ]
             [#assign networkLinkTarget = getLinkTarget(occurrence, networkLink ) ]
-            
+
             [#if ! networkLinkTarget?has_content ]
                 [@cfException listMode "Network could not be found" networkLink /]
                 [#break]
@@ -71,7 +71,7 @@
         [#assign configSets =
                 getInitConfigDirectories() +
                 getInitConfigBootstrap(component.Role!"")]
-                
+
         [#assign fragment =
             contentIfContent(solution.Fragment, getComponentId(component)) ]
 
@@ -98,7 +98,6 @@
         [#-- Add in fragment specifics including override of defaults --]
         [#assign fragmentListMode = "model"]
         [#assign fragmentId = formatFragmentId(_context)]
-        [#assign containerId = fragmentId]
         [#include fragmentList?ensure_starts_with("/")]
 
         [#assign environmentVariables = getFinalEnvironment(occurrence, _context).Environment ]
@@ -124,7 +123,7 @@
                             getPolicyDocument(
                                 ec2IPAddressUpdatePermission() +
                                     s3ListPermission(codeBucket) +
-                                    s3ReadPermission(codeBucket) + 
+                                    s3ReadPermission(codeBucket) +
                                     cwLogsProducePermission(computeClusterLogGroupName),
                                 "basic")
                         ] +
@@ -151,15 +150,15 @@
                     /]
                 [/#if]
 
-                [#assign configSets += 
+                [#assign configSets +=
                     getInitConfigEIPAllocation(
                         getReference(
-                            bastionEIPId, 
+                            bastionEIPId,
                             ALLOCATION_ATTRIBUTE_TYPE
                         ))]
             [/#if]
 
-            [#if deploymentSubsetRequired("lg", true) && 
+            [#if deploymentSubsetRequired("lg", true) &&
                     isPartOfCurrentDeploymentUnit(bastionLgId) ]
                 [@createLogGroup
                     mode=listMode
@@ -227,7 +226,7 @@
                     outputs={}
                 /]
 
-                [#assign asgTags =                     
+                [#assign asgTags =
                     getCfTemplateCoreTags(
                         bastionAutoScaleGroupName
                         tier,
@@ -235,7 +234,7 @@
                         "",
                         true)]
 
-                [@createEc2AutoScaleGroup 
+                [@createEc2AutoScaleGroup
                     mode=listMode
                     id=bastionAutoScaleGroupId
                     tier=tier

--- a/aws/templates/solution/solution_spa.ftl
+++ b/aws/templates/solution/solution_spa.ftl
@@ -36,7 +36,6 @@
         [#-- Add in container specifics including override of defaults --]
         [#assign fragmentListMode = "model"]
         [#assign fragmentId = formatFragmentId(_context)]
-        [#assign containerId = fragmentId]
         [#include fragmentList?ensure_starts_with("/")]
 
         [#assign securityProfile    = getSecurityProfile(solution.Profiles.Security, SPA_COMPONENT_TYPE)]
@@ -57,10 +56,10 @@
         [#assign eventHandlerLinks = {} ]
         [#assign eventHandlers = []]
 
-        [#if solution.CloudFront.RedirectAliases.Enabled 
+        [#if solution.CloudFront.RedirectAliases.Enabled
                     && ( aliases?size > 1) ]
 
-            [#assign cfRedirectLink = { 
+            [#assign cfRedirectLink = {
                 "cfredirect" : {
                     "Tier" : "gbl",
                     "Component" : "cfredirect",
@@ -71,10 +70,10 @@
                 }
             }]
 
-            [#if getLinkTarget(occurrence, cfRedirectLink.cfredirect )?has_content ]          
+            [#if getLinkTarget(occurrence, cfRedirectLink.cfredirect )?has_content ]
                 [#assign eventHandlerLinks += cfRedirectLink]
 
-                [#assign _context += 
+                [#assign _context +=
                     {
                         "ForwardHeaders" : (_context.ForwardHeaders![]) + [
                             "Host"
@@ -93,7 +92,7 @@
                             )
                         ]
                     }]
-            [#else] 
+            [#else]
                 [@cfException
                     mode=listMode
                     description="Could not find cfredirect component"


### PR DESCRIPTION
As part of switching to the term "fragment" in preference to the term
"container", remove the availability of the "containerId" variable from
within fragment files.

The switch of filenames has been in place for a while, and use of the
older variable should have been switched to fragmentId. This change will
identify any lingering use of the older term and thus may require
remediation of fragment files.