### PR TITLE
<feat> rds replace through delete

### DIFF
--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -333,6 +333,10 @@
                                 solution.Backup.SnapshotOnDeploy,
                                 rdsRestoreSnapshot)]
                     [/#if]
+
+                    [#if solution.Backup.UpdateReplacePolicy == "Delete" ]
+                        [#assign hibernate = true ]
+                    [/#if]
                 [#break]
 
                 [#case "replace2"]


### PR DESCRIPTION
When running an RDS replacement we spin up a new RDS instance using the snapshot created at the start of the process then do it again. 

This adds the option to instead remove the RDS instance in the replace 1 template and then create a new one in the replace 2 template instead of migrating to one and then to another