### PR TITLE
<feature> Api Gateway - basepath control

### DIFF
--- a/aws/templates/application/application_apigateway.ftl
+++ b/aws/templates/application/application_apigateway.ftl
@@ -262,7 +262,10 @@
                             "Bucket" : operationsBucket,
                             "Key" : swaggerFileLocation
                         },
-                        "Name" : apiName
+                        "Name" : apiName,
+                        "Parameters" : {
+                            "basepath" : solution.BasePathBehaviour
+                        }
                     } +
                     attributeIfTrue(
                         "EndpointConfiguration",

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -229,6 +229,13 @@ object.
                     "Names" : "LogMetrics",
                     "Subobjects" : true,
                     "Children" : logMetricChildrenConfiguration
+                },
+                {
+                    "Names" : "BasePathBehaviour",
+                    "Description" : "How to handle base paths provided in the spec",
+                    "Type" : STRING_TYPE,
+                    "Values" : [ "ignore", "prepend", "split" ],
+                    "Default" : "ignore"
                 }
             ]
         },


### PR DESCRIPTION
Based on https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-import-api-basePath.html 

 you can specify how API Gateway handles a basepath parameter defined in a swagger spec. This PR adds support for how to handle the basepath 
 - ignore
- prepend ( add all of the basepath)
- split ( drop the first path, intended to work with stage names ) 