### PR TITLE
<bugfix> Conditionally create logmetric resources

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -515,7 +515,7 @@
                 [/#list]
             [/#list]
 
-            [#list resources.logMetrics as logMetricName,logMetric ]
+            [#list resources.logMetrics!{} as logMetricName,logMetric ]
 
                 [@createLogMetric
                     mode=listMode

--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -580,7 +580,7 @@
                     [/#if]
                 [/#list]
 
-                [#list resources.logMetrics as logMetricName,logMetric ]
+                [#list resources.logMetrics!{} as logMetricName,logMetric ]
 
                     [@createLogMetric
                         mode=listMode

--- a/aws/templates/application/application_lambda.ftl
+++ b/aws/templates/application/application_lambda.ftl
@@ -241,7 +241,7 @@
                 [/#if]
 
                 [#if solution.PredefineLogGroup && deploymentType == "REGIONAL"]
-                    [#list resources.logMetrics as logMetricName,logMetric ]
+                    [#list resources.logMetrics!{} as logMetricName,logMetric ]
 
                         [@createLogMetric
                             mode=listMode

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -588,9 +588,9 @@ created in either case.
                     "Id" : accessLgId,
                     "Name" : accessLgName,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
-                },
-                "logMetrics" : logMetrics
+                }
             } +
+            attributeIfContent("logMetrics", logMetrics) +
             attributeIfContent("cf", cfResources) +
             attributeIfContent("wafacl", wafResources) +
             attributeIfContent("docs", docsResources) +

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -508,9 +508,9 @@
                     "Id" : lgInstanceLogId,
                     "Name" : lgInstanceLogName,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
-                },
-                "logMetrics" : logMetrics
-            },
+                }
+            } +
+            attributeIfContent("logMetrics", logMetrics),
             "Attributes" : {
             },
             "Roles" : {
@@ -558,16 +558,16 @@
                     "Name" : taskName,
                     "Type" : AWS_ECS_TASK_RESOURCE_TYPE
                 }
-            } + 
+            } +
             solution.TaskLogGroup?then(
                 {
                     "lg" : {
                         "Id" : lgId,
                         "Name" : lgName,
                         "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
-                    },
-                    "logMetrics" : logMetrics
-                },
+                    }
+                } +
+                attributeIfContent("logMetrics", logMetrics),
                 {}
             ) +
             attributeIfTrue(
@@ -648,9 +648,9 @@
                         "Id" : lgId,
                         "Name" : lgName,
                         "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
-                    },
-                    "logMetrics" : logMetrics
-                },
+                    }
+                } +
+                attributeIfContent("logMetrics", logMetrics),
                 {}
             ) +
             attributeIfTrue(
@@ -660,7 +660,7 @@
                     "Id" : taskRoleId,
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
                 }
-            ) + 
+            ) +
             attributeIfContent(
                 "scheduleRole",
                 solution.Schedules,
@@ -668,7 +668,7 @@
                     "Id" : formatDependentRoleId(taskId, "schedule"),
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
                 }
-            ) + 
+            ) +
             attributeIfTrue(
                 "securityGroup",
                 solution.NetworkMode == "awsvpc",

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -275,9 +275,9 @@
                     "Id" : formatLogGroupId(core.Id),
                     "Name" : lgName,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
-                },
-                "logMetrics" : logMetrics
+                }
             } +
+            attributeIfContent("logMetrics", logMetrics) +
             attributeIfTrue(
                 "version",
                 fixedCodeVersion,

--- a/aws/templates/id/id_mobilenotifier.ftl
+++ b/aws/templates/id/id_mobilenotifier.ftl
@@ -98,7 +98,7 @@
                         }
                     ]
                 },
-                { 
+                {
                     "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
@@ -210,9 +210,9 @@
                     "Id" : lgFailureId,
                     "Name" : lgFailureName,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
-                },
-                "logMetrics" : logMetrics
-            },
+                }
+            } +
+            attributeIfContent("logMetrics", logMetrics),
             "Attributes" : {
                 "ARN" : (engine == MOBILENOTIFIER_SMS_ENGINE)?then(
                             formatArn(

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -27,14 +27,14 @@
         [#assign defaultLogDriver = solution.LogDriver ]
         [#assign fixedIP = solution.FixedIP ]
 
-        [#assign hibernate = solution.Hibernate.Enabled && 
+        [#assign hibernate = solution.Hibernate.Enabled &&
                                 getExistingReference(ecsId)?has_content ]
 
         [#assign logFileProfile = getLogFileProfile(tier, component, "ECS")]
         [#assign bootstrapProfile = getBootstrapProfile(tier, component, "ECS")]
         [#assign processorProfile = getProcessor(tier, component, "ECS")]
         [#assign storageProfile = getStorage(tier, component, "ECS")]
-    
+
         [#assign networkLink = tier.Network.Link!{} ]
 
         [#assign networkLinkTarget = getLinkTarget(occurrence, networkLink ) ]
@@ -59,7 +59,7 @@
                         component,
                         "",
                         true)]
-        
+
         [#assign environmentVariables = {}]
 
         [#assign configSetName = componentType ]
@@ -100,16 +100,16 @@
 
         [#assign environmentVariables += getFinalEnvironment(occurrence, _context).Environment ]
 
-        [#assign configSets += 
+        [#assign configSets +=
             getInitConfigEnvFacts(environmentVariables, false) +
             getInitConfigDirsFiles(_context.Files, _context.Directories) ]
-        
+
         [#list bootstrapProfile.BootStraps as bootstrapName ]
             [#assign bootstrap = bootstraps[bootstrapName]]
             [#assign configSets +=
                 getInitConfigUserBootstrap(bootstrap, environmentVariables )!{}]
         [/#list]
-            
+
         [#if deploymentSubsetRequired("iam", true) &&
                 isPartOfCurrentDeploymentUnit(ecsRoleId)]
             [#assign linkPolicies = getLinkTargetsOutboundRoles(_context.Links) ]
@@ -187,7 +187,7 @@
                 [#assign linkTargetConfiguration = linkTarget.Configuration ]
                 [#assign linkTargetResources = linkTarget.State.Resources ]
                 [#assign linkTargetAttributes = linkTarget.State.Attributes ]
-                
+
                 [#switch linkTargetCore.Type]
                     [#case EFS_MOUNT_COMPONENT_TYPE]
                         [#assign configSets +=
@@ -207,7 +207,7 @@
                 component=component
                 vpcId=vpcId /]
 
-            [#list resources.logMetrics as logMetricName,logMetric ]
+            [#list resources.logMetrics!{} as logMetricName,logMetric ]
 
                 [@createLogMetric
                     mode=listMode
@@ -304,7 +304,7 @@
                     getInitConfigEIPAllocation(allocationIds)]
             [/#if]
 
-            [@createEc2AutoScaleGroup 
+            [@createEc2AutoScaleGroup
                 mode=listMode
                 id=ecsAutoScaleGroupId
                 tier=tier

--- a/aws/templates/solution/solution_mobilenotifier.ftl
+++ b/aws/templates/solution/solution_mobilenotifier.ftl
@@ -135,7 +135,7 @@
 
             [#if deploymentSubsetRequired(MOBILENOTIFIER_COMPONENT_TYPE, true)]
 
-                [#list resources.logMetrics as logMetricName,logMetric ]
+                [#list resources.logMetrics!{} as logMetricName,logMetric ]
 
                     [@createLogMetric
                         mode=listMode
@@ -226,10 +226,10 @@
                                 "       \"" + engine + "\" " +
                                 "       \"$\{tmpdir}/cli-" +
                                         platformAppAttributesCliId + "-" + platformAppAttributesCommand + ".json\")\""
-                            ] + 
+                            ] +
                             pseudoStackOutputScript(
                                 "SNS Platform App",
-                                { 
+                                {
                                     formatId(platformAppId, "arn") : "$\{platform_app_arn}",
                                     platformAppId : core.Name
                                 },


### PR DESCRIPTION
At present, a logMetrics resource attribute is always being added in the
state of any component that supports them.

This causes getLinkTarget to always return the component as deployed even
if it is not.

This change makes creation of logMetric resources conditional on at
least one logMetric being defined.