### PR TITLE
<feat> RDS restore from rds dataset

### DIFF
--- a/aws/templates/id/id_dataset.ftl
+++ b/aws/templates/id/id_dataset.ftl
@@ -90,7 +90,7 @@
 
         [#case "rds" ]
 
-            [#local registryPrefix = getRegistryEndPoint("rdssnapshot", occurrence) ]
+            [#local registryPrefix = getRegistryPrefix("rdssnapshot", occurrence) ]
             [#local registryImage = formatName(
                                         registryPrefix,
                                         "rdssnapshot",

--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -160,6 +160,17 @@
                     "Names" : "Alerts",
                     "Subobjects" : true,
                     "Children" : alertChildrenConfiguration
+                },
+                {
+                    "Names" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                },
+                {
+                    "Names" : "AlwaysCreateFromSnapshot",
+                    "Description" : "Always create the database from a snapshot",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
                 }
             ]
     }


### PR DESCRIPTION
This PR adds support for restoring RDS instances based on an rds dataset 

Linking an RDS instance to an rds dataset will make the instance use the data set latest snapshot as a manual snapshot

To enforce this behaviour and make sure that an empty database isn't created a new parameter has also been added to the rds component `AlwaysCreateFromSnapshot` 

With this enable the database instance can only be created when a snapshot has been configured. This prevents empty databases from being created when they were supposed to have a snapshot