### PR TITLE
<feat> Cognito Userpool federation

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -940,6 +940,10 @@ behaviour.
                 [#local result = getUserPoolClientState(occurrence, parentOccurrence)]
                 [#break]
 
+            [#case USERPOOL_AUTHPROVIDER_COMPONENT_TYPE]
+                [#local result = getUserPoolAuthProviderState(occurrence)]
+                [#break]
+
             [#case BASTION_COMPONENT_TYPE ]
                 [#local result = getBastionState(occurrence)]
                 [#break]

--- a/aws/templates/id/id_userpool.ftl
+++ b/aws/templates/id/id_userpool.ftl
@@ -6,12 +6,15 @@
 [#assign AWS_COGNITO_IDENTITYPOOL_RESOURCE_TYPE = "identitypool"]
 [#assign AWS_COGNITO_IDENTITYPOOL_ROLEMAPPING_RESOURCE_TYPE = "rolemapping"]
 [#assign AWS_COGNITO_USERPOOL_DOMAIN_RESOURCE_TYPE = "userpooldomain" ]
+[#assign AWS_COGNITO_USERPOOL_AUTHPROVIDER_RESOURCE_TYPE = "userpoolauthprovider" ]
+
+[#assign USERPOOL_COMPONENT_ROLE_UNAUTH_EXTENSTION = "unauth" ]
+[#assign USERPOOL_COMPONENT_ROLE_AUTH_EXTENSTION = "auth" ]
 
 [#-- Components --]
 [#assign USERPOOL_COMPONENT_TYPE = "userpool"]
 [#assign USERPOOL_CLIENT_COMPONENT_TYPE = "userpoolclient" ]
-[#assign USERPOOL_COMPONENT_ROLE_UNAUTH_EXTENSTION = "unauth" ]
-[#assign USERPOOL_COMPONENT_ROLE_AUTH_EXTENSTION = "auth" ]
+[#assign USERPOOL_AUTHPROVIDER_COMPONENT_TYPE = "userpoolauthprovider" ]
 
 [#assign componentConfiguration +=
     {
@@ -157,81 +160,6 @@
                             "Children" : certificateChildConfiguration
                         }
                     ]
-                },
-                {
-                    "Names" : "AuthProviders",
-                    "Subobjects" : true,
-                    "Children" : [
-                        {
-                            "Names" : "Engine",
-                            "Type" : STRING_TYPE,
-                            "Values" : [ "SAML", "OIDC" ],
-                            "Mandatory" : true
-                        },
-                        {
-                            "Names" : "AttributeMappings",
-                            "Subobjects" : true,
-                            "Children" : [
-                                {
-                                    "Names" : "UserPoolAttribute",
-                                    "Type" : STRING_TYPE,
-                                    "Default" : ""
-                                },
-                                {
-                                    "Names" : "ProviderAttribute",
-                                    "Type" : STRING_TYPE,
-                                    "Mandatory" : true
-                                }
-                            ] 
-                        },
-                        {
-                            "Names" : "SAML",
-                            "Children" : [
-                                {
-                                    "Names" : "MetadataUrl",
-                                    "Type" : STRING_TYPE,
-                                    "Default" : ""
-                                }
-                            ]
-                        },
-                        {
-                            "Names" : "OIDC",
-                            "Children" : [
-                                {
-                                    "Names" : "ClientId",
-                                    "Type" : STRING_TYPE,
-                                    "Default" : ""
-                                },
-                                {
-                                    "Names" : "AttributesRequestMethod",
-                                    "Type" : STRING_TYPE,
-                                    "Values" : [ "GET", "POST" ],
-                                    "Default" : "GET"
-                                },
-                                {
-                                    "Names" : "Endpoints",
-                                    "Children" : [
-                                        {
-                                            "Names" : "Authorisation",
-                                            "Type" : STRING_TYPE
-                                        },
-                                        {
-                                            "Names" : "Token",
-                                            "Type" : STRING_TYPE
-                                        },
-                                        {
-                                            "Names" : "Userinfo",
-                                            "Type" : STRING_TYPE
-                                        },
-                                        {
-                                            "Names" : "JSONWebKey",
-                                            "Type" : STRING_TYPE
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
                 }
             ],
             "Components" : [
@@ -239,6 +167,11 @@
                     "Type" : USERPOOL_CLIENT_COMPONENT_TYPE,
                     "Component" : "Clients",
                     "Link" : [ "Client" ]
+                },
+                {
+                    "Type" : USERPOOL_AUTHPROVIDER_COMPONENT_TYPE,
+                    "Component" : "AuthProviders",
+                    "Link" : [ "AuthProvider" ]
                 }
             ]
         },
@@ -264,7 +197,7 @@
                         {
                             "Names" : "Scopes",
                             "Type" : ARRAY_OF_STRING_TYPE,
-                            "Values" : [ "phone", "email", "openid", "Cognito" ],
+                            "Values" : [ "phone", "email", "openid", "aws.cognito.signin.user.admin", "profile" ],
                             "Default" : [ "email", "openid" ]
                         },
                         {
@@ -293,7 +226,7 @@
                 },
                 {
                     "Names" : "AuthProviders",
-                    "Description" : "The Ids of any authproviders that can use this client",
+                    "Description" : "A list of user pool auth providers which can use this cient",
                     "Type" : ARRAY_OF_STRING_TYPE,
                     "Default" : [ "COGNITO" ]
                 },
@@ -301,6 +234,66 @@
                     "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
+                }
+            ]
+        },
+        USERPOOL_AUTHPROVIDER_COMPONENT_TYPE : {
+            "Properties" : [
+                {
+                    "Type" : "Description",
+                    "Value" : "An external auth provider which will federate with the user pool"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Names" : "Engine",
+                    "Type" : STRING_TYPE,
+                    "Values" : [ "SAML", "OIDC" ],
+                    "Mandatory" : true
+                },
+                {
+                    "Names" : "AttributeMappings",
+                    "Subobjects" : true,
+                    "Children" : [
+                        {
+                            "Names" : "UserPoolAttribute",
+                            "Type" : STRING_TYPE,
+                            "Default" : ""
+                        },
+                        {
+                            "Names" : "ProviderAttribute",
+                            "Type" : STRING_TYPE,
+                            "Mandatory" : true
+                        }
+                    ] 
+                },
+                {
+                    "Names" : "IDPIdentifiers",
+                    "Type" : ARRAY_OF_STRING_TYPE,
+                    "Description" : "A list of identifiers that can be used to pick the IDP - E.g. email domain"
+                },
+                {
+                    "Names" : "SAML",
+                    "Children" : [
+                        {
+                            "Names" : "MetadataUrl",
+                            "Type" : STRING_TYPE,
+                            "Default" : ""
+                        },
+                        {
+                            "Names" : "EnableIDPSignOut",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        }
+                    ]
                 }
             ]
         }
@@ -465,8 +458,8 @@
 [#function getUserPoolClientState occurrence parent ]
     [#local core = occurrence.Core]
 
-    [#assign userPoolClientId = formatResourceId(AWS_COGNITO_USERPOOL_CLIENT_RESOURCE_TYPE, core.Id)]
-    [#assign userPoolClientName = formatSegmentFullName(core.Name)]
+    [#local userPoolClientId = formatResourceId(AWS_COGNITO_USERPOOL_CLIENT_RESOURCE_TYPE, core.Id)]
+    [#local userPoolClientName = formatSegmentFullName(core.Name)]
 
     [#local parentAttributes = parent.State.Attributes ]
     [#local parentResources = parent.State.Resources ]
@@ -489,6 +482,31 @@
                 "CLIENT" : getReference(userPoolClientId)
             } + 
             parentAttributes,
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }]
+[/#function]
+
+[#function getUserPoolAuthProviderState occurrence ]
+    [#local core = occurrence.Core]
+
+    [#assign authProviderId = formatResourceId(AWS_COGNITO_USERPOOL_AUTHPROVIDER_RESOURCE_TYPE, core.Id)]
+    [#assign authProviderName = core.SubComponent.Name]
+
+    [#return
+        {
+            "Resources" : {
+                "authprovider" : {
+                    "Id" : authProviderId,
+                    "Name" : authProviderName,
+                    "Type" : AWS_COGNITO_USERPOOL_AUTHPROVIDER_RESOURCE_TYPE
+                }
+            },
+            "Attributes" : {
+                "PROVIDER_NAME" : authProviderName
+            },
             "Roles" : {
                 "Inbound" : {},
                 "Outbound" : {}

--- a/aws/templates/id/id_userpool.ftl
+++ b/aws/templates/id/id_userpool.ftl
@@ -210,11 +210,13 @@
                 },
                 {
                     "Names" : "ClientGenerateSecret",
+                    "Description" : "Generate a client secret which musht be provided in auth calls",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
                     "Names" : "ClientTokenValidity",
+                    "Description" : "Time in days that the refresh token is valid for",
                     "Type" : NUMBER_TYPE,
                     "Default" : 30
                 },
@@ -226,7 +228,7 @@
                 },
                 {
                     "Names" : "AuthProviders",
-                    "Description" : "A list of user pool auth providers which can use this cient",
+                    "Description" : "A list of user pool auth providers which can use this client",
                     "Type" : ARRAY_OF_STRING_TYPE,
                     "Default" : [ "COGNITO" ]
                 },
@@ -255,6 +257,7 @@
             "Attributes" : [
                 {
                     "Names" : "Engine",
+                    "Description" : "The authentication provider type",
                     "Type" : STRING_TYPE,
                     "Values" : [ "SAML", "OIDC" ],
                     "Mandatory" : true
@@ -265,11 +268,13 @@
                     "Children" : [
                         {
                             "Names" : "UserPoolAttribute",
+                            "Description" : "The name of the attribute in the user pool schema - the id of the mapping will be used if not provided",
                             "Type" : STRING_TYPE,
                             "Default" : ""
                         },
                         {
                             "Names" : "ProviderAttribute",
+                            "Description" : "The provider attribute which will be mapped",
                             "Type" : STRING_TYPE,
                             "Mandatory" : true
                         }
@@ -278,18 +283,20 @@
                 {
                     "Names" : "IDPIdentifiers",
                     "Type" : ARRAY_OF_STRING_TYPE,
-                    "Description" : "A list of identifiers that can be used to pick the IDP - E.g. email domain"
+                    "Description" : "A list of identifiers that can be used to automatically pick the IDP - E.g. email domain"
                 },
                 {
                     "Names" : "SAML",
                     "Children" : [
                         {
                             "Names" : "MetadataUrl",
+                            "Description" : "The SAML metadataUrl endpoint",
                             "Type" : STRING_TYPE,
                             "Default" : ""
                         },
                         {
                             "Names" : "EnableIDPSignOut",
+                            "Description" : "Enable the IDP Signout Flow",
                             "Type" : BOOLEAN_TYPE,
                             "Default" : true
                         }

--- a/aws/templates/id/id_userpool.ftl
+++ b/aws/templates/id/id_userpool.ftl
@@ -157,6 +157,81 @@
                             "Children" : certificateChildConfiguration
                         }
                     ]
+                },
+                {
+                    "Names" : "AuthProviders",
+                    "Subobjects" : true,
+                    "Children" : [
+                        {
+                            "Names" : "Engine",
+                            "Type" : STRING_TYPE,
+                            "Values" : [ "SAML", "OIDC" ],
+                            "Mandatory" : true
+                        },
+                        {
+                            "Names" : "AttributeMappings",
+                            "Subobjects" : true,
+                            "Children" : [
+                                {
+                                    "Names" : "UserPoolAttribute",
+                                    "Type" : STRING_TYPE,
+                                    "Default" : ""
+                                },
+                                {
+                                    "Names" : "ProviderAttribute",
+                                    "Type" : STRING_TYPE,
+                                    "Mandatory" : true
+                                }
+                            ] 
+                        },
+                        {
+                            "Names" : "SAML",
+                            "Children" : [
+                                {
+                                    "Names" : "MetadataUrl",
+                                    "Type" : STRING_TYPE,
+                                    "Default" : ""
+                                }
+                            ]
+                        },
+                        {
+                            "Names" : "OIDC",
+                            "Children" : [
+                                {
+                                    "Names" : "ClientId",
+                                    "Type" : STRING_TYPE,
+                                    "Default" : ""
+                                },
+                                {
+                                    "Names" : "AttributesRequestMethod",
+                                    "Type" : STRING_TYPE,
+                                    "Values" : [ "GET", "POST" ],
+                                    "Default" : "GET"
+                                },
+                                {
+                                    "Names" : "Endpoints",
+                                    "Children" : [
+                                        {
+                                            "Names" : "Authorisation",
+                                            "Type" : STRING_TYPE
+                                        },
+                                        {
+                                            "Names" : "Token",
+                                            "Type" : STRING_TYPE
+                                        },
+                                        {
+                                            "Names" : "Userinfo",
+                                            "Type" : STRING_TYPE
+                                        },
+                                        {
+                                            "Names" : "JSONWebKey",
+                                            "Type" : STRING_TYPE
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
                 }
             ],
             "Components" : [
@@ -215,6 +290,12 @@
                     "Description" : "Enable the use of the identity pool for this client",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : true
+                },
+                {
+                    "Names" : "AuthProviders",
+                    "Description" : "The Ids of any authproviders that can use this client",
+                    "Type" : ARRAY_OF_STRING_TYPE,
+                    "Default" : [ "COGNITO" ]
                 },
                 {
                     "Names" : "Links",

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -82,6 +82,10 @@
             "Type" : STRING_TYPE
         },
         {
+            "Names" : [ "AuthProvider" ],
+            "Type" : STRING_TYPE
+        },
+        {
             "Names" : "Instance",
             "Type" : STRING_TYPE
         },


### PR DESCRIPTION
This PR adds support for Cognito User pool federation. User pool federation allows for cognito users to be created in a user pool based on authentication from another provider. 

Once a user has authenticated with Cognito via their authentication provider a user entry is created in the userpool and the user can then authenticate with systems which use this user pool as an idp 

User attributes can also be mapped in to attributes on the user created in the cognito user pool 

Example configuration 
```
                    "userpool" : { 
                        "Clients" : {
                            "default" : {
                                "ClientGenerateSecret" : false,
                                "OAuth" : {
                                    "Scopes" : [
                                        "aws.cognito.signin.user.admin",
                                        "email",
                                        "openid",
                                        "profile"
                                    ],
                                    "Flows" : [
                                        "code"
                                    ]
                                },
                                "AuthProviders" : [
                                    "COGNITO",
                                    "GoSource"
                                ],
                                "Links" : {
                                    "app" : {
                                        "Tier" : "external",
                                        "Component" : "app"
                                    }
                                }
                            }
                        },
                        "AuthProviders" : {
                            "GoSource" : {
                                "Engine" : "SAML",
                                "IDPIdentifiers" : [ "gosource.com.au"],
                                "AttributeMappings" : {
                                    "email" : {
                                        "ProviderAttribute" : "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
                                    },
                                    "family_name" : {
                                        "ProviderAttribute" : "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"
                                    },
                                    "given_name" : {
                                        "ProviderAttribute" : "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"
                                    },
                                    "name" : {
                                        "ProviderAttribute" : "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
                                    }
                                },
                                "SAML" : {
                                    "MetadataUrl" : "https://login.microsoftonline.com/abc123/federationmetadata/2007-06/federationmetadata.xml"
                                }
                            }
                        }
                    }
```

In this example we are creating a SAML (Azure AD)  based authentication provider which will federate with the userpool 

The default client allows this provider to authenticate through it via the AuthProviders configuration on the Client 