### PR TITLE
<feature> Expanded WAF Support for API Gateway

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -8,7 +8,7 @@
           "Title": "Zone A",
           "Name": "a",
           "Description": "Zone A",
-          "AWSZone": "ap-northeast-1a"          
+          "AWSZone": "ap-northeast-1a"
         },
         "c": {
           "Title": "Zone C",
@@ -2340,18 +2340,431 @@
       }
     }
   },
+  "WAFValueSets" : {
+    "default" : {
+      "badcookies" : ["bad-cookie"],
+      "badtokens" : ["bad-tokens"],
+      "loginpaths" : ["/login"],
+      "traversalpaths" : ["../","://"],
+      "adminpaths" : ["/admin"],
+      "adminips" : ["0.0.0.0/0"],
+      "phpquery" : [
+        "_SERVER[",
+        "_ENV[",
+        "auto_prepend_file=",
+        "auto_append_file=",
+        "allow_url_include=",
+        "disable_functions=",
+        "open_basedir=",
+        "safe_mode="
+      ],
+      "phpuri" : ["php", "/"],
+      "maxuri" : 1024,
+      "maxquery" : 1024,
+      "maxbody" : 4096,
+      "maxcookie" : 4093,
+      "csrfsize" : 36,
+      "uristartswith" : [
+        "/includes"
+      ],
+      "uriendswith" : [
+        ".cfg",
+        ".conf",
+        ".config",
+        ".ini",
+        ".log",
+        ".bak",
+        ".backup"
+      ],
+      "blacklistedips" : [],
+      "whitelistedips" : [],
+      "sqlheaders" : [
+        {"Type" : "HEADER", "Data" : "cookie"},
+        {"Type" : "HEADER", "Data" : "authorization"}
+      ],
+      "badcookieheaders" : [
+        {"Type" : "HEADER", "Data" : "cookie"}
+      ],
+      "badtokenheaders" : [
+        {"Type" : "HEADER", "Data" : "authorization"}
+      ],
+      "xssheaders" : [
+        {"Type" : "HEADER", "Data" : "cookie"}
+      ],
+      "csrfheaders" : [
+        "x-csrf-token"
+      ]
+    }
+  },
+  "WAFConditions" : {
+    "OWASP2017A1" : {
+      "Type" : "SqlInjectionMatch",
+      "Filters" : [
+        {
+          "FieldsToMatch" : [
+            {"Type": "URI"},
+            {"Type" : "QUERY_STRING"},
+            {"Type": "BODY"},
+            "sqlheaders"
+          ],
+          "Transformations" : ["URL_DECODE", "HTML_ENTITY_DECODE"]
+        }
+      ]
+    },
+    "OWASP2017A2-1" : {
+      "Type" : "ByteMatch",
+      "Description" : "Bad cookies",
+      "Filters" : [
+        {
+          "FieldsToMatch" : {"Type": "HEADER", "Data" : "cookie"},
+          "Constraints" : "CONTAINS",
+          "Targets" : ["badcookies"],
+          "Transformations" : ["URL_DECODE", "HTML_ENTITY_DECODE"]
+        }
+      ]
+    },
+    "OWASP2017A2-2" : {
+      "Type" : "ByteMatch",
+      "Description" : "Bad tokens",
+      "Filters" : [
+        {
+          "FieldsToMatch" : {"Type": "HEADER", "Data" : "authorisation"},
+          "Constraints" : "ENDS_WITH",
+          "Targets" : ["badtokens"],
+          "Transformations" : ["URL_DECODE", "HTML_ENTITY_DECODE"]
+        }
+      ]
+    },
+    "OWASP2017A2-3" : {
+      "Type" : "ByteMatch",
+      "Description" : "Login rate limiting",
+      "Filters" : [
+        {
+          "FieldsToMatch" : {"Type": "URI"},
+          "Constraints" : "STARTS_WITH",
+          "Targets" : ["loginpaths"],
+          "Transformations" : ["URL_DECODE", "HTML_ENTITY_DECODE"]
+        }
+      ]
+    },
+    "OWASP2017A3" : {
+      "Type" : "XssMatch",
+      "Filters" : [
+        {
+          "FieldsToMatch" : [
+            {"Type": "URI"},
+            {"Type" : "QUERY_STRING"},
+            {"Type": "BODY"},
+            "xssheaders"
+          ],
+          "Transformations" : ["URL_DECODE", "HTML_ENTITY_DECODE"]
+        }
+      ]
+    },
+    "OWASP2017A4-1" : {
+      "Type" : "ByteMatch",
+      "Description" : "Path traversal",
+      "Filters" : [
+        {
+          "FieldsToMatch" : [
+              {"Type": "URI"},
+              {"Type": "QUERY_STRING"}
+          ],
+          "Constraints" : "CONTAINS",
+          "Targets" : ["traversalpaths"],
+          "Transformations" : ["URL_DECODE", "HTML_ENTITY_DECODE"]
+        }
+      ]
+    },
+    "OWASP2017A4-2" : {
+      "Type" : "ByteMatch",
+      "Description" : "Admin Functions",
+      "Filters" : [
+        {
+          "FieldsToMatch" : {"Type": "URI"},
+          "Constraints" : "STARTS_WITH",
+          "Targets" : ["adminpaths"],
+          "Transformations" : "URL_DECODE"
+        }
+      ]
+    },
+    "OWASP2017A4-3" : {
+      "Type" : "IPMatch",
+      "Description" : "Admin Functions",
+      "Filters" : [
+        {
+          "Targets" : ["adminips"]
+        }
+      ]
+    },
+    "OWASP2017A5-PHP" : {
+      "Type" : "ByteMatch",
+      "Description" : "Insecure PHP Configuration",
+      "Filters" : [
+        {
+          "FieldsToMatch" : {"Type": "QUERY_STRING"},
+          "Constraints" : "CONTAINS",
+          "Targets" : ["phpquery"],
+          "Transformations" : "URL_DECODE"
+        },
+        {
+          "FieldsToMatch" : {"Type": "URI"},
+          "Constraints" : "ENDS_WITH",
+          "Targets" : ["phpuri"],
+          "Transformations" : "URL_DECODE"
+        }
+      ]
+    },
+    "OWASP2017A7" : {
+      "Type" : "SizeConstraint",
+      "Description" : "Basic size limits",
+      "Filters" : [
+        {
+          "FieldsToMatch" : {"Type": "URI"},
+          "Sizes" : ["maxuri"],
+          "Operators" : ["GT"],
+          "Transformations" : "NONE"
+        },
+        {
+          "FieldsToMatch" : {"Type": "QUERY_STRING"},
+          "Sizes" : ["maxquery"],
+          "Operators" : ["GT"],
+          "Transformations" : "NONE"
+        },
+        {
+          "FieldsToMatch" : {"Type": "BODY"},
+          "Sizes" : ["maxbody"],
+          "Operators" : ["GT"],
+          "Transformations" : "NONE"
+        },
+        {
+          "FieldsToMatch" : {"Type" : "HEADER", "Data" : "cookie"},
+          "Sizes" : ["maxcookie"],
+          "Operators" : ["GT"],
+          "Transformations" : "NONE"
+        }
+      ]
+    },
+    "OWASP2017A8-1" : {
+      "Type" : "ByteMatch",
+      "Description" : "CSRF Method",
+      "Filters" : [
+        {
+          "FieldsToMatch" : {"Type": "METHOD"},
+          "Constraints" : "EXACTLY",
+          "Targets" : ["post"],
+          "Transformations" : "LOWERCASE"
+        }
+      ]
+    },
+    "OWASP2017A8-2" : {
+      "Type" : "SizeConstraint",
+      "Description" : "CSRF Size",
+      "Filters" : [
+        {
+          "FieldsToMatch" : ["csrfheaders"],
+          "Sizes" : ["csrfsize"],
+          "Operators" : ["EQ"],
+          "Transformations" : "NONE"
+        }
+      ]
+    },
+    "OWASP2017A9" : {
+      "Type" : "ByteMatch",
+      "Description" : "Known vulnerabilities",
+      "Filters" : [
+        {
+          "FieldsToMatch" : {"Type": "URI"},
+          "Constraints" : "STARTS_WITH",
+          "Targets" : ["uristartswith"],
+          "Transformations" : "LOWERCASE"
+        },
+        {
+          "FieldsToMatch" : {"Type": "URI"},
+          "Constraints" : "ENDS_WITH",
+          "Targets" : ["uriendswith"],
+          "Transformations" : "LOWERCASE"
+        }
+      ]
+    },
+    "blacklist" : {
+      "Type" : "IPMatch",
+      "Description" : "Blacklist",
+      "Filters" : [
+        {
+          "Targets" : ["blacklistedips"]
+        }
+      ]
+    },
+    "whitelist" : {
+      "Type" : "IPMatch",
+      "Description" : "Whitelist",
+      "Filters" : [
+        {
+          "Targets" : ["whitelistedips"]
+        }
+      ]
+    }
+},
+  "WAFRules" : {
+    "OWASP2017A1" : {
+      "Description" : "SQL Injection protections",
+      "Conditions" : [
+        {
+          "Condition" : "OWASP2017A1",
+          "Negated" : false
+        }
+      ]
+    },
+    "OWASP2017A2" : {
+      "Description" : "Broken Tokens",
+      "Conditions" : [
+        {
+          "Condition" : "OWASP2017A2-1",
+          "Negated" : false
+        },
+        {
+          "Condition" : "OWASP2017A2-2",
+          "Negated" : false
+        }
+      ]
+    },
+    "OWASP2017A3" : {
+      "Description" : "Cross Site Scripting protections",
+      "Conditions" : [
+        {
+          "Condition" : "OWASP2017A3",
+          "Negated" : false
+        }
+      ]
+    },
+    "OWASP2017A4-1" : {
+      "Description" : "Path Traversal",
+      "Conditions" : [
+        {
+          "Condition" : "OWASP2017A4-1",
+          "Negated" : false
+        }
+      ]
+    },
+    "OWASP2017A4-2" : {
+      "Description" : "Admin path protections",
+      "Conditions" : [
+        {
+          "Condition" : "OWASP2017A4-2",
+          "Negated" : false
+        },
+        {
+          "Condition" : "OWASP2017A4-3",
+          "Negated" : true
+        }
+      ]
+    },
+    "OWASP2017A5-PHP" : {
+      "Description" : "PHP Specific protections",
+      "Conditions" : [
+        {
+          "Condition" : "OWASP2017A5-PHP",
+          "Negated" : false
+        }
+      ]
+    },
+    "OWASP2017A7" : {
+      "Description" : "Size Constraints",
+      "Conditions" : [
+        {
+          "Condition" : "OWASP2017A7",
+          "Negated" : false
+        }
+      ]
+    },
+    "OWASP2017A8" : {
+      "Description" : "CSRF Detection",
+      "Conditions" : [
+        {
+          "Condition" : "OWASP2017A8-1",
+          "Negated" : false
+        },
+        {
+          "Condition" : "OWASP2017A8-2",
+          "Negated" : true
+        }
+      ]
+    },
+    "OWASP2017A9" : {
+      "Description" : "Known Vulnerabilities",
+      "Conditions" : [
+        {
+          "Condition" : "OWASP2017A9",
+          "Negated" : false
+        }
+      ]
+    },
+    "blacklist" : {
+      "Description" : "Blacklist",
+      "Conditions" : [
+        {
+          "Condition" : "blacklist",
+          "Negated" : false
+        }
+      ]
+    },
+    "whitelist" : {
+      "Description" : "Whitelist",
+      "Conditions" : [
+        {
+          "Condition" : "whitelist",
+          "Negated" : false
+        }
+      ]
+    }
+  },
+  "WAFRuleGroups" : {
+    "OWASP2017-Basic" : {
+      "WAFRules" : [
+        "OWASP2017A1",
+        "OWASP2017A3",
+        "OWASP2017A7",
+        "OWASP2017A9"
+      ]
+    }
+  },
+  "WAFProfiles" : {
+    "OWASP2017" : {
+      "Rules" : [
+        {
+          "RuleGroup" : "OWASP2017-Basic",
+          "Action" : "BLOCK"
+        }
+      ],
+      "DefaultAction" : "ALLOW"
+    },
+    "whitelist" : {
+      "Rules" : [
+        {
+          "Rule" : "whitelist",
+          "Action" : "ALLOW"
+        }
+      ],
+      "DefaultAction" : "BLOCK"
+    }
+  },
   "SecurityProfiles": {
     "default": {
       "lb": {
         "application": {
-          "HTTPSProfile": "ELBSecurityPolicy-TLS-1-2-2017-01"
+          "HTTPSProfile": "ELBSecurityPolicy-TLS-1-2-2017-01",
+          "WAFProfile" : "OWASP2017",
+          "WAFValueSet" : "default"
         },
         "classic": {
           "HTTPSProfile": "ELBSecurityPolicy-2016-08"
         }
       },
       "apigateway": {
-        "HTTPSProfile": "TLSv1"
+        "HTTPSProfile": "TLSv1",
+        "WAFProfile" : "OWASP2017",
+        "WAFValueSet" : "default"
       },
       "spa": {
         "HTTPSProfile": "TLSv1"

--- a/aws/templates/account/account_waf.ftl
+++ b/aws/templates/account/account_waf.ftl
@@ -12,7 +12,7 @@
                     listMode,
                     ipSetId,
                     ipSetName,
-                    expandCIDR([8, 16..32], cidrs )
+                    expandCIDR([8, 16..32], cidrs)
                 /]
                 [@createWAFRule
                     listMode,

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -847,7 +847,7 @@ behaviour.
             [#case DATAPIPELINE_COMPONENT_TYPE ]
                 [#local result = getDataPipelineState(occurrence)]
                 [#break]
-            
+
             [#case DATAVOLUME_COMPONENT_TYPE ]
                 [#local result = getDataVolumeState(occurrence)]
                 [#break]
@@ -935,7 +935,7 @@ behaviour.
             [#case USERPOOL_COMPONENT_TYPE]
                 [#local result = getUserPoolState(occurrence, result)]
                 [#break]
-            
+
             [#case USERPOOL_CLIENT_COMPONENT_TYPE]
                 [#local result = getUserPoolClientState(occurrence, parentOccurrence)]
                 [#break]
@@ -951,7 +951,7 @@ behaviour.
             [#case NETWORK_COMPONENT_TYPE ]
                 [#local result = getNetworkState(occurrence)]
                 [#break]
-            
+
             [#case NETWORK_ROUTE_TABLE_COMPONENT_TYPE ]
                 [#local result = getNetworkRouteTableState(occurrence )]
                 [#break]
@@ -971,7 +971,7 @@ behaviour.
             [#case BASELINE_COMPONENT_TYPE ]
                 [#local result = getBaselineState(occurrence)]
                 [#break]
-            
+
             [#case BASELINE_DATA_COMPONENT_TYPE ]
                 [#local result = getBaselineStorageState(occurrence, parentOccurrence)]
                 [#break]
@@ -1396,7 +1396,7 @@ behaviour.
         [#local typeObject = component ]
     [/#if]
 
-    [#--  Deployment Profile Configuration Overrides --] 
+    [#--  Deployment Profile Configuration Overrides --]
     [#local deploymentProfileComponents = getDeploymentProfile(typeObject, deploymentMode) ]
     [#local typeObject = mergeObjects(typeObject, deploymentProfileComponents[type]!{} )]
 
@@ -1902,17 +1902,10 @@ behaviour.
 [/#function]
 
 [#function getSecurityProfile profileName type engine="" ]
-    [#local profile = {} ]
 
-    [#if (securityProfiles[profileName][type])??]
-        [#local profile = securityProfiles[profileName][type]]
-    [/#if]
+    [#local profile = (securityProfiles[profileName][type])!{} ]
+    [#return profile[engine]!profile ]
 
-    [#if engine?has_content && profile[engine]?has_content ]
-        [#return profile[engine] ]
-    [#else]
-        [#return profile ]
-    [/#if]
 [/#function]
 
 [#function getNetworkEndpoints endpointGroups zone region ]
@@ -1921,7 +1914,7 @@ behaviour.
 
     [#local regionObject = regions[region]]
     [#local zoneNetworkEndpoints = regionObject.Zones[zone].NetworkEndpoints ]
-    
+
     [#list endpointGroups as endpointGroup ]
         [#if networkEndpointGroups[endpointGroup]?? ]
             [#list networkEndpointGroups[endpointGroup].Services as service ]
@@ -1935,14 +1928,14 @@ behaviour.
     [#list services as service ]
         [#list zoneNetworkEndpoints as zoneNetworkEndpoint ]
             [#if (zoneNetworkEndpoint.ServiceName!"")?ends_with(service) ]
-                [#local networkEndpoints += 
-                    { 
-                        service : zoneNetworkEndpoint  
+                [#local networkEndpoints +=
+                    {
+                        service : zoneNetworkEndpoint
                     }]
             [/#if]
         [/#list]
     [/#list]
-    
+
     [#return networkEndpoints]
 [/#function]
 
@@ -1989,7 +1982,7 @@ behaviour.
             [/#if]
         [/#list]
     [/#if]
-    
+
     [#local deploymentProfile = {} ]
     [#list deploymentProfileNames as deploymentProfileName ]
         [#local deploymentProfile = mergeObjects( deploymentProfile, (deploymentProfiles[deploymentProfileName])!{} )]
@@ -2374,47 +2367,6 @@ behaviour.
 
 [/#function]
 
-[#-- WAF functions --]
-
-[#function getWAFDefault configuration={} ]
-    [#list configuration.IPAddressGroups as group]
-        [#if (getIPAddressGroup(group).IsOpen)!false ]
-            [#return "ALLOW" ]
-        [/#if]
-    [/#list]
-    [#return configuration.Default ]
-[/#function]
-
-[#function getWAFRules configuration={} ]
-    [#local result = [] ]
-
-    [#local wafDefault = getWAFDefault(configuration) ]
-    [#local wafRuleDefault = configuration.RuleDefault ]
-
-    [#list configuration.IPAddressGroups as group]
-        [#local addressGroup = getIPAddressGroup(group) ]
-        [#if ! addressGroup.IsOpen]
-            [#if group?is_hash]
-                [#local action = (group.Action?upper_case)!wafRuleDefault ]
-            [#else]
-                [#local action = wafRuleDefault ]
-            [/#if]
-            [#if (wafDefault == "ALLOW") && (action == "ALLOW") ]
-                [#-- more useful to count if default is allow --]
-                [#local action = "COUNT" ]
-            [/#if]
-            [#local result += [
-                    {
-                        "Id" : "${formatWAFIPSetRuleId(addressGroup)}",
-                        "Action" : "${action}"
-                    }
-                ]
-            ]
-        [/#if]
-    [/#list]
-    [#return result ]
-[/#function]
-
 [#function getResourceMetricDimensions resource resources]
     [#local resourceMetricAttributes = metricAttributes[resource.Type]!{} ]
 
@@ -2447,18 +2399,18 @@ behaviour.
                         [#local occurrenceDimensions += [{
                             "Name" : name,
                             "Value" : getReference(otherResource.Id, value.Property)
-                        }]]   
-                        [#break]      
+                        }]]
+                        [#break]
                     [#case "PseudoOutput" ]
                         [#local occurrenceDimensions += [{
                             "Name" : name,
                             "Value" : { "Ref" : value }
                         }]]
-                        [#break]          
+                        [#break]
                 [/#switch]
             [/#list]
         [/#list]
-        
+
         [#return occurrenceDimensions]
     [#else]
         [@cfException
@@ -2478,7 +2430,7 @@ behaviour.
             [#case "_productPath" ]
                 [#return formatProductRelativePath()]
                 [#break]
-            
+
             [#default]
                 [#return resourceTypeNameSpace]
         [/#switch]
@@ -2507,13 +2459,13 @@ behaviour.
 [#function getMonitoredResources resources, resourceQualifier ]
     [#local monitoredResources = {} ]
 
-    [#list resources as id,resource ] 
+    [#list resources as id,resource ]
 
-        [#if !resource["Type"]?has_content && resource?is_hash] 
+        [#if !resource["Type"]?has_content && resource?is_hash]
             [#list resource as id,subResource ]
                 [#local monitoredResources += getMonitoredResources({id : subResource}, resourceQualifier)]
             [/#list]
-        
+
         [#else]
 
             [#if resourceQualifier.Id?has_content || resourceQualifier.Type?has_content ]
@@ -2532,7 +2484,7 @@ behaviour.
 
             [#else]
 
-                [#if resource["Type"]?has_content] 
+                [#if resource["Type"]?has_content]
 
                     [#if resource["Monitored"]!false ]
                         [#local monitoredResources += {

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -482,9 +482,15 @@ created in either case.
     [#if wafPresent]
         [#local wafResources =
             {
+                "acl" : {
                     "Id" : formatDependentWAFAclId(apiId),
                     "Name" : formatComponentWAFAclName(core.Tier, core.Component, occurrence),
                     "Type" : AWS_WAF_ACL_RESOURCE_TYPE
+                },
+                "association" : {
+                    "Id" : formatDependentWAFAclAssociationId(apiId),
+                    "Type" : AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE
+                }
             } ]
     [/#if]
 
@@ -586,7 +592,7 @@ created in either case.
                 "logMetrics" : logMetrics
             } +
             attributeIfContent("cf", cfResources) +
-            attributeIfContent("wafacl", cfResources) +
+            attributeIfContent("wafacl", wafResources) +
             attributeIfContent("docs", docsResources) +
             attributeIfContent("customDomains", customDomainResources),
             "Attributes" : {

--- a/aws/templates/id/id_waf.ftl
+++ b/aws/templates/id/id_waf.ftl
@@ -8,6 +8,7 @@
 [#-- AWs hasn't defined any of interest                        --]
 [#assign AWS_WAF_RULE_RESOURCE_TYPE = "wafRule" ]
 [#assign AWS_WAF_ACL_RESOURCE_TYPE = "wafAcl" ]
+[#assign AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE = "wafAssoc" ]
 
 [#-- TODO(mfl): Deprecate direct creation of IPSet rule --]
 [#assign AWS_WAF_IPSET_RESOURCE_TYPE = "wafIpSet" ]
@@ -61,6 +62,19 @@
 [#function formatDependentWAFAclId resourceId extensions...]
     [#return formatDependentResourceId(
                 AWS_WAF_ACL_RESOURCE_TYPE,
+                resourceId,
+                extensions)]
+[/#function]
+
+[#function formatWAFAclAssociationId ids...]
+    [#return formatResourceId(
+                AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE,
+                ids)]
+[/#function]
+
+[#function formatDependentWAFAclAssociationId resourceId extensions...]
+    [#return formatDependentResourceId(
+                AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE,
                 resourceId,
                 extensions)]
 [/#function]

--- a/aws/templates/resource/start.ftl
+++ b/aws/templates/resource/start.ftl
@@ -49,7 +49,7 @@
 [/#function]
 
 [#function getArn idOrArn existingOnly=false inRegion=""]
-    [#if idOrArn?contains(":")]
+    [#if idOrArn?is_hash || idOrArn?contains(":")]
         [#return idOrArn]
     [#else]
         [#return

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -261,18 +261,6 @@
             "Names" : "OWASP",
             "Type" : BOOLEAN_TYPE,
             "Default" : false
-        },
-        {
-            "Names" : "Default",
-            "Type" : STRING_TYPE,
-            "Values" : ["ALLOW", "BLOCK"],
-            "Default" : "BLOCK"
-        },
-        {
-            "Names" : "RuleDefault",
-            "Type" : STRING_TYPE,
-            "Values" : ["ALLOW", "BLOCK"],
-            "Default" : "ALLOW"
         }
     ]
 ]
@@ -962,16 +950,16 @@
     [/#switch]
 [/#function]
 
-[#function getGroupCIDRs groups checkIsOpen=true occurrence={}]
+[#function getGroupCIDRs groups checkIsOpen=true occurrence={} asBoolean=false]
     [#local cidrs = [] ]
     [#list asFlattenedArray(groups) as group]
         [#local nextGroup = getIPAddressGroup(group, occurrence) ]
         [#if checkIsOpen && nextGroup.IsOpen!false]
-            [#return ["0.0.0.0/0"] ]
+            [#return valueIfTrue(false, asBoolean, ["0.0.0.0/0"]) ]
         [/#if]
         [#local cidrs += nextGroup.CIDR ]
     [/#list]
-    [#return cidrs]
+    [#return valueIfTrue(true, asBoolean, cidrs) ]
 [/#function]
 
 


### PR DESCRIPTION
Add support for global and regional WAF configurations

Generate endpoint specific WAF rules/acl so no need for account level
configuration.

Add configuration support for profiles of WAF rules, initially to
support the OWASP 2017 rules sets.

Separate sets of values that may vary between uses of the OWASP rules
from the rules themselves.

Add a default resource policy that ensures the default stage used for
deployments cannotbe accessed via the API.