### PR TITLE
<fix> Disable predefined resources which are not required

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1325,12 +1325,14 @@
         "seg-dns": {
           "DeploymentUnits": [
             "dns"
-          ]
+          ],
+          "Enabled" : false
         },
         "seg-dashboard": {
           "DeploymentUnits": [
             "dashboard"
-          ]
+          ],
+          "Enabled" : false
         },
         "baseline" :{
           "DeploymentUnits" : [ "baseline" ],
@@ -1529,9 +1531,8 @@
               "default": {
                 "Versions": {
                   "v1": {
-                    "DeploymentUnits": [
-                      "cfredirect-v1"
-                    ],
+                    "DeploymentUnits": [ "cfredirect-v1" ],
+                    "Enabled" : false,
                     "Fragment": "_cfredirect-v1"
                   }
                 }


### PR DESCRIPTION
We have a couple of baked in components which aren't required by all solutions. This disables them and means that the would have to be explicitly enabled in solutions which use them 

