### PR TITLE
<fix> remove sensitve variables from mobile apps

### DIFF
--- a/aws/runExpoAppPublish.sh
+++ b/aws/runExpoAppPublish.sh
@@ -242,6 +242,7 @@ function main() {
   fi
 
   # Update the app.json with build context information - Also ensure we always have a unique IOS build number
+  # filter out the credentials used for the build process
   jq --slurpfile envConfig "${OPS_PATH}/config.json" '.expo.extra.build_reference=env.BUILD_REFERENCE | .expo.ios.buildNumber=env.BUILD_NUMBER | .expo.extra= .expo.extra + $envConfig[]' <  "./app.json" > "${tmpdir}/environment-app.json"  
   mv "${tmpdir}/environment-app.json" "./app.json"
 

--- a/aws/templates/application/application_mobileapp.ftl
+++ b/aws/templates/application/application_mobileapp.ftl
@@ -29,7 +29,7 @@
                 "Environment" : {},
                 "Links" : contextLinks,
                 "DefaultCoreVariables" : false,
-                "DefaultEnvironmentVariables" : false,
+                "DefaultEnvironmentVariables" : true,
                 "DefaultLinkVariables" : false
             }
         ]
@@ -39,7 +39,7 @@
         [#assign fragmentId = formatFragmentId(_context)]
         [#include fragmentList?ensure_starts_with("/")]
 
-        [#assign finalAsFileEnvironment = getFinalEnvironment(occurrence, _context) ]
+        [#assign finalAsFileEnvironment = getFinalEnvironment(occurrence, _context, { "Json" : { "Include" : { "Sensitive" : false }}}) ]
 
         [#if deploymentSubsetRequired("config", false)]
             [@cfConfig

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -450,6 +450,7 @@
 [#function getFinalEnvironment occurrence context environmentSettings={}]
     [#local asFile = environmentSettings.AsFile!false]
     [#local serialisationConfig = environmentSettings.Json!{}]
+
     [#return
         {
             "Environment" :


### PR DESCRIPTION
Remove sensitive variables from mobile apps as they should not be included in binary app builds 

A mobile app would not have permissions to decrypt encrypted values and its possible to access these values without authenticating