### PR TITLE
<fix> remove alarms when hibernating

### DIFF
--- a/aws/templates/solution/solution_cache.ftl
+++ b/aws/templates/solution/solution_cache.ftl
@@ -94,42 +94,6 @@
 
         [#if deploymentSubsetRequired("cache", true)]
 
-            [#list solution.Alerts?values as alert ]
-
-                [#assign monitoredResources = getMonitoredResources(resources, alert.Resource)]
-                [#list monitoredResources as name,monitoredResource ]
-
-                    [@cfDebug listMode monitoredResource false /]
-
-                    [#switch alert.Comparison ]
-                        [#case "Threshold" ]
-                            [@createCountAlarm
-                                mode=listMode
-                                id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
-                                severity=alert.Severity
-                                resourceName=core.FullName
-                                alertName=alert.Name
-                                actions=[
-                                    getReference(formatSegmentSNSTopicId())
-                                ]
-                                metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
-                                namespace=getResourceMetricNamespace(monitoredResource.Type)
-                                description=alert.Description!alert.Name
-                                threshold=alert.Threshold
-                                statistic=alert.Statistic
-                                evaluationPeriods=alert.Periods
-                                period=alert.Time
-                                operator=alert.Operator
-                                reportOK=alert.ReportOk
-                                missingData=alert.MissingData
-                                dimensions=getResourceMetricDimensions(monitoredResource, resources)
-                                dependencies=monitoredResource.Id
-                            /]
-                        [#break]
-                    [/#switch]
-                [/#list]
-            [/#list]
-
             [@createDependentSecurityGroup
                 mode=listMode
                 tier=tier
@@ -174,6 +138,43 @@
             /]
 
             [#if !hibernate]
+
+                [#list solution.Alerts?values as alert ]
+
+                    [#assign monitoredResources = getMonitoredResources(resources, alert.Resource)]
+                    [#list monitoredResources as name,monitoredResource ]
+
+                        [@cfDebug listMode monitoredResource false /]
+
+                        [#switch alert.Comparison ]
+                            [#case "Threshold" ]
+                                [@createCountAlarm
+                                    mode=listMode
+                                    id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
+                                    severity=alert.Severity
+                                    resourceName=core.FullName
+                                    alertName=alert.Name
+                                    actions=[
+                                        getReference(formatSegmentSNSTopicId())
+                                    ]
+                                    metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
+                                    namespace=getResourceMetricNamespace(monitoredResource.Type)
+                                    description=alert.Description!alert.Name
+                                    threshold=alert.Threshold
+                                    statistic=alert.Statistic
+                                    evaluationPeriods=alert.Periods
+                                    period=alert.Time
+                                    operator=alert.Operator
+                                    reportOK=alert.ReportOk
+                                    missingData=alert.MissingData
+                                    dimensions=getResourceMetricDimensions(monitoredResource, resources)
+                                    dependencies=monitoredResource.Id
+                                /]
+                            [#break]
+                        [/#switch]
+                    [/#list]
+                [/#list]
+                
                 [@cfResource
                     mode=listMode
                     id=cacheId

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -250,42 +250,6 @@
 
         [#if deploymentSubsetRequired("rds", true)]
 
-            [#list solution.Alerts?values as alert ]
-
-                [#assign monitoredResources = getMonitoredResources(resources, alert.Resource)]
-                [#list monitoredResources as name,monitoredResource ]
-
-                    [@cfDebug listMode monitoredResource false /]
-
-                    [#switch alert.Comparison ]
-                        [#case "Threshold" ]
-                            [@createCountAlarm
-                                mode=listMode
-                                id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
-                                severity=alert.Severity
-                                resourceName=core.FullName
-                                alertName=alert.Name
-                                actions=[
-                                    getReference(formatSegmentSNSTopicId())
-                                ]
-                                metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
-                                namespace=getResourceMetricNamespace(monitoredResource.Type)
-                                description=alert.Description!alert.Name
-                                threshold=alert.Threshold
-                                statistic=alert.Statistic
-                                evaluationPeriods=alert.Periods
-                                period=alert.Time
-                                operator=alert.Operator
-                                reportOK=alert.ReportOk
-                                missingData=alert.MissingData
-                                dimensions=getResourceMetricDimensions(monitoredResource, resources)
-                                dependencies=monitoredResource.Id
-                            /]
-                        [#break]
-                    [/#switch]
-                [/#list]
-            [/#list]
-
             [@createDependentComponentSecurityGroup
                 mode=listMode
                 tier=tier
@@ -391,6 +355,43 @@
             [/#switch]
 
             [#if !hibernate]
+
+                [#list solution.Alerts?values as alert ]
+
+                    [#assign monitoredResources = getMonitoredResources(resources, alert.Resource)]
+                    [#list monitoredResources as name,monitoredResource ]
+
+                        [@cfDebug listMode monitoredResource false /]
+
+                        [#switch alert.Comparison ]
+                            [#case "Threshold" ]
+                                [@createCountAlarm
+                                    mode=listMode
+                                    id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
+                                    severity=alert.Severity
+                                    resourceName=core.FullName
+                                    alertName=alert.Name
+                                    actions=[
+                                        getReference(formatSegmentSNSTopicId())
+                                    ]
+                                    metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
+                                    namespace=getResourceMetricNamespace(monitoredResource.Type)
+                                    description=alert.Description!alert.Name
+                                    threshold=alert.Threshold
+                                    statistic=alert.Statistic
+                                    evaluationPeriods=alert.Periods
+                                    period=alert.Time
+                                    operator=alert.Operator
+                                    reportOK=alert.ReportOk
+                                    missingData=alert.MissingData
+                                    dimensions=getResourceMetricDimensions(monitoredResource, resources)
+                                    dependencies=monitoredResource.Id
+                                /]
+                            [#break]
+                        [/#switch]
+                    [/#list]
+                [/#list]
+
                 [@createRDSInstance
                         mode=listMode
                         id=rdsId


### PR DESCRIPTION
Remove alarms when we hibernate a component and remove resources from the template. This prevents reference lookups in the templates 

Applied to 
 - cache 
 - rds