### PR TITLE
<fix> deployment profiles with instance version

### DIFF
--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -115,6 +115,11 @@
             {
                 "Names" : "Type",
                 "Type" : STRING_TYPE
+            },
+            {
+                "Names" : "Enabled",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
             }
         ]
 ]


### PR DESCRIPTION
* Fixes deployment profiles so that they can be applied at the instance and version level of a component and still get processed 
   They used to only be applied at the typeObject level but are now applied as part of the solution configuration generation process
* Adds Enable/Disable to links to allow for Deployment profile modes which might not want a specific link to apply