### PR TITLE
<feature> Service registries

### DIFF
--- a/aws/templates/application/application_ecs.ftl
+++ b/aws/templates/application/application_ecs.ftl
@@ -261,7 +261,7 @@
                                         [#assign portAttributes = {}]
                                         [#if serviceRecordTypes?seq_contains("SRV") ]
                                             [#assign portAttributes = {
-                                                "ContainerPort" : ports[portMapping.ContainerPort].Port,
+                                                "ContainerPort" : ports[portMapping.ContainerPort].Port
                                             }]
                                         [/#if]
 

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -2293,6 +2293,38 @@ behaviour.
     [#return { targetLinkName : targetLink } ]
 [/#function]
 
+[#function getSrvRegLink occurrence port ]
+
+    [#assign core = occurrence.Core]
+    [#assign targetTierId = (port.SrvReg.Tier) ]
+    [#assign targetComponentId = (port.SrvReg.Component) ]
+    [#assign targetLinkName = formatName(port.SrvReg.LinkName) ]
+    [#assign registryService = contentIfContent(port.SrvReg.RegistryService, port.Name)]
+
+    [#-- Need to be careful to allow an empty value for --]
+    [#-- Instance/Version to be explicitly provided and --]
+    [#-- correctly handled in getLinkTarget.            --]
+    [#--                                                --]
+    [#-- Also note that the LinkName configuration      --]
+    [#-- must be provided if more than one port is used --]
+    [#-- (e.g. classic ELB) to avoid links overwriting  --]
+    [#-- each other.                                    --]
+    [#local targetLink =
+        {
+            "Id" : targetLinkName,
+            "Name" : targetLinkName,
+            "Tier" : targetTierId,
+            "Component" : targetComponentId
+        } +
+        attributeIfTrue("Instance", port.SrvReg.Instance??, port.SrvReg.Instance!"") +
+        attributeIfTrue("Version",  port.SrvReg.Version??, port.SrvReg.Version!"") +
+        attributeIfContent("RegistryService",  registryService)
+    ]
+    [@cfDebug listMode { targetLinkName : targetLink } false /]
+
+    [#return { targetLinkName : targetLink } ]
+[/#function]
+
 [#function isDuplicateLink links link ]
 
     [#local linkKey = ""]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -908,6 +908,14 @@ behaviour.
                 [#local result = getRDSState(occurrence)]
                 [#break]
 
+            [#case REGISTRY_COMPONENT_TYPE]
+                [#local result = getRegistryState(occurrence)]
+                [#break]
+            
+            [#case REGISTRY_SERVICE_COMPONENT_TYPE]
+                [#local result = getRegistryServiceState(occurrence, parentOccurrence)]
+                [#break]
+
             [#case "s3"]
                 [#local result = getS3State(occurrence)]
                 [#break]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -908,12 +908,12 @@ behaviour.
                 [#local result = getRDSState(occurrence)]
                 [#break]
 
-            [#case REGISTRY_COMPONENT_TYPE]
-                [#local result = getRegistryState(occurrence)]
+            [#case SERVICE_REGISTRY_COMPONENT_TYPE]
+                [#local result = getServiceRegistryState(occurrence)]
                 [#break]
             
-            [#case REGISTRY_SERVICE_COMPONENT_TYPE]
-                [#local result = getRegistryServiceState(occurrence, parentOccurrence)]
+            [#case SERVICE_REGISTRY_SERVICE_COMPONENT_TYPE]
+                [#local result = getServiceRegistryServiceState(occurrence, parentOccurrence)]
                 [#break]
 
             [#case "s3"]
@@ -2293,13 +2293,13 @@ behaviour.
     [#return { targetLinkName : targetLink } ]
 [/#function]
 
-[#function getSrvRegLink occurrence port ]
+[#function getRegistryLink occurrence port ]
 
     [#assign core = occurrence.Core]
-    [#assign targetTierId = (port.SrvReg.Tier) ]
-    [#assign targetComponentId = (port.SrvReg.Component) ]
-    [#assign targetLinkName = formatName(port.SrvReg.LinkName) ]
-    [#assign registryService = contentIfContent(port.SrvReg.RegistryService, port.Name)]
+    [#assign targetTierId = (port.Registry.Tier) ]
+    [#assign targetComponentId = (port.Registry.Component) ]
+    [#assign targetLinkName = formatName(port.Registry.LinkName) ]
+    [#assign registryService = contentIfContent(port.Registry.RegistryService, port.Name)]
 
     [#-- Need to be careful to allow an empty value for --]
     [#-- Instance/Version to be explicitly provided and --]
@@ -2307,7 +2307,7 @@ behaviour.
     [#--                                                --]
     [#-- Also note that the LinkName configuration      --]
     [#-- must be provided if more than one port is used --]
-    [#-- (e.g. classic ELB) to avoid links overwriting  --]
+    [#-- to avoid links overwriting                     --]
     [#-- each other.                                    --]
     [#local targetLink =
         {
@@ -2316,8 +2316,8 @@ behaviour.
             "Tier" : targetTierId,
             "Component" : targetComponentId
         } +
-        attributeIfTrue("Instance", port.SrvReg.Instance??, port.SrvReg.Instance!"") +
-        attributeIfTrue("Version",  port.SrvReg.Version??, port.SrvReg.Version!"") +
+        attributeIfTrue("Instance", port.Registry.Instance??, port.Registry.Instance!"") +
+        attributeIfTrue("Version",  port.Registry.Version??, port.Registry.Version!"") +
         attributeIfContent("RegistryService",  registryService)
     ]
     [@cfDebug listMode { targetLinkName : targetLink } false /]

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -547,22 +547,22 @@
 
             [/#if]
 
-            [#if port.SrvReg.Configured]
-                [#local srvRegLink = getSrvRegLink(task, port)]
+            [#if port.Registry.Configured]
+                [#local RegistryLink = getRegistryLink(task, port)]
 
-                [#if isDuplicateLink(containerLinks, srvRegLink) ]
+                [#if isDuplicateLink(containerLinks, RegistryLink) ]
                     [@cfException
                         mode=listMode
                         description="Duplicate Link Name"
                         context=containerLinks
-                        detail=srvRegLink /]
+                        detail=RegistryLink /]
                     [#continue]
                 [/#if]
 
                 [#-- Add to normal container links --]
-                [#local containerLinks += srvRegLink]
+                [#local containerLinks += RegistryLink]
 
-                [#list srvRegLink as key,serviceRegistry]
+                [#list RegistryLink as key,serviceRegistry]
                     [#local containerPortMapping +=
                         {
                             "ServiceRegistry" :

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -547,6 +547,36 @@
 
             [/#if]
 
+            [#if port.SrvReg.Configured]
+                [#local srvRegLink = getSrvRegLink(task, port)]
+
+                [#if isDuplicateLink(containerLinks, srvRegLink) ]
+                    [@cfException
+                        mode=listMode
+                        description="Duplicate Link Name"
+                        context=containerLinks
+                        detail=srvRegLink /]
+                    [#continue]
+                [/#if]
+
+                [#-- Treat the LB link like any other - this will also detect --]
+                [#-- if the target is missing                                 --]
+                [#local containerLinks += srvRegLink]
+
+                [#-- Ports should only be defined if connecting to a load balancer --]
+                [#list srvRegLink as key,serviceRegistry]
+                    [#local containerPortMapping +=
+                        {
+                            "ServiceRegistry" :
+                                {
+                                    "Link" : serviceRegistry.Name
+                                }
+                        }
+                    ]
+
+                [/#list]
+            [/#if]
+
             [#if port.IPAddressGroups?has_content]
                 [#if solution.NetworkMode == "awsvpc" || !port.LB.Configured ]
                     [#list getGroupCIDRs(port.IPAddressGroups, true, task ) as cidr]

--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -559,11 +559,9 @@
                     [#continue]
                 [/#if]
 
-                [#-- Treat the LB link like any other - this will also detect --]
-                [#-- if the target is missing                                 --]
+                [#-- Add to normal container links --]
                 [#local containerLinks += srvRegLink]
 
-                [#-- Ports should only be defined if connecting to a load balancer --]
                 [#list srvRegLink as key,serviceRegistry]
                     [#local containerPortMapping +=
                         {

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -77,10 +77,14 @@
                     "Names" : "DynamicHostPort",
                     "Type" : BOOLEAN_TYPE,
                     "Default" : false
-                }
+                },
                 {
                     "Names" : "LB",
                     "Children" : lbChildConfiguration
+                },
+                {
+                    "Names" : "SrvReg",
+                    "Children" : srvRegChildConfiguration
                 },
                 {
                     "Names" : "IPAddressGroups",

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -83,7 +83,7 @@
                     "Children" : lbChildConfiguration
                 },
                 {
-                    "Names" : "SrvReg",
+                    "Names" : "Registry",
                     "Children" : srvRegChildConfiguration
                 },
                 {

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -77,6 +77,11 @@
                     "Names" : "Alerts",
                     "Subobjects" : true,
                     "Children" : alertChildrenConfiguration
+                },
+                {
+                    "Names" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
                 }
             ],
             "Components" : [

--- a/aws/templates/id/id_serviceregistry.ftl
+++ b/aws/templates/id/id_serviceregistry.ftl
@@ -4,12 +4,12 @@
 [#assign AWS_CLOUDMAP_INSTANCE_RESOURCE_TYPE = "cloudmapinstance" ]
 
 [#-- Components --]
-[#assign REGISTRY_COMPONENT_TYPE = "registry" ]
-[#assign REGISTRY_SERVICE_COMPONENT_TYPE = "registryservice" ]
+[#assign SERVICE_REGISTRY_COMPONENT_TYPE = "serviceregistry" ]
+[#assign SERVICE_REGISTRY_SERVICE_COMPONENT_TYPE = "serviceregistryservice" ]
 
 [#assign componentConfiguration +=
     {
-        REGISTRY_COMPONENT_TYPE : {
+        SERVICE_REGISTRY_COMPONENT_TYPE : {
             "Properties"  : [
                 {
                     "Type"  : "Description",
@@ -47,7 +47,7 @@
                 }
             ]
         },
-        REGISTRY_SERVICE_COMPONENT_TYPE : {
+        SERVICE_REGISTRY_SERVICE_COMPONENT_TYPE : {
             "Properties"  : [
                 {
                     "Type"  : "Description",
@@ -101,7 +101,7 @@
         }
     }]
 
-[#function getRegistryState occurrence ]
+[#function getServiceRegistryState occurrence ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
@@ -130,7 +130,7 @@
 [/#function]
 
 
-[#function getRegistryServiceState occurrence parent ]
+[#function getServiceRegistryServiceState occurrence parent ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/aws/templates/id/id_serviceregistry.ftl
+++ b/aws/templates/id/id_serviceregistry.ftl
@@ -1,6 +1,6 @@
 [#-- Resources --]
-[#assign AWS_CLOUDMAP_DNS_NAMESPACE_RESOURCE_TYPE = "cloudmapDNSNamespace" ]
-[#assign AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE = "cloudmapService"]
+[#assign AWS_CLOUDMAP_DNS_NAMESPACE_RESOURCE_TYPE = "cloudmapdnsnamespace" ]
+[#assign AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE = "cloudmapservice"]
 
 [#-- Components --]
 [#assign REGISTRY_COMPONENT_TYPE = "registry" ]
@@ -8,7 +8,7 @@
 
 [#assign componentConfiguration +=
     {
-        SERIVCE_REGISTRY_COMPONENT_TYPE : {
+        REGISTRY_COMPONENT_TYPE : {
             "Properties"  : [
                 {
                     "Type"  : "Description",
@@ -79,8 +79,9 @@
                 {
                     "Names" : "RecordTypes",
                     "Description" : "The types of DNS records that an instance can register with the service",
-                    "Type" : ARRAY_OF_STRING_TYPE
-                    "Values" : [ "A", "AAAA", "CNMAE", SRV ]
+                    "Type" : ARRAY_OF_STRING_TYPE,
+                    "Values" : [ "A", "AAAA", "CNMAE", "SRV" ],
+                    "Default" : [ "A", "AAAA" ]
                 },
                 {
                     "Names" : "RecordTTL",
@@ -93,18 +94,18 @@
                     "Description" : "How the service returns records to the client",
                     "Values" : [ "AllAtOnce", "OnlyOne" ],
                     "Type" : STRING_TYPE,
-                    "Default" : "OnlyOne
+                    "Default" : "OnlyOne"
                 }
             ]
         }
     }]
 
-[#function getRegistryState occurrence]
+[#function getRegistryState occurrence ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
     [#local domainObject = getCertificateObject(solution.Namespace, segmentQualifiers)]
-    [#local domainName = getCertificatePrimaryDomain(domainObject) ]
+    [#local domainName = getCertificatePrimaryDomain(domainObject).Name ]
 
     [#return
         {
@@ -136,7 +137,7 @@
     [#local parentAttributes = parent.State.Attributes ]
 
     [#local serviceHostObject = mergeObjects(parentSolution.Namespace, solution.ServiceName) ]
-    [#local domainObject = getCertificateObject( serviceHostNameObject, segmentQualifiers)]
+    [#local domainObject = getCertificateObject( serviceHostObject, segmentQualifiers)]
 
     [#local serviceHost = getHostName(domainObject, occurrence)  ]
     [#local hostName = formatDomainName(serviceHost, parentAttributes["DOMAIN_NAME"] ) ]

--- a/aws/templates/id/id_serviceregistry.ftl
+++ b/aws/templates/id/id_serviceregistry.ftl
@@ -1,0 +1,163 @@
+[#-- Resources --]
+[#assign AWS_CLOUDMAP_DNS_NAMESPACE_RESOURCE_TYPE = "cloudmapDNSNamespace" ]
+[#assign AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE = "cloudmapService"]
+
+[#-- Components --]
+[#assign REGISTRY_COMPONENT_TYPE = "registry" ]
+[#assign REGISTRY_SERVICE_COMPONENT_TYPE = "registryservice" ]
+
+[#assign componentConfiguration +=
+    {
+        SERIVCE_REGISTRY_COMPONENT_TYPE : {
+            "Properties"  : [
+                {
+                    "Type"  : "Description",
+                    "Value" : "DNS based service registry"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
+                },
+                {
+                    "Names" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                },
+                {
+                    "Names" : "Namespace",
+                    "Children" : domainNameChildConfiguration
+                }
+            ],
+            "Components" : [
+                {
+                    "Type" : REGISTRY_SERVICE_COMPONENT_TYPE,
+                    "Component" : "RegistryServices",
+                    "Link" : ["RegistryService" ]
+                }
+            ]
+        },
+        REGISTRY_SERVICE_COMPONENT_TYPE : {
+            "Properties"  : [
+                {
+                    "Type"  : "Description",
+                    "Value" : "An individual service in the registry"
+                },
+                {
+                    "Type" : "Providers",
+                    "Value" : [ "aws" ]
+                },
+                {
+                    "Type" : "ComponentLevel",
+                    "Value" : "solution"
+                }
+            ],
+            "Attributes" : [
+                {
+                    "Names" : "Profiles",
+                    "Children" : profileChildConfiguration
+                },
+                {
+                    "Names" : "Links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                },
+                {
+                    "Names" : "ServiceName",
+                    "Description" : "The hostname portion of the DNS record which will identify this service",
+                    "Children" : hostNameChildConfiguration
+                },
+                {
+                    "Names" : "RecordTypes",
+                    "Description" : "The types of DNS records that an instance can register with the service",
+                    "Type" : ARRAY_OF_STRING_TYPE
+                    "Values" : [ "A", "AAAA", "CNMAE", SRV ]
+                },
+                {
+                    "Names" : "RecordTTL",
+                    "Description" : "DNS record TTL ( in seconds)",
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 300
+                },
+                {
+                    "Names" : "RoutingPolicy",
+                    "Description" : "How the service returns records to the client",
+                    "Values" : [ "AllAtOnce", "OnlyOne" ],
+                    "Type" : STRING_TYPE,
+                    "Default" : "OnlyOne
+                }
+            ]
+        }
+    }]
+
+[#function getRegistryState occurrence]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#local domainObject = getCertificateObject(solution.Namespace, segmentQualifiers)]
+    [#local domainName = getCertificatePrimaryDomain(domainObject) ]
+
+    [#return
+        {
+            "Resources" : {
+                "namespace" : {
+                    "Id" : formatResourceId(AWS_CLOUDMAP_DNS_NAMESPACE_RESOURCE_TYPE, core.Id),
+                    "Name" : core.FullName,
+                    "DomainName" : domainName,
+                    "Type" : AWS_CLOUDMAP_DNS_NAMESPACE_RESOURCE_TYPE
+                }
+            }, 
+            "Attributes" : {
+                "DOMAIN_NAME" : domainName
+            },
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#function]
+
+
+[#function getRegistryServiceState occurrence parent ]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#local parentSolution = parent.Configuration.Solution ]
+    [#local parentAttributes = parent.State.Attributes ]
+
+    [#local serviceHostObject = mergeObjects(parentSolution.Namespace, solution.ServiceName) ]
+    [#local domainObject = getCertificateObject( serviceHostNameObject, segmentQualifiers)]
+
+    [#local serviceHost = getHostName(domainObject, occurrence)  ]
+    [#local hostName = formatDomainName(serviceHost, parentAttributes["DOMAIN_NAME"] ) ]
+
+    [#return
+        {
+            "Resources" : {
+                "service" : {
+                    "Id" : formatResourceId(AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE, core.Id),
+                    "Name" : core.FullName,
+                    "ServiceName" : serviceHost,
+                    "Type" : AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE
+                }
+            }, 
+            "Attributes" : {
+                "FQDN" : hostName
+            },
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#function]

--- a/aws/templates/id/id_serviceregistry.ftl
+++ b/aws/templates/id/id_serviceregistry.ftl
@@ -41,7 +41,7 @@
             ],
             "Components" : [
                 {
-                    "Type" : REGISTRY_SERVICE_COMPONENT_TYPE,
+                    "Type" : SERVICE_REGISTRY_SERVICE_COMPONENT_TYPE,
                     "Component" : "RegistryServices",
                     "Link" : ["RegistryService" ]
                 }
@@ -143,7 +143,7 @@
     [#local serviceHost = getHostName(domainObject, occurrence)  ]
     [#local hostName = formatDomainName(serviceHost, parentAttributes["DOMAIN_NAME"] ) ]
 
-    [#assign serviceId = formatResourceId(AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE, core.Id, hostName)]
+    [#assign serviceId = formatResourceId(AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE, core.Id)]
 
     [#return
         {

--- a/aws/templates/id/id_serviceregistry.ftl
+++ b/aws/templates/id/id_serviceregistry.ftl
@@ -1,6 +1,7 @@
 [#-- Resources --]
 [#assign AWS_CLOUDMAP_DNS_NAMESPACE_RESOURCE_TYPE = "cloudmapdnsnamespace" ]
-[#assign AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE = "cloudmapservice"]
+[#assign AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE = "cloudmapservice" ]
+[#assign AWS_CLOUDMAP_INSTANCE_RESOURCE_TYPE = "cloudmapinstance" ]
 
 [#-- Components --]
 [#assign REGISTRY_COMPONENT_TYPE = "registry" ]
@@ -80,8 +81,8 @@
                     "Names" : "RecordTypes",
                     "Description" : "The types of DNS records that an instance can register with the service",
                     "Type" : ARRAY_OF_STRING_TYPE,
-                    "Values" : [ "A", "AAAA", "CNMAE", "SRV" ],
-                    "Default" : [ "A", "AAAA" ]
+                    "Values" : [ "A", "AAAA", "CNAME", "SRV" ],
+                    "Default" : [ "A" ]
                 },
                 {
                     "Names" : "RecordTTL",
@@ -142,18 +143,22 @@
     [#local serviceHost = getHostName(domainObject, occurrence)  ]
     [#local hostName = formatDomainName(serviceHost, parentAttributes["DOMAIN_NAME"] ) ]
 
+    [#assign serviceId = formatResourceId(AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE, core.Id, hostName)]
+
     [#return
         {
             "Resources" : {
                 "service" : {
-                    "Id" : formatResourceId(AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE, core.Id),
+                    "Id" : serviceId,
                     "Name" : core.FullName,
                     "ServiceName" : serviceHost,
                     "Type" : AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE
                 }
             }, 
             "Attributes" : {
-                "FQDN" : hostName
+                "FQDN" : hostName,
+                "RECORD_TYPES" : solution.RecordTypes?join(","),
+                "SERVICE_ARN" : getExistingReference(serviceId, ARN_ATTRIBUTE_TYPE)
             },
             "Roles" : {
                 "Inbound" : {},

--- a/aws/templates/resource/resource_cloudmap.ftl
+++ b/aws/templates/resource/resource_cloudmap.ftl
@@ -23,10 +23,19 @@
     }
 ]
 
+[#assign CLOUDMAP_INSTANCE_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+
 [#assign outputMappings +=
     {
         AWS_CLOUDMAP_DNS_NAMESPACE_RESOURCE_TYPE : CLOUDMAP_DNS_NAMESPACE_OUTPUT_MAPPINGS,
-        AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE : CLOUDMAP_SERVICE_OUTPUT_MAPPINGS
+        AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE : CLOUDMAP_SERVICE_OUTPUT_MAPPINGS,
+        AWS_CLOUDMAP_INSTANCE_RESOURCE_TYPE : CLOUDMAP_INSTANCE_OUTPUT_MAPPINGS
     }
 ]
 
@@ -111,7 +120,7 @@
             /]
         [/#if]
 
-        [#if recordTypes.size > 1 ]
+        [#if recordTypes?size > 1 ]
             [@cfException
                 mode=listMode
                 description="CNAME record types can not be used with other record types"
@@ -133,12 +142,64 @@
                     "RoutingPolicy" : routingPolicy
                 },
                 "Name" : hostName,
-                "NamespaceId" : getReference(namespaceId)
+                "NamespaceId" : getReference(namespaceId),
+                "HealthCheckCustomConfig" : {
+                    "FailureThreshold" : 1
+                }
             }
         outputs=CLOUDMAP_SERVICE_OUTPUT_MAPPINGS
         dependencies=dependencies
     /]
 [/#macro]
 
+[#function getCloudMapInstanceAttribute type value ]
+    [#switch type ] 
+        [#case "alias" ]
+            [#local type = "AWS_ALIAS_DNS_NAME" ]
+            [#break]
+        [#case "cname" ]
+            [#local type = "AWS_INSTANCE_CNAME" ]
+            [#break]
+        [#case "ipv4" ]
+            [#local type = "AWS_INSTANCE_IPV4" ]
+            [#break]
+        [#case "ipv6" ]
+            [#local type = "AWS_INSTANCE_IPV6" ]
+            [#break]
+        [#case "port" ]
+            [#local type = "AWS_INSTANCE_PORT" ]
+            [#break]
+        [#default]
+            [@cfException
+                mode=listMode
+                description="invalid attribute type"
+                context=type
+            /]
+    [/#switch]
 
+    [#return { type : value }]
+[/#function]
+
+[#macro createCloudMapInstance 
+    mode id
+    serviceId
+    instanceId
+    instanceAttributes
+    dependencies=""
+]
+
+    [@cfResource 
+        mode=mode
+        id=id
+        type="AWS::ServiceDiscovery::Instance"
+        properties=
+            {
+                "InstanceAttributes": instanceAttributes,
+                "ServiceId": getReference(serviceId),
+                "InstanceId" : instanceId
+            }
+        outputs=CLOUDMAP_INSTANCE_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]
 

--- a/aws/templates/resource/resource_cloudmap.ftl
+++ b/aws/templates/resource/resource_cloudmap.ftl
@@ -1,0 +1,129 @@
+[#-- Cloud Map Resources --]
+
+
+[#assign CLOUDMAP_DNS_NAMESPACE_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        ARN_ATTRIBUTE_TYPE : { 
+            "Attribute" : "Arn"
+        }
+    }
+]
+
+[#assign CLOUDMAP_SERVICE_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        ARN_ATTRIBUTE_TYPE : { 
+            "Attribute" : "Arn"
+        },
+        NAME_ATTRIBUTE_TYPE : {
+            "Attribute" : "Name"
+        }
+    }
+]
+
+[#assign outputMappings +=
+    {
+        AWS_CLOUDMAP_DNS_NAMESPACE_RESOURCE_TYPE : CLOUDMAP_DNS_NAMESPACE_OUTPUT_MAPPINGS,
+        AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE : CLOUDMAP_SERVICE_OUTPUT_MAPPINGS
+    }
+]
+
+[#macro createCloudMapDNSNamespace 
+    mode id name 
+    domainName
+    public
+    vpcId=""
+    dependencies=""
+]
+    
+    [#if public ]
+        [@cfResource 
+            mode=mode
+            id=id
+            type="AWS::ServiceDiscovery::PublicDnsNamespace"
+            properties=
+                {
+                    "Description" : name
+                    "Name" : domainName
+                }
+            outputs=CLOUDMAP_DNS_NAMESPACE_OUTPUT_MAPPINGS
+            dependencies=dependencies
+        /]
+    [#else]
+        [@cfResource 
+            mode=mode
+            id=id
+            type="AWS::ServiceDiscovery::PrivateDnsNamespace"
+            properties=
+                {
+                    "Description" : name
+                    "Name" : domainName,
+                    "Vpc" : getReference(vpcId)
+                }
+            outputs=CLOUDMAP_DNS_NAMESPACE_OUTPUT_MAPPINGS
+            dependencies=dependencies
+        /]
+    [/#if]
+[/#macro]
+
+[#macro createCloudMapService
+    mode id name
+    namespaceId
+    hostName
+    routingPolicy
+    recordTypes
+    recordTTL
+    dependencies=""
+]
+
+    [#local dnsRecords = [] ]
+    [#list recordTypes as recordType ]
+        [#assign dnsRecords += 
+            [ 
+                {
+                    "TTL" : recordTTL?c,
+                    "Type" : recordType?upper_case
+                }
+            ]]
+    [/#list]
+    
+
+    [#switch routingPolicy?upper_case ]
+        [#case "ALLATONCE" ]
+        [#case "MULTIVALUE" ]
+            [#local routingPolicy = "MULTIVALUE" ]
+            [#break]
+        
+        [#case "ONLYONE" ]
+        [#csae "WEIGHTED" ]
+            [#local routingPolicy = "WEIGHTED" ]
+            [#break]
+    [/#switch]
+
+    [@cfResource 
+        mode=mode
+        id=id
+        type="AWS::ServiceDiscovery::Service"
+        properties=
+            {
+                "Description" : name,
+                "DnsConfig" : {
+                    "DnsRecords" : dnsRecords,
+                    "NamespaceId" : getReference(namespaceId),
+                    "RoutingPolicy" : routingPolicy
+                },
+                "Name" : hostName,
+                "NamespaceId" : getReference(namespaceId)
+            }
+        outputs=CLOUDMAP_SERVICE_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]
+
+
+

--- a/aws/templates/resource/resource_ecs.ftl
+++ b/aws/templates/resource/resource_ecs.ftl
@@ -259,6 +259,7 @@
             desiredCount 
             taskId 
             loadBalancers
+            serviceRegistries
             engine 
             networkMode=""
             networkConfiguration={}
@@ -288,9 +289,14 @@
             } + 
             valueIfContent(
                 {
-                    "LoadBalancers" : loadBalancers![]
+                    "LoadBalancers" : loadBalancers
                 },
-                loadBalancers![]) +
+                loadBalancers) +
+            valueIfContent(
+                {
+                    "ServiceRegistries" : serviceRegistries
+                },
+                serviceRegistries) +
             valueIfTrue(
                 {
                     "SchedulingStrategy" : "DAEMON"

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -139,8 +139,7 @@
     ]
 ]
 
-[#assign
-    logMetricChildrenConfiguration = [
+[#assign logMetricChildrenConfiguration = [
         {
             "Names" : "LogFilter",
             "Type" : STRING_TYPE,
@@ -149,8 +148,7 @@
     ]
 ]
 
-[#assign
-    alertChildrenConfiguration = [
+[#assign alertChildrenConfiguration = [
         "Description",
         {
             "Names" : "Name",
@@ -349,24 +347,6 @@
     }
 ]]
 
-[#assign certificateChildConfiguration = [
-    {
-        "Names" : "Qualifiers",
-        "Type" : OBJECT_TYPE
-    },
-    {
-        "Names" : "External",
-        "Type" : BOOLEAN_TYPE
-    },
-    {
-        "Names" : "Wildcard",
-        "Type" : BOOLEAN_TYPE
-    }
-] + 
-    domainNameChildConfiguration + 
-    hostNameChildConfiguration
-] 
-
 [#assign domainNameChildConfiguration = [
     {
         "Names" : "Qualifiers",
@@ -443,6 +423,25 @@
         ]
     }
 ]]
+
+[#assign certificateChildConfiguration = 
+    domainNameChildConfiguration + 
+    hostNameChildConfiguration + 
+    [
+        {
+            "Names" : "Qualifiers",
+            "Type" : OBJECT_TYPE
+        },
+        {
+            "Names" : "External",
+            "Type" : BOOLEAN_TYPE
+        },
+        {
+            "Names" : "Wildcard",
+            "Type" : BOOLEAN_TYPE
+        }
+    ]
+] 
 
 [#assign pathChildConfiguration = [
     {

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -361,11 +361,41 @@
     {
         "Names" : "Wildcard",
         "Type" : BOOLEAN_TYPE
+    }
+] + 
+    domainNameChildConfiguration + 
+    hostNameChildConfiguration
+] 
+
+[#assign domainNameChildConfiguration = [
+    {
+        "Names" : "Qualifiers",
+        "Type" : OBJECT_TYPE
     },
     {
         "Names" : "Domain",
         "Type" : STRING_TYPE
     },
+    {
+        "Names" : "IncludeInDomain",
+        "Children" : [
+            {
+                "Names" : "Product",
+                "Type" : BOOLEAN_TYPE
+            },
+            {
+                "Names" : "Environment",
+                "Type" : BOOLEAN_TYPE
+            },
+            {
+                "Names" : "Segment",
+                "Type" : BOOLEAN_TYPE
+            }
+        ]
+    }
+]]
+
+[#assign hostNameChildConfiguration = [
     {
         "Names" : "Host",
         "Type" : STRING_TYPE,
@@ -408,23 +438,6 @@
             },
             {
                 "Names" : "Host",
-                "Type" : BOOLEAN_TYPE
-            }
-        ]
-    },
-    {
-        "Names" : "IncludeInDomain",
-        "Children" : [
-            {
-                "Names" : "Product",
-                "Type" : BOOLEAN_TYPE
-            },
-            {
-                "Names" : "Environment",
-                "Type" : BOOLEAN_TYPE
-            },
-            {
-                "Names" : "Segment",
                 "Type" : BOOLEAN_TYPE
             }
         ]

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -88,7 +88,11 @@
         {
             "Names" : [ "DataFeed" ],
             "Type" : STRING_TYPE
-        }
+        },
+        {
+            "Names" : [ "RegistryService" ],
+            "Type" : STRING_TYPE
+        },
         {
             "Names" : "Instance",
             "Type" : STRING_TYPE
@@ -254,6 +258,37 @@
             "Names" : ["PortMapping", "Port"],
             "Type" : STRING_TYPE,
             "Default" : ""
+        }
+    ]
+]
+
+[#assign srvRegChildConfiguration = [
+        {
+            "Names" : "Tier",
+            "Type" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "Component",
+            "Type" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "LinkName",
+            "Type" : STRING_TYPE,
+            "Default" : "srvreg"
+        },
+        {
+            "Names" : "Instance",
+            "Type" : STRING_TYPE
+        },
+        {
+            "Names" : "Version",
+            "Type" : STRING_TYPE
+        },
+        {
+            "Names" : "RegistryService",
+            "Type" : STRING_TYPE
         }
     ]
 ]

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -131,7 +131,7 @@
                 [#assign linkTargetAttributes = linkTarget.State.Attributes ]
 
                 [#switch linkTargetCore.Type]
-                    [#case REGISTRY_SERVICE_COMPONENT_TYPE ]
+                    [#case SERVICE_REGISTRY_SERVICE_COMPONENT_TYPE ]
                         [#assign registryServiceId = linkTargetResources["service"].Id ]
                         [#assign instanceAttributes = getCloudMapInstanceAttribute( 
                                                         "alias",

--- a/aws/templates/solution/solution_lb.ftl
+++ b/aws/templates/solution/solution_lb.ftl
@@ -114,6 +114,45 @@
             [/#list]
         [/#if]
 
+
+        [#list solution.Links?values as link]
+            [#if link?is_hash]
+
+                [#assign linkTarget = getLinkTarget(occurrence, link) ]
+                [@cfDebug listMode linkTarget false /]
+
+                [#if !linkTarget?has_content]
+                    [#continue]
+                [/#if]
+
+                [#assign linkTargetCore = linkTarget.Core ]
+                [#assign linkTargetConfiguration = linkTarget.Configuration ]
+                [#assign linkTargetResources = linkTarget.State.Resources ]
+                [#assign linkTargetAttributes = linkTarget.State.Attributes ]
+
+                [#switch linkTargetCore.Type]
+                    [#case REGISTRY_SERVICE_COMPONENT_TYPE ]
+                        [#assign registryServiceId = linkTargetResources["service"].Id ]
+                        [#assign instanceAttributes = getCloudMapInstanceAttribute( 
+                                                        "alias",
+                                                        getExistingReference(lbId, DNS_ATTRIBUTE_TYPE) )]
+                        
+                        [#if deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
+                            [#assign cloudMapInstanceId = formatDependentResourceId(
+                                                                AWS_CLOUDMAP_INSTANCE_RESOURCE_TYPE, lbId, registryServiceId)]
+                            [@createCloudMapInstance 
+                                mode=listMode
+                                id=cloudMapInstanceId
+                                serviceId=registryServiceId
+                                instanceId=core.ShortName
+                                instanceAttributes=instanceAttributes
+                            /]
+                        [/#if]
+                        [#break]
+                [/#switch]
+            [/#if]
+        [/#list]
+
         [#list occurrence.Occurrences![] as subOccurrence]
 
             [#assign core = subOccurrence.Core ]

--- a/aws/templates/solution/solution_registry.ftl
+++ b/aws/templates/solution/solution_registry.ftl
@@ -1,5 +1,5 @@
 [#-- Service Registry --]
-[#if (componentType == REGISTRY_COMPONENT_TYPE) ]
+[#if (componentType == SERVICE_REGISTRY_COMPONENT_TYPE) ]
 
     [#list requiredOccurrences(
             getOccurrences(tier, component),
@@ -31,7 +31,7 @@
         [#assign routeTableConfiguration = routeTableLinkTarget.Configuration.Solution ]
         [#assign publicRouteTable = routeTableConfiguration.Public ]
 
-        [#if deploymentSubsetRequired(REGISTRY_COMPONENT_TYPE, true) ]
+        [#if deploymentSubsetRequired(SERVICE_REGISTRY_COMPONENT_TYPE, true) ]
             [@createCloudMapDNSNamespace 
                 mode=listMode
                 id=registryId
@@ -52,7 +52,7 @@
             [#assign serviceName = resources["service"].Name]
             [#assign serviceHostName = resources["service"].ServiceName ]
 
-            [#if deploymentSubsetRequired(REGISTRY_COMPONENT_TYPE, true) ]
+            [#if deploymentSubsetRequired(SERVICE_REGISTRY_COMPONENT_TYPE, true) ]
                 [@createCloudMapService
                     mode=listMode
                     id=serviceId

--- a/aws/templates/solution/solution_registry.ftl
+++ b/aws/templates/solution/solution_registry.ftl
@@ -1,0 +1,70 @@
+[#-- Service Registry --]
+[#if (componentType == REGISTRY_COMPONENT_TYPE) ]
+
+    [#list requiredOccurrences(
+            getOccurrences(tier, component),
+            deploymentUnit) as occurrence]
+
+        [@cfDebug listMode occurrence false /]
+
+        [#assign core = occurrence.Core ]
+        [#assign solution = occurrence.Configuration.Solution ]
+        [#assign resources = occurrence.State.Resources ]
+
+        [#assign registryId = resources["namespace"].Id ]
+        [#assign registryName = resources["namespace"].Name ]
+        [#assign registryDnsDomain = resource["namespace"].DomainName ]
+
+        [#-- Network lookup --]
+        [#assign networkLink = tier.Network.Link!{} ]
+        [#assign networkLinkTarget = getLinkTarget(occurrence, networkLink ) ]
+        
+        [#if ! networkLinkTarget?has_content ]
+            [@cfException listMode "Network could not be found" networkLink /]
+            [#break]
+        [/#if]
+
+        [#assign networkConfiguration = networkLinkTarget.Configuration.Solution]
+        [#assign networkResources = networkLinkTarget.State.Resources ]
+        [#assign vpcId = networkResources["vpc"].Id ]
+        [#assign routeTableLinkTarget = getLinkTarget(occurrence, networkLink + { "RouteTable" : tier.Network.RouteTable })]
+        [#assign routeTableConfiguration = routeTableLinkTarget.Configuration.Solution ]
+        [#assign publicRouteTable = routeTableConfiguration.Public ]
+
+        [#if deploymentSubsetRequired(REGISTRY_COMPONENT_TYPE, true) ]
+            [@createCloudMapDNSNamespace 
+                mode=listMode
+                id=registryId
+                name=registryName
+                domainName=registryDnsDomain
+                public=publicRouteTable
+                vpcId=vpcId
+            /]
+        [/#if]
+
+        [#list occurrence.Occurrences![] as subOccurrence]
+
+            [#assign core = subOccurrence.Core ]
+            [#assign solution = subOccurrence.Configuration.Solution ]
+            [#assign resources = subOccurrence.State.Resources ]
+
+            [#assign serviceId = resources["service"].Id]
+            [#assign serviceName = resources["service"].Name]
+            [#assign serviceHostName = resources["service"].ServiceName ]
+
+            [#if deploymentSubsetRequired(REGISTRY_COMPONENT_TYPE, true) ]
+                [#macro createCloudMapService
+                    mode=listMode
+                    id=serviceId
+                    name=serviceName
+                    namespaceId=registryId
+                    hostName=serviceHostName
+                    routingPolicy=solution.RoutingPolicy
+                    recordTypes=solution.RecordTypes
+                    recordTTL=soltuion.RecordTTL
+                    dependencies=registryId
+                /]
+            [/#if]
+        [/#list]
+    [/#list]
+[/#if]

--- a/aws/templates/solution/solution_registry.ftl
+++ b/aws/templates/solution/solution_registry.ftl
@@ -13,7 +13,7 @@
 
         [#assign registryId = resources["namespace"].Id ]
         [#assign registryName = resources["namespace"].Name ]
-        [#assign registryDnsDomain = resource["namespace"].DomainName ]
+        [#assign registryDnsDomain = resources["namespace"].DomainName ]
 
         [#-- Network lookup --]
         [#assign networkLink = tier.Network.Link!{} ]
@@ -53,7 +53,7 @@
             [#assign serviceHostName = resources["service"].ServiceName ]
 
             [#if deploymentSubsetRequired(REGISTRY_COMPONENT_TYPE, true) ]
-                [#macro createCloudMapService
+                [@createCloudMapService
                     mode=listMode
                     id=serviceId
                     name=serviceName
@@ -61,7 +61,7 @@
                     hostName=serviceHostName
                     routingPolicy=solution.RoutingPolicy
                     recordTypes=solution.RecordTypes
-                    recordTTL=soltuion.RecordTTL
+                    recordTTL=solution.RecordTTL
                     dependencies=registryId
                 /]
             [/#if]


### PR DESCRIPTION
Adds support for service registries which provide a DNS and API based service discovery service based on AWS Cloud Map https://aws.amazon.com/cloud-map/ 

It works in a similar way to Load balancers with a central registry that contains child services. Load balancers or ECS containers ( at the moment) link to a service which allows them to register with CloudMap 

Examples 

The registry itself 
```
                "services" : {
                    "DeploymentUnits" : [ "service-registry"],
                    "serviceregistry" : {
                        "Namespace" : {
                            "IncludeInDomain" : {
                                "Environment" : true,
                                "Segment" : true
                            }
                        },
                        "RegistryServices" : {
                            "www" : {
                                "ServiceName" : {
                                    "IncludeInHost" : {
                                        "Host" : true,
                                        "Environment" : false,
                                        "Component" : false
                                    },
                                    "RoutingPolicy" : "AllAtOnce",
                                    "Host" : "www"
                                }
                            },
                            "public" : {
                                "RecordTypes" : [ "A", "AAAA" ],
                                "ServiceName" : {
                                    "IncludeInHost" : {
                                        "Host" : true,
                                        "Environment" : false,
                                        "Component" : false
                                    },
                                    "RoutingPolicy" : "OnlyOne",
                                    "Host" : "public"
                                }
                            }
                        }
                    }
                }
```

An ECS registration 
```
                            "squid" : {
                                "Engine" : "ec2",
                                "DeploymentUnits" : [ "squid" ],
                                "Containers" : {
                                    "_squid" : {
                                        "Version" : "latest",
                                        "Cpu" : 256,
                                        "Memory" : 512,
                                        "MaximumMemory" : 512,
                                        "Ports" : {
                                            "squid" : {
                                                "Registry" : {
                                                    "Tier" : "app",
                                                    "Component" : "services",
                                                    "RegistryService" : "www"
                                                }
                                            }
                                        }
                                    }
                                }
                            },
                            "NetworkMode" : "awsvpc"
```

A Load balancer
```
                    "lb" : {
                        "Logs" : true,
                        "Engine" : "network",
                        "IPAddressGroups" : ["_global"],
                        "Links" : {
                            "registry" : {
                                "Tier" : "app",
                                "Component" : "services",
                                "RegistryService" : "public"
                            }
                        },
```


The Certificate naming process is used but has been split across the registry and the service. The registry controls the domain name the registry service controls the hostname portion