### PR TITLE
<refactor> Reduce rules needed for basic OWASP

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -2610,6 +2610,7 @@
   "WAFRules" : {
     "OWASP2017A1" : {
       "Description" : "SQL Injection protections",
+      "NameSuffix" : "owasp-sql",
       "Conditions" : [
         {
           "Condition" : "OWASP2017A1",
@@ -2619,6 +2620,7 @@
     },
     "OWASP2017A2" : {
       "Description" : "Broken Tokens",
+      "NameSuffix" : "owasp-tokens",
       "Conditions" : [
         {
           "Condition" : "OWASP2017A2-1",
@@ -2632,6 +2634,7 @@
     },
     "OWASP2017A3" : {
       "Description" : "Cross Site Scripting protections",
+      "NameSuffix" : "owasp-xss",
       "Conditions" : [
         {
           "Condition" : "OWASP2017A3",
@@ -2641,6 +2644,7 @@
     },
     "OWASP2017A4-1" : {
       "Description" : "Path Traversal",
+      "NameSuffix" : "owasp-paths",
       "Conditions" : [
         {
           "Condition" : "OWASP2017A4-1",
@@ -2650,6 +2654,7 @@
     },
     "OWASP2017A4-2" : {
       "Description" : "Admin path protections",
+      "NameSuffix" : "owasp-admin-paths",
       "Conditions" : [
         {
           "Condition" : "OWASP2017A4-2",
@@ -2663,6 +2668,7 @@
     },
     "OWASP2017A5-PHP" : {
       "Description" : "PHP Specific protections",
+      "NameSuffix" : "owasp-php",
       "Conditions" : [
         {
           "Condition" : "OWASP2017A5-PHP",
@@ -2672,6 +2678,7 @@
     },
     "OWASP2017A7" : {
       "Description" : "Size Constraints",
+      "NameSuffix" : "owasp-size",
       "Conditions" : [
         {
           "Condition" : "OWASP2017A7",
@@ -2681,6 +2688,7 @@
     },
     "OWASP2017A8" : {
       "Description" : "CSRF Detection",
+      "NameSuffix" : "owasp-csrf",
       "Conditions" : [
         {
           "Condition" : "OWASP2017A8-1",
@@ -2694,7 +2702,30 @@
     },
     "OWASP2017A9" : {
       "Description" : "Known Vulnerabilities",
+      "NameSuffix" : "owasp-vulnerabilities",
       "Conditions" : [
+        {
+          "Condition" : "OWASP2017A9",
+          "Negated" : false
+        }
+      ]
+    },
+    "OWASP2017-Basic" : {
+      "Description" : "Minimal checks",
+      "NameSuffix" : "owasp-basic",
+      "Conditions" : [
+        {
+          "Condition" : "OWASP2017A1",
+          "Negated" : false
+        },
+        {
+          "Condition" : "OWASP2017A3",
+          "Negated" : false
+        },
+        {
+          "Condition" : "OWASP2017A7",
+          "Negated" : false
+        },
         {
           "Condition" : "OWASP2017A9",
           "Negated" : false
@@ -2703,6 +2734,7 @@
     },
     "blacklist" : {
       "Description" : "Blacklist",
+      "NameSuffix" : "blacklist",
       "Conditions" : [
         {
           "Condition" : "blacklist",
@@ -2712,6 +2744,7 @@
     },
     "whitelist" : {
       "Description" : "Whitelist",
+      "NameSuffix" : "whitelist",
       "Conditions" : [
         {
           "Condition" : "whitelist",
@@ -2723,10 +2756,7 @@
   "WAFRuleGroups" : {
     "OWASP2017-Basic" : {
       "WAFRules" : [
-        "OWASP2017A1",
-        "OWASP2017A3",
-        "OWASP2017A7",
-        "OWASP2017A9"
+        "OWASP2017-Basic"
       ]
     }
   },

--- a/aws/templates/resource/resource_waf.ftl
+++ b/aws/templates/resource/resource_waf.ftl
@@ -260,10 +260,10 @@
         [#local conditionName = condition.Name!conditionId]
         [#-- Generate id/name from rule equivalents if not provided --]
         [#if !conditionId?has_content]
-            [#local conditionId = formatDependentWAFConditionId(condition.Type, id, condition?counter)]
+            [#local conditionId = formatDependentWAFConditionId(condition.Type, id, "c" + condition?counter?c)]
         [/#if]
         [#if !conditionName?has_content]
-            [#local conditionName = formatName(name,condition.Type,condition?counter)]
+            [#local conditionName = formatName(name,"c" + condition?counter?c,condition.Type)]
         [/#if]
         [#if condition.Filters?has_content]
             [#-- Condition to be created with the rule --]
@@ -326,13 +326,13 @@
             [#-- Rule to be created with the acl --]
             [#-- Generate id/name/metric from acl equivalents if not provided --]
             [#if !ruleId?has_content]
-                [#local ruleId = formatDependentWAFRuleId(id,"rule",rule?counter)]
+                [#local ruleId = formatDependentWAFRuleId(id,"r" + rule?counter?c)]
             [/#if]
             [#if !ruleName?has_content]
-                [#local ruleName = formatName(name,"rule",rule?counter)]
+                [#local ruleName = formatName(name,"r" + rule?counter?c,rule.NameSuffix!"")]
             [/#if]
             [#if !ruleMetric?has_content]
-                [#local ruleMetric = formatId(metric,"rule",rule?counter)]
+                [#local ruleMetric = formatId(metric,"r" + rule?counter?c)]
             [/#if]
             [#if rule.Conditions?has_content]
                 [@createWAFRule
@@ -397,7 +397,13 @@
                     ] ]
                 [/#if]
             [/#list]
-            [#local result += [{"Conditions" : conditionList, "Action" : ruleEntry.Action}] ]
+            [#local result += [
+                {
+                    "Conditions" : conditionList,
+                    "Action" : ruleEntry.Action
+                } +
+                attributeIfContent("NameSuffix", rules[ruleListEntry].NameSuffix!"")
+            ] ]
         [/#list]
     [/#list]
     [#return result]


### PR DESCRIPTION
WAF charges per ACL and per rule so good to minimise the number of rules
as far as possible. The basic OWASP checks can be combined in a single
rule since if any of them matches, the rule fires and the request can be
blocked.

Also rework the naming of rules and conditions to provide more informative
values in the console.