### PR TITLE
<feature>Processor profiles for occurrences

### DIFF
--- a/aws/templates/application/application_computecluster.ftl
+++ b/aws/templates/application/application_computecluster.ftl
@@ -27,7 +27,7 @@
         [#assign logFileProfile = getLogFileProfile(tier, component, "ComputeCluster")]
         [#assign bootstrapProfile = getBootstrapProfile(tier, component, "ComputeCluster")]
         [#assign storageProfile = getStorage(tier, component, "ComputeCluster")]
-        [#assign processorProfile = getProcessor(tier, component, "ComputeCluster")]
+        [#assign processorProfile = getProcessor(occurrence, "ComputeCluster")]
 
         [#assign networkLink = tier.Network.Link!{} ]
 

--- a/aws/templates/application/application_datapipeline.ftl
+++ b/aws/templates/application/application_datapipeline.ftl
@@ -25,8 +25,8 @@
         [#assign securityGroupId = resources["securityGroup"].Id]
         [#assign securityGroupName = resources["securityGroup"].Name]
 
-        [#assign ec2ProcessorProfile = getProcessor(tier, component, "EC2")]
-        [#assign emrProcessorProfile = getProcessor(tier, component, "EMR")]
+        [#assign ec2ProcessorProfile = getProcessor(occurrence, "EC2")]
+        [#assign emrProcessorProfile = getProcessor(occurrence, "EMR")]
 
         [#assign pipelineCreateCommand = "createPipeline"]
      

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1847,12 +1847,12 @@ behaviour.
 [/#function]
 
 [#-- Get processor settings --]
-[#function getProcessor tier component type extensions...]
-    [#local tc = formatComponentShortName(
-                    tier,
-                    component,
-                    extensions)]
-    [#local defaultProfile = "default"]
+[#function getProcessor occurrence type ]
+
+    [#local tc = formatComponentShortName( occurrence.Core.Tier.Id, occurrence.Core.Component.Id)]
+
+    [#local processorProfile = occurrence.Configuration.Solution.Profiles.Processor ]
+    
     [#if (component[type].Processor)??]
         [#return component[type].Processor]
     [/#if]
@@ -1862,11 +1862,11 @@ behaviour.
     [#if (processors[solutionObject.CapacityProfile][type])??]
         [#return processors[solutionObject.CapacityProfile][type]]
     [/#if]
-    [#if (processors[defaultProfile][tc])??]
-        [#return processors[defaultProfile][tc]]
+    [#if (processors[processorProfile][tc])??]
+        [#return processors[processorProfile][tc]]
     [/#if]
-    [#if (processors[defaultProfile][type])??]
-        [#return processors[defaultProfile][type]]
+    [#if (processors[processorProfile][type])??]
+        [#return processors[processorProfile][type]]
     [/#if]
     [#return {}]
 [/#function]

--- a/aws/templates/id/id_bastion.ftl
+++ b/aws/templates/id/id_bastion.ftl
@@ -44,7 +44,14 @@
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
+                    "Children" : profileChildConfiguration + 
+                                    [
+                                        {
+                                            "Names" : "Processor",
+                                            "Type" : STRING_TYPE,
+                                            "Default" : "default"
+                                        }
+                                    ]
                 },
                 {
                     "Names" : "AutoScaling",

--- a/aws/templates/id/id_cache.ftl
+++ b/aws/templates/id/id_cache.ftl
@@ -51,7 +51,14 @@
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
+                    "Children" : profileChildConfiguration + 
+                                    [
+                                        {
+                                            "Names" : "Processor",
+                                            "Type" : STRING_TYPE,
+                                            "Default" : "default"
+                                        }
+                                    ]
                 },
                 {
                     "Names" : "Hibernate",

--- a/aws/templates/id/id_computecluster.ftl
+++ b/aws/templates/id/id_computecluster.ftl
@@ -31,7 +31,14 @@
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
+                    "Children" : profileChildConfiguration + 
+                                    [
+                                        {
+                                            "Names" : "Processor",
+                                            "Type" : STRING_TYPE,
+                                            "Default" : "default"
+                                        }
+                                    ]
                 },
                 {
                     "Names" : "UseInitAsService",

--- a/aws/templates/id/id_datapipeline.ftl
+++ b/aws/templates/id/id_datapipeline.ftl
@@ -61,7 +61,14 @@
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
+                    "Children" : profileChildConfiguration + 
+                                    [
+                                        {
+                                            "Names" : "Processor",
+                                            "Type" : STRING_TYPE,
+                                            "Default" : "default"
+                                        }
+                                    ]
                 }
             ]
         }

--- a/aws/templates/id/id_ec2.ftl
+++ b/aws/templates/id/id_ec2.ftl
@@ -121,7 +121,14 @@
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
+                    "Children" : profileChildConfiguration +
+                                    [
+                                        {
+                                            "Names" : "Processor",
+                                            "Type" : STRING_TYPE,
+                                            "Default" : "default"
+                                        }
+                                    ]
                 },
                 {
                     "Names" : "Ports",

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -154,7 +154,14 @@
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
+                    "Children" : profileChildConfiguration +
+                                    [
+                                        {
+                                            "Names" : "Processor",
+                                            "Type" : STRING_TYPE,
+                                            "Default" : "default"
+                                        }
+                                    ]
                 },
                 {
                     "Names" : "AutoScaling",

--- a/aws/templates/id/id_es.ftl
+++ b/aws/templates/id/id_es.ftl
@@ -77,7 +77,14 @@
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
+                    "Children" : profileChildConfiguration + 
+                                    [
+                                        {
+                                            "Names" : "Processor",
+                                            "Type" : STRING_TYPE,
+                                            "Default" : "default"
+                                        }
+                                    ]
                 },
                 {
                     "Names" : "Alerts",

--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -139,7 +139,14 @@
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
+                    "Children" : profileChildConfiguration + 
+                                    [
+                                        {
+                                            "Names" : "Processor",
+                                            "Type" : STRING_TYPE,
+                                            "Default" : "default"
+                                        }
+                                    ]
                 },
                 {
                     "Names" : "Hibernate",

--- a/aws/templates/segment/segment_bastion.ftl
+++ b/aws/templates/segment/segment_bastion.ftl
@@ -57,9 +57,9 @@
         [#assign logFileProfile = getLogFileProfile(tier, component, BASTION_COMPONENT_TYPE)]
         [#assign bootstrapProfile = getBootstrapProfile(tier, component, BASTION_COMPONENT_TYPE)]
 
-        [#assign processorProfile = (getProcessor(tier, component, "SSH")?has_content)?then(
-                                        getProcessor(tier, component, "SSH"),
-                                        getProcessor(tier, component, BASTION_COMPONENT_TYPE)
+        [#assign processorProfile = (getProcessor(occurrence, "SSH")?has_content)?then(
+                                        getProcessor(occurrence, "SSH"),
+                                        getProcessor(occurrence, BASTION_COMPONENT_TYPE)
                                     )]
 
         [#assign processorProfile += {

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -494,7 +494,7 @@
 [#assign profileChildConfiguration = [
     {
         "Names" : "Deployment",
-        "Type" : STRING_TYPE
+        "Type" : ARRAY_OF_STRING_TYPE
     }
 ]]
 

--- a/aws/templates/solution/solution_ElasticSearch.ftl
+++ b/aws/templates/solution/solution_ElasticSearch.ftl
@@ -17,7 +17,7 @@
         [#assign esName = resources["es"].Name]
         [#assign esServiceRoleId = resources["servicerole"].Id]
 
-        [#assign processorProfile = getProcessor(tier, component, "ElasticSearch")]
+        [#assign processorProfile = getProcessor(occurrence, "ElasticSearch")]
         [#assign master = processorProfile.Master!{}]
 
         [#assign esUpdateCommand = "updateESDomain" ]

--- a/aws/templates/solution/solution_cache.ftl
+++ b/aws/templates/solution/solution_cache.ftl
@@ -80,7 +80,7 @@
                                                 cacheSecurityGroupId, 
                                                 port)]
 
-        [#assign processorProfile = getProcessor(tier, component, "ElastiCache")]
+        [#assign processorProfile = getProcessor(occurrence, "ElastiCache")]
         [#assign countPerZone = processorProfile.CountPerZone]
         [#assign awsZones = [] ]
         [#list zones as zone]

--- a/aws/templates/solution/solution_ec2.ftl
+++ b/aws/templates/solution/solution_ec2.ftl
@@ -23,7 +23,7 @@
         [#assign ec2LogGroupId          = resources["lg"].Id]
         [#assign ec2LogGroupName        = resources["lg"].Name]
 
-        [#assign processorProfile       = getProcessor(tier, component, "EC2")]
+        [#assign processorProfile       = getProcessor(occurrence, "EC2")]
         [#assign storageProfile         = getStorage(tier, component, "EC2")]
         [#assign logFileProfile         = getLogFileProfile(tier, component, "EC2")]
         [#assign bootstrapProfile       = getBootstrapProfile(tier, component, "EC2")]

--- a/aws/templates/solution/solution_ecs.ftl
+++ b/aws/templates/solution/solution_ecs.ftl
@@ -32,7 +32,7 @@
 
         [#assign logFileProfile = getLogFileProfile(tier, component, "ECS")]
         [#assign bootstrapProfile = getBootstrapProfile(tier, component, "ECS")]
-        [#assign processorProfile = getProcessor(tier, component, "ECS")]
+        [#assign processorProfile = getProcessor(occurrence, "ECS")]
         [#assign storageProfile = getStorage(tier, component, "ECS")]
 
         [#assign networkLink = tier.Network.Link!{} ]

--- a/aws/templates/solution/solution_rds.ftl
+++ b/aws/templates/solution/solution_rds.ftl
@@ -176,7 +176,7 @@
             [/#if]
         [/#list]
 
-        [#assign processorProfile = getProcessor(tier, component, "RDS")]
+        [#assign processorProfile = getProcessor(occurrence, "RDS")]
 
         [#if deploymentSubsetRequired("prologue", false)]
             [@cfScript


### PR DESCRIPTION
Adds the ability to define a Processor profile on components which have instance types. Currently processor is a Component level configuration which uses the name of the component or type to override the processor group which is selected. 

This PR adds the ability to define the processor group to use through the profile configuration, so that the processor profile can be changes based on deployment Mode ( via deployment Profiles ) or as instance level overrides 

Backwards compatibility with the older style of processor lookup has been maintained, at this stage this is just another way to set the processor 