### PR TITLE
<refactor>Data pipeline resource creation cleanup

### DIFF
--- a/aws/templates/id/id_datapipeline.ftl
+++ b/aws/templates/id/id_datapipeline.ftl
@@ -87,13 +87,8 @@
                     "Id" : formatResourceId( AWS_IAM_ROLE_RESOURCE_TYPE, core.Id, "pipeline" ),
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
                 },
-                "resourceInstanceProfile" : {
-                    "Id" : formatResourceId( AWS_EC2_INSTANCE_PROFILE_RESOURCE_TYPE, core.Id ),
-                    "Type" : AWS_EC2_INSTANCE_PROFILE_RESOURCE_TYPE
-                },
                 "resourceRole" : {
                     "Id" : formatResourceId( AWS_IAM_ROLE_RESOURCE_TYPE, core.Id, "resource" ),
-                    "Name" : core.FullName,
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
                 },
                 "securityGroup" : {

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -981,8 +981,30 @@ function update_data_pipeline() {
   local definitionfile="$1"; shift
   local parameterobjectfile="$1"; shift
   local parametervaluefile="$1"; shift
+  local cfnStackName="$1"; shift
+  local securityGroupId="$1"; shift
+  local pipelineRoleId="$1"; shift 
+  local resourceRoleId="$1"; shift
 
-  pipeline_details="$(aws --region "${region}" datapipeline put-pipeline-definition --pipeline-id "${pipelineid}" --pipeline-definition "file://${definitionfile}" --parameter-objects "file://${parameterobjectfile}" --parameter-values-uri "file://${parametervaluefile}" )"
+  # Add resources created during stack creation 
+  securityGroup="$(get_cloudformation_stack_output "${region}" "${cfnStackName}" "${securityGroupId}" "ref" || return $?)"
+
+  if [[ "${pipelineRoleId}" != arn:* ]]; then
+    pipelineRole="$(get_cloudformation_stack_output "${region}" "${cfnStackName}" "${pipelineRoleId}" "ref" || return $?)" 
+  else
+    pipelineRole="${pipelieRoleId}"
+  fi
+  
+  if [[ "${resourceRoleId}" != arn:* ]]; then
+    resourceRole="$(get_cloudformation_stack_output "${region}" "${cfnStackName}" "${resourceRoleId}" "ref" || return $?)" 
+  else
+    resourceRole="${resourceRoleId}"
+  fi 
+
+  arnLookupValueFile="$(filePath ${parametervaluefile})/ArnLookup-$(fileBase ${parametervaluefile})"
+  jq --arg pipelineRole "${pipelineRole}" --arg resourceRole "${resourceRole}" --arg securityGroup "${securityGroup}" '.my_SECURITY_GROUP_ID = $securityGroup | .my_ROLE_PIPELINE_NAME = $pipelineRole | .my_ROLE_RESOURCE_NAME = $resourceRole' < "${parametervaluefile}" > "${arnLookupValueFile}"
+
+  pipeline_details="$(aws --region "${region}" datapipeline put-pipeline-definition --pipeline-id "${pipelineid}" --pipeline-definition "file://${definitionfile}" --parameter-objects "file://${parameterobjectfile}" --parameter-values-uri "file://${arnLookupValueFile}" )"
   pipeline_errored="$(echo "${pipeline_details}" | jq -r '.errored ')"
 
   if [[ "${pipeline_errored}" == "false" ]]; then

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -990,13 +990,13 @@ function update_data_pipeline() {
   securityGroup="$(get_cloudformation_stack_output "${region}" "${cfnStackName}" "${securityGroupId}" "ref" || return $?)"
 
   if [[ "${pipelineRoleId}" != arn:* ]]; then
-    pipelineRole="$(get_cloudformation_stack_output "${region}" "${cfnStackName}" "${pipelineRoleId}" "ref" || return $?)" 
+    pipelineRole="$(get_cloudformation_stack_output "${region}" "${cfnStackName}" "${pipelineRoleId}" "arn" || return $?)" 
   else
     pipelineRole="${pipelieRoleId}"
   fi
   
   if [[ "${resourceRoleId}" != arn:* ]]; then
-    resourceRole="$(get_cloudformation_stack_output "${region}" "${cfnStackName}" "${resourceRoleId}" "ref" || return $?)" 
+    resourceRole="$(get_cloudformation_stack_output "${region}" "${cfnStackName}" "${resourceRoleId}" "arn" || return $?)" 
   else
     resourceRole="${resourceRoleId}"
   fi 


### PR DESCRIPTION
When pipelines were first implemented all resources were created in the IAM stack so that they were available to reference in the pipeline values file. 

Instead this refactor creates the resources as normal and then we lookup the cloudformation stack outputs to find out the details of resources created during the template pass. 

This is mainly to reduce the number of outputs created in the iam stack when deploying a large number of resources 