### PR TITLE
<feat> SPA Path based routing to LB

### DIFF
--- a/aws/templates/id/id_spa.ftl
+++ b/aws/templates/id/id_spa.ftl
@@ -139,6 +139,48 @@
                                     "Mandatory" : true
                                 }
                             ]
+                        },
+                        {
+                            "Names" : "Paths",
+                            "Subobjects" : true,
+                            "Description" : "Additional path based routes to other components",
+                            "Children" : [
+                                {
+                                    "Names" : "PathPattern",
+                                    "Type" : STRING_TYPE,
+                                    "Mandatory" : true
+                                },
+                                {
+                                    "Names" : "Link",
+                                    "Children" : linkChildrenConfiguration,
+                                    "Mandatory" : true
+                                },
+                                {
+                                    "Names" : "CachingTTL",
+                                    "Children" : [
+                                        {
+                                            "Names" : "Default",
+                                            "Type" : NUMBER_TYPE,
+                                            "Default" : 600
+                                        },
+                                        {
+                                            "Names" : "Maximum",
+                                            "Type" : NUMBER_TYPE,
+                                            "Default" : 31536000
+                                        },
+                                        {
+                                            "Names" : "Minimum",
+                                            "Type" : NUMBER_TYPE,
+                                            "Default" : 0
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Names" : "Compress",
+                                    "Type" : BOOLEAN_TYPE,
+                                    "Default" : false
+                                }
+                            ]
                         }
                     ]
                 },
@@ -175,6 +217,18 @@
             [#local fqdn = getExistingReference(cfId,DNS_ATTRIBUTE_TYPE)]
     [/#if]
 
+    [#assign pathResources = {}]
+    [#list solution.CloudFront.Paths as id,path ]
+        [#assign pathResources += {
+            id : {
+                "cforigin" : {
+                    "Id" : id,
+                    "Type" : AWS_CLOUDFRONT_ORIGIN_RESOURCE_TYPE
+                }
+            }
+        }]
+    [/#list]
+
     [#return
         {
             "Resources" : {
@@ -195,7 +249,8 @@
                     "Id" : formatDependentWAFAclId(cfId),
                     "Name" : formatComponentWAFAclName(core.Tier, core.Component, occurrence),
                     "Type" : AWS_WAF_ACL_RESOURCE_TYPE
-                }
+                },
+                "paths" : pathResources
             },
             "Attributes" : {
                 "FQDN" : fqdn,

--- a/aws/templates/id/id_spa.ftl
+++ b/aws/templates/id/id_spa.ftl
@@ -249,9 +249,9 @@
                     "Id" : formatDependentWAFAclId(cfId),
                     "Name" : formatComponentWAFAclName(core.Tier, core.Component, occurrence),
                     "Type" : AWS_WAF_ACL_RESOURCE_TYPE
-                },
-                "paths" : pathResources
-            },
+                }
+            } + 
+            attributeIfContent( "paths", pathResources ),
             "Attributes" : {
                 "FQDN" : fqdn,
                 "URL" : "https://" + fqdn

--- a/aws/templates/resource/resource_cf.ftl
+++ b/aws/templates/resource/resource_cf.ftl
@@ -130,6 +130,40 @@
     ]
 [/#function]
 
+[#function getCFLBCacheBehaviour origin path="" ttl={"Default" : 600} compress=true forwardHeaders=[] eventHandlers=[] ]
+        [#return
+        getCFCacheBehaviour(
+            origin,
+            path,
+            {
+                "Allowed" : [
+                    "DELETE",
+                    "GET",
+                    "HEAD",
+                    "OPTIONS",
+                    "PATCH",
+                    "POST",
+                    "PUT"
+                ],
+                "Cached" : [
+                    "GET",
+                    "HEAD"
+                ]
+            },
+            ttl,
+            {
+                "Cookies" : {
+                    "Forward" : "all"
+                },
+                "Headers" : forwardHeaders,
+                "QueryString" : true
+            },
+            compress,
+            eventHandlers
+        )
+    ]
+[/#function]
+
 [#function getCFAPIGatewayCacheBehaviour origin customHeaders=[] compress=true]
     [#return
         getCFCacheBehaviour(

--- a/aws/templates/solution/solution_spa.ftl
+++ b/aws/templates/solution/solution_spa.ftl
@@ -191,7 +191,7 @@
                 _context.ForwardHeaders) ]
             [#assign cacheBehaviours += configCacheBehaviour ]
 
-            [#list resources["paths"] as id, path ]
+            [#list resources["paths"]!{} as id, path ]
                 [#assign pathOriginIdId = path["cforigin"]["Id"] ]
                 [#assign pathSolution = solution.CloudFront.Paths[id] ]
 


### PR DESCRIPTION
Adds support for custom routing paths on SPAs. This allows specifc paths to be routed to a other components - currently LB ports are supported 

Example
```
                "www" : {
                    "spa" : {
                        "Instances" : {
                            "default" : {
                                "Versions" : {
                                    "v1" : {
                                        "DeploymentUnits" : ["www-v1"]
                                    }
                                }
                            }
                        },
                        "CloudFront" : {
                            "Paths" : {
                                "api" : {
                                    "PathPattern" : "/api/*",
                                    "Link" : {
                                        "Tier" : "elb",
                                        "Component" : "api-lb",
                                        "Port" : "httpsapi"
                                    }
                                }
                            }
                        }
                    }
                }
``` 

This example would route requests for `/api/*` to the api-lb httpsapi public endpoint  