### PR TITLE
<refactor> Add dynamic state routine lookup

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -815,200 +815,26 @@ behaviour.
 
         [/#if]
 
-        [#switch core.Type!""]
-            [#case LB_COMPONENT_TYPE]
-                [#local result = getLBState(occurrence)]
-                [#break]
+        [#local stateMacro = ["aws", core.Type!"", "cf", "state"]?join("_")]
+        [#if (.vars[stateMacro]!"")?is_directive]
+            [@(.vars[stateMacro]) occurrence parentOccurrence result /]
+            [#local result = componentState]
+        [#else]
 
-            [#case LB_PORT_COMPONENT_TYPE]
-                [#local result = getLBPortState(occurrence, parentOccurrence)]
-                [#break]
-
-            [#case APIGATEWAY_COMPONENT_TYPE]
-                [#local result = getAPIGatewayState(occurrence)]
-                [#break]
-
-            [#case APIGATEWAY_USAGEPLAN_COMPONENT_TYPE]
-                [#local result = getAPIGatewayUsagePlanState(occurrence)]
-                [#break]
-
-            [#case "cache"]
-                [#local result = getCacheState(occurrence)]
-                [#break]
-
-            [#case "contenthub"]
-                [#local result = getContentHubState(occurrence, result)]
-                [#break]
-
-            [#case "contentnode"]
-                [#local result = getContentNodeState(occurrence)]
-                [#break]
-
-            [#case DATAFEED_COMPONENT_TYPE]
-                [#local result = getDataFeedState(occurrence)]
-                [#break]
-
-            [#case DATASET_COMPONENT_TYPE ]
-                [#local result = getDataSetState(occurrence)]
-                [#break]
-
-            [#case DATAPIPELINE_COMPONENT_TYPE ]
-                [#local result = getDataPipelineState(occurrence)]
-                [#break]
-
-            [#case DATAVOLUME_COMPONENT_TYPE ]
-                [#local result = getDataVolumeState(occurrence)]
-                [#break]
-
-            [#case EC2_COMPONENT_TYPE]
-                [#local result = getEC2State(occurrence)]
-                [#break]
-
-            [#case COMPUTECLUSTER_COMPONENT_TYPE]
-                [#local result = getComputeClusterState(occurrence)]
-                [#break]
-
-            [#case "ecs"]
-                [#local result = getECSState(occurrence)]
-                [#break]
-
-            [#case "efs"]
-                [#local result = getEFSState(occurrence)]
-                [#break]
-
-            [#case "efsMount" ]
-                [#local result = getEFSMountState(occurrence, parentOccurrence)]
-                [#break]
-
-            [#case ES_COMPONENT_TYPE]
-                [#local result = getESState(occurrence, result)]
-                [#break]
-
-            [#case "function"]
-                [#local result = getFunctionState(occurrence, parentOccurrence)]
-                [#break]
-
-            [#case "lambda"]
-                [#local result = getLambdaState(occurrence)]
-                [#break]
-
-            [#case MOBILEAPP_COMPONENT_TYPE]
-                [#local result = getMobileAppState(occurrence)]
-                [#break]
-
-            [#case MOBILENOTIFIER_COMPONENT_TYPE ]
-                [#local result = getMobileNotifierState(occurrence)]
-                [#break]
-
-            [#case MOBILENOTIFIER_PLATFORM_COMPONENT_TYPE ]
-                [#local result = getMobileNotifierPlatformState(occurrence)]
-                [#break]
-
-            [#case "rds"]
-                [#local result = getRDSState(occurrence)]
-                [#break]
-
-            [#case SERVICE_REGISTRY_COMPONENT_TYPE]
-                [#local result = getServiceRegistryState(occurrence)]
-                [#break]
-            
-            [#case SERVICE_REGISTRY_SERVICE_COMPONENT_TYPE]
-                [#local result = getServiceRegistryServiceState(occurrence, parentOccurrence)]
-                [#break]
-
-            [#case "s3"]
-                [#local result = getS3State(occurrence)]
-                [#break]
-
-            [#case "service"]
-                [#local result = getServiceState(occurrence)]
-                [#break]
-
-            [#case "spa"]
-                [#local result = getSPAState(occurrence)]
-                [#break]
-
-            [#case SQS_COMPONENT_TYPE]
-                [#local result = getSQSState(occurrence, result)]
-                [#break]
-
-            [#case CONFIGSTORE_COMPONENT_TYPE]
-                [#local result = getConfigStoreState(occurrence)]
-                [#break]
-
-            [#case CONFIGSTORE_BRANCH_COMPONENT_TYPE]
-                [#local result = getConfigBranchState(occurrence, parentOccurrence)]
-                [#break]
-
-            [#case "task"]
-                [#local result = getTaskState(occurrence, parentOccurrence)]
-                [#break]
-
-            [#case USER_COMPONENT_TYPE ]
-                [#local result = getUserState(occurrence) ]
-                [#break]
-
-            [#case USERPOOL_COMPONENT_TYPE]
-                [#local result = getUserPoolState(occurrence, result)]
-                [#break]
-
-            [#case USERPOOL_CLIENT_COMPONENT_TYPE]
-                [#local result = getUserPoolClientState(occurrence, parentOccurrence)]
-                [#break]
-
-            [#case USERPOOL_AUTHPROVIDER_COMPONENT_TYPE]
-                [#local result = getUserPoolAuthProviderState(occurrence)]
-                [#break]
-
-            [#case BASTION_COMPONENT_TYPE ]
-                [#local result = getBastionState(occurrence)]
-                [#break]
-
-            [#case NETWORK_COMPONENT_TYPE ]
-                [#local result = getNetworkState(occurrence)]
-                [#break]
-
-            [#case NETWORK_ROUTE_TABLE_COMPONENT_TYPE ]
-                [#local result = getNetworkRouteTableState(occurrence )]
-                [#break]
-
-            [#case NETWORK_ACL_COMPONENT_TYPE ]
-                [#local result = getNetworkACLState(occurrence)]
-                [#break]
-
-            [#case NETWORK_GATEWAY_COMPONENT_TYPE ]
-                [#local result = getNetworkGatewayState(occurrence)]
-                [#break]
-
-            [#case NETWORK_GATEWAY_DESTINATION_COMPONENT_TYPE ]
-                [#local result = getNetworkGatewayDestinationState(occurrence, parentOccurrence)]
-                [#break]
-
-            [#case BASELINE_COMPONENT_TYPE ]
-                [#local result = getBaselineState(occurrence)]
-                [#break]
-
-            [#case BASELINE_DATA_COMPONENT_TYPE ]
-                [#local result = getBaselineStorageState(occurrence, parentOccurrence)]
-                [#break]
-
-            
-            [#case BASELINE_KEY_COMPONENT_TYPE ]
-                [#local result = getBaselineKeyState(occurrence, parentOccurrence)]
-                [#break]
-
-            [#case "external"]
-                [#local result +=
-                    {
-                        "Roles" : {
-                            "Inbound" : {},
-                            "Outbound" : {}
+            [#switch core.Type!""]
+                [#case "external"]
+                    [#local result +=
+                        {
+                            "Roles" : {
+                                "Inbound" : {},
+                                "Outbound" : {}
+                            }
                         }
-                    }
-                ]
-                [#break]
+                    ]
+                    [#break]
 
-        [/#switch]
+            [/#switch]
+        [/#if]
     [/#if]
 
     [#-- Update resource deployment status --]

--- a/aws/templates/id/id_apigateway.ftl
+++ b/aws/templates/id/id_apigateway.ftl
@@ -321,6 +321,11 @@ If Certificate is not configured, then Mode 1 is used if CloudFront is
 configured and Mode 4 is used if CloudFront is not configured. No mappings are
 created in either case.
 --]
+
+[#macro aws_apigateway_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getAPIGatewayState(occurrence)]
+[/#macro]
+
 [#function getAPIGatewayState occurrence]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
@@ -640,6 +645,10 @@ created in either case.
         }
     ]
 [/#function]
+
+[#macro aws_apiusageplan_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getAPIGatewayUsagePlanState(occurrence)]
+[/#macro]
 
 [#function getAPIGatewayUsagePlanState occurrence]
     [#local core = occurrence.Core]

--- a/aws/templates/id/id_baseline.ftl
+++ b/aws/templates/id/id_baseline.ftl
@@ -147,6 +147,9 @@
         }
     }]
 
+[#macro aws_baseline_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getBaselineState(occurrence)]
+[/#macro]
 
 [#function getBaselineState occurrence]
     [#local core = occurrence.Core]
@@ -192,6 +195,10 @@
     ]
     [#return result ]
 [/#function]
+
+[#macro aws_baselinedata_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getBaselineStorageState(occurrence, parent)]
+[/#macro]
 
 [#function getBaselineStorageState occurrence parent ]
     [#local core = occurrence.Core]
@@ -252,6 +259,10 @@
     [#return result ]
 [/#function]
 
+[#macro aws_baselinekey_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getBaselineKeyState(occurrence, parent)]
+[/#macro]
+
 [#function getBaselineKeyState occurrence parent ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
@@ -278,7 +289,7 @@
                 [#local cmkAliasName = core.FullName ]
             [/#if]
 
-            [#local resources += 
+            [#local resources +=
                 {
                     "cmk" : {
                         "Id" : legacyVpc?then(formatSegmentCMKId(), cmkId),
@@ -309,7 +320,7 @@
                 [#local keyPairName = core.FullName ]
             [/#if]
 
-            [#local resources += 
+            [#local resources +=
                 {
                     "localKeyPair" : {
                         "Id" : formatResourceId(LOCAL_SSH_PRIVATE_KEY_RESOURCE_TYPE, core.Id),
@@ -331,7 +342,7 @@
             [#local OAIId = formatResourceId( AWS_CLOUDFRONT_ACCESS_ID_RESOURCE_TYPE, core.Id) ]
             [#local OAIName = core.FullName ]
 
-            [#local resources += 
+            [#local resources +=
                 {
                     "originAccessId" : {
                         "Id" : OAIId,
@@ -392,4 +403,4 @@
             formatSegmentS3Id("application"),
             formatSegmentS3Id("backups")
         )]
-[/#function]    
+[/#function]

--- a/aws/templates/id/id_bastion.ftl
+++ b/aws/templates/id/id_bastion.ftl
@@ -37,14 +37,14 @@
                     "Type" : STRING_TYPE,
                     "Default" : ""
                 },
-                { 
+                {
                     "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : profileChildConfiguration + 
+                    "Children" : profileChildConfiguration +
                                     [
                                         {
                                             "Names" : "Processor",
@@ -86,6 +86,10 @@
         }
     }]
 
+[#macro aws_bastion_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getBastionState(occurrence)]
+[/#macro]
+
 [#function getBastionState occurrence]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
@@ -120,7 +124,7 @@
                     "Name" : core.FullName,
                     "Type" : AWS_EC2_AUTO_SCALE_GROUP_RESOURCE_TYPE
                 },
-                "lg" : {             
+                "lg" : {
                     "Id" : formatLogGroupId(core.Id),
                     "Name" : core.FullAbsolutePath,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
@@ -132,7 +136,7 @@
                                 formatResourceId(AWS_EC2_LAUNCH_CONFIG_RESOURCE_TYPE, core.Id)
                     ),
                     "Type" : AWS_EC2_LAUNCH_CONFIG_RESOURCE_TYPE
-                } 
+                }
             },
             "Attributes" : {
             },

--- a/aws/templates/id/id_cache.ftl
+++ b/aws/templates/id/id_cache.ftl
@@ -51,7 +51,7 @@
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : profileChildConfiguration + 
+                    "Children" : profileChildConfiguration +
                                     [
                                         {
                                             "Names" : "Processor",
@@ -84,6 +84,10 @@
             ]
         }
 }]
+
+[#macro aws_cache_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getCacheState(occurrence)]
+[/#macro]
 
 [#function getCacheState occurrence]
     [#local core = occurrence.Core]

--- a/aws/templates/id/id_computecluster.ftl
+++ b/aws/templates/id/id_computecluster.ftl
@@ -3,7 +3,7 @@
 
 [#assign componentConfiguration +=
     {
-        COMPUTECLUSTER_COMPONENT_TYPE : { 
+        COMPUTECLUSTER_COMPONENT_TYPE : {
             "Properties" : [
                 {
                     "Type" : "Description",
@@ -31,7 +31,7 @@
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : profileChildConfiguration + 
+                    "Children" : profileChildConfiguration +
                                     [
                                         {
                                             "Names" : "Processor",
@@ -73,8 +73,12 @@
         }
     }]
 
+[#macro aws_computecluster_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getComputeClusterState(occurrence)]
+[/#macro]
+
 [#function getComputeClusterState occurrence]
-    
+
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution ]
     [#local buildReference = getOccurrenceBuildReference(occurrence) ]
@@ -100,7 +104,7 @@
                     "Name" : core.FullName,
                     "Type" : AWS_EC2_AUTO_SCALE_GROUP_RESOURCE_TYPE
                 },
-                "lg" : {             
+                "lg" : {
                     "Id" : formatLogGroupId(core.Id),
                     "Name" : core.FullAbsolutePath,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
@@ -122,7 +126,7 @@
                                 replaceAlphaNumericOnly(buildReference))
                     ),
                     "Type" : AWS_EC2_LAUNCH_CONFIG_RESOURCE_TYPE
-                } 
+                }
             },
             "Attributes" : {
             },

--- a/aws/templates/id/id_contenthub.ftl
+++ b/aws/templates/id/id_contenthub.ftl
@@ -9,7 +9,7 @@
 
 [#assign componentConfiguration +=
     {
-        CONTENTHUB_HUB_COMPONENT_TYPE : { 
+        CONTENTHUB_HUB_COMPONENT_TYPE : {
             "Properties" : [
                 {
                     "Type" : "Description",
@@ -49,6 +49,10 @@
         }
     }]
 
+[#macro aws_contenthub_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getContentHubState(occurrence, baseState)]
+[/#macro]
+
 [#function getContentHubState occurrence baseState]
     [#local core = occurrence.Core]
 
@@ -59,7 +63,7 @@
         [#local prefix = (baseState.Attributes["PREFIX"])!"COTException: Prefix not found" ]
 
         [#return
-            baseState + 
+            baseState +
             {
                 "Attributes" : {
                     "ENGINE" : engine,
@@ -92,7 +96,7 @@
                     "REPOSITORY" : repoistory,
                     "BRANCH" : branch,
                     "PREFIX" : prefix
-                },           
+                },
                 "Roles" : {
                     "Inbound" : {},
                     "Outbound" : {}
@@ -107,7 +111,7 @@
 
 [#assign componentConfiguration +=
     {
-        CONTENTHUB_NODE_COMPONENT_TYPE : { 
+        CONTENTHUB_NODE_COMPONENT_TYPE : {
             "Properties" : [
                 {
                     "Type" : "Description",
@@ -135,6 +139,10 @@
             ]
         }
     }]
+
+[#macro aws_contentnode_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getContentNodeState(occurrence)]
+[/#macro]
 
 [#function getContentNodeState occurrence]
     [#local core = occurrence.Core]

--- a/aws/templates/id/id_datafeed.ftl
+++ b/aws/templates/id/id_datafeed.ftl
@@ -17,7 +17,7 @@
                 },
                 {
                     "Type" : "ComponentLevel",
-                    "Value" : "solution" 
+                    "Value" : "solution"
                 }
             ],
             "Attributes" : [
@@ -89,7 +89,7 @@
                             "Values" : [ "AllDocuments", "FailedDocumentsOnly" ],
                             "Default" : "FailedDocumentsOnly"
                         }
-                    ]   
+                    ]
                 },
                 {
                     "Names" : "Destination",
@@ -121,6 +121,10 @@
     }
 ]
 
+[#macro aws_datafeed_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getDataFeedState(occurrence)]
+[/#macro]
+
 [#function getDataFeedState occurrence ]
 
     [#local core = occurrence.Core]
@@ -133,7 +137,7 @@
     [#return
         {
             "Resources" : {
-                "stream" : { 
+                "stream" : {
                     "Id" : streamId,
                     "Name" : streamName,
                     "Type" : AWS_KINESIS_FIREHOSE_STREAM_RESOURCE_TYPE,
@@ -143,7 +147,7 @@
                     "Id" : formatResourceId(AWS_IAM_ROLE_RESOURCE_TYPE, core.Id),
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
                 }
-            } + 
+            } +
             solution.Logging?then(
                 {
                     "lg" : {
@@ -163,7 +167,7 @@
                     }
                 },
                 {}
-            ) + 
+            ) +
             (solution.LogWatchers?has_content)?then(
                 {
                     "subscriptionRole" : {

--- a/aws/templates/id/id_datapipeline.ftl
+++ b/aws/templates/id/id_datapipeline.ftl
@@ -61,7 +61,7 @@
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : profileChildConfiguration + 
+                    "Children" : profileChildConfiguration +
                                     [
                                         {
                                             "Names" : "Processor",
@@ -74,8 +74,13 @@
         }
     }]
 
+
+[#macro aws_datapipeline_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getDataPipelineState(occurrence)]
+[/#macro]
+
 [#function getDataPipelineState occurrence]
-    
+
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution ]
     [#local buildReference = getOccurrenceBuildReference(occurrence) ]

--- a/aws/templates/id/id_dataset.ftl
+++ b/aws/templates/id/id_dataset.ftl
@@ -50,8 +50,13 @@
         }
     }]
 
+
+[#macro aws_dataset_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getDataSetState(occurrence)]
+[/#macro]
+
 [#function getDataSetState occurrence]
-    
+
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution ]
     [#local buildReference = getOccurrenceBuildReference(occurrence, true ) ]
@@ -78,20 +83,20 @@
 
             [#local attributes += {
                 "DATASET_PREFIX" : datasetPrefix,
-                "DATASET_REGISTRY" : "s3://" + registryBucket + 
+                "DATASET_REGISTRY" : "s3://" + registryBucket +
                                             formatAbsolutePath(
                                                 registryPrefix),
-                "DATASET_LOCATION" : "s3://" + registryBucket + 
+                "DATASET_LOCATION" : "s3://" + registryBucket +
                                             formatAbsolutePath(
                                                 registryPrefix,
                                                 buildReference)
                 }]
 
             [#local consumePolicy +=
-                    s3ConsumePermission( 
+                    s3ConsumePermission(
                         registryBucket,
                         registryPrefix)]
-            
+
             [#local resources += {
                 "datasetS3" : {
                     "Id" : formatId(DATASET_S3_SNAPSHOT_RESOURCE_TYPE, core.Id),
@@ -109,7 +114,7 @@
                                         registryPrefix,
                                         "rdssnapshot",
                                         productId,
-                                        dataSetDeploymentUnit, 
+                                        dataSetDeploymentUnit,
                                         buildReference)]
 
             [#local attributes += {
@@ -154,23 +159,23 @@
                 [#assign linkTargetConfiguration = linkTarget.Configuration ]
                 [#assign linkTargetResources = linkTarget.State.Resources ]
                 [#assign linkTargetAttributes = linkTarget.State.Attributes ]
-                
+
                 [#local attributes += linkTargetAttributes]
 
                 [#switch linkTargetCore.Type]
                     [#case S3_COMPONENT_TYPE ]
-                        [#local attributes += { 
+                        [#local attributes += {
                             "DATASET_MASTER_LOCATION" :  "s3://" + linkTargetAttributes.NAME + formatAbsolutePath(datasetPrefix )
                         }]
                         [#local producePolicy += s3ProducePermission(
                                                     linkTargetAttributes.NAME,
-                                                    datasetPrefix 
+                                                    datasetPrefix
                             )]
                         [#break]
 
                     [#case RDS_COMPONENT_TYPE ]
                         [#break]
-                    
+
                     [#default]
                         [#local attributes += {
                             "DATASET_ENGINE" : "COTException: DataSet Support not available for " + linkTargetCore.Type

--- a/aws/templates/id/id_datavolume.ftl
+++ b/aws/templates/id/id_datavolume.ftl
@@ -85,6 +85,10 @@
         }
     }]
 
+[#macro aws_datavolume_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getDataVolumeState(occurrence)]
+[/#macro]
+
 [#function getDataVolumeState occurrence]
 
     [#local core = occurrence.Core]
@@ -100,7 +104,7 @@
 
     [#list resourceZones as zone ]
         [#local dataVolumeId = formatResourceId(AWS_EC2_EBS_RESOURCE_TYPE, core.Id, zone.Id )]
-        [#local zoneResources += 
+        [#local zoneResources +=
             {
                 zone.Id : {
                     "ebsVolume" : {
@@ -108,7 +112,7 @@
                         "Name" : core.FullName,
                         "Type" : AWS_EC2_EBS_RESOURCE_TYPE
                     }
-                } + 
+                } +
                 (solution.Backup.Enabled)?then(
                     {
                         "taskCreateSnapshot" : {
@@ -136,7 +140,7 @@
                     "Type" : AWS_EC2_EBS_MANUAL_SNAPSHOT_RESOURCE_TYPE
                 },
                 "Zones" : zoneResources
-            } + 
+            } +
             (solution.Backup.Enabled)?then(
                 {
                     "maintenanceWindow" : {
@@ -153,7 +157,7 @@
                         "Id" : formatResourceId( AWS_IAM_ROLE_RESOURCE_TYPE, "service", core.Id  ),
                         "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
                     },
-                    "maintenanceLambdaRole" : { 
+                    "maintenanceLambdaRole" : {
                         "Id" : formatResourceId( AWS_IAM_ROLE_RESOURCE_TYPE, "lambda", core.Id ),
                         "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
                     }

--- a/aws/templates/id/id_ec2.ftl
+++ b/aws/templates/id/id_ec2.ftl
@@ -149,6 +149,10 @@
         }
     }]
 
+[#macro aws_ec2_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getEC2State(occurrence)]
+[/#macro]
+
 [#function getEC2State occurrence]
     [#local core = occurrence.Core]
 
@@ -197,7 +201,7 @@
                     "Id" : formatComponentRoleId(core.Tier, core.Component),
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
                 },
-                "lg" : {             
+                "lg" : {
                     "Id" : formatLogGroupId(core.Id),
                     "Name" : core.FullAbsolutePath,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE

--- a/aws/templates/id/id_ecs.ftl
+++ b/aws/templates/id/id_ecs.ftl
@@ -440,6 +440,9 @@
         }
     } ]
 
+[#macro aws_ecs_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getECSState(occurrence)]
+[/#macro]
 
 [#function getECSState occurrence]
     [#local core = occurrence.Core ]
@@ -532,6 +535,10 @@
     ]
 [/#function]
 
+[#macro aws_service_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getServiceState(occurrence)]
+[/#macro]
+
 [#function getServiceState occurrence]
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
@@ -620,6 +627,10 @@
         }
     ]
 [/#function]
+
+[#macro aws_task_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getTaskState(occurrence, parent)]
+[/#macro]
 
 [#function getTaskState occurrence parent]
     [#local core = occurrence.Core ]

--- a/aws/templates/id/id_efs.ftl
+++ b/aws/templates/id/id_efs.ftl
@@ -56,7 +56,7 @@
                 {
                     "Type" : EFS_MOUNT_COMPONENT_TYPE,
                     "Component" : "Mounts",
-                    "Link" : "Mount" 
+                    "Link" : "Mount"
                 }
             ]
         },
@@ -85,6 +85,10 @@
         }
     }]
 
+[#macro aws_efs_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getEFSState(occurrence)]
+[/#macro]
+
 [#function getEFSState occurrence]
 
     [#local core = occurrence.Core]
@@ -93,7 +97,7 @@
 
     [#local zoneResources = {} ]
     [#list zones as zone ]
-        [#local zoneResources += 
+        [#local zoneResources +=
             {
                 zone.Id : {
                     "efsMountTarget" : {
@@ -127,12 +131,16 @@
     ]
 [/#function]
 
+[#macro aws_efsmount_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getEFSMountState(occurrence, parent)]
+[/#macro]
+
 [#function getEFSMountState occurrence parent ]
     [#local configuration = occurrence.Configuration.Solution]
 
     [#local efsId = parent.State.Attributes["EFS"] ]
 
-    [#return 
+    [#return
         {
             "Resources" : {},
             "Attributes" : {

--- a/aws/templates/id/id_es.ftl
+++ b/aws/templates/id/id_es.ftl
@@ -83,7 +83,7 @@
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : profileChildConfiguration + 
+                    "Children" : profileChildConfiguration +
                                     [
                                         {
                                             "Names" : "Processor",
@@ -101,6 +101,14 @@
         }
     }]
 
+[#macro aws_elasticsearch_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getESState(occurrence, baseState)]
+[/#macro]
+
+[#macro aws_es_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getESState(occurrence, baseState)]
+[/#macro]
+
 [#function getESState occurrence baseState]
     [#local core = occurrence.Core]
 
@@ -111,7 +119,7 @@
             valueIfContent(
                 {
                     "Resources" : {
-                        "es" : { 
+                        "es" : {
                             "Id" : esId,
                             "Type" : AWS_ES_RESOURCE_TYPE,
                             "Deployed" : true
@@ -140,7 +148,7 @@
     [#return
         {
             "Resources" : {
-                "es" : { 
+                "es" : {
                     "Id" : esId,
                     "Name" : core.ShortFullName,
                     "Type" : AWS_ES_RESOURCE_TYPE,

--- a/aws/templates/id/id_lambda.ftl
+++ b/aws/templates/id/id_lambda.ftl
@@ -211,6 +211,10 @@
     }
 ]
 
+[#macro aws_lambda_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getLambdaState(occurrence)]
+[/#macro]
+
 [#function getLambdaState occurrence]
     [#local core = occurrence.Core]
 
@@ -233,6 +237,10 @@
         }
     ]
 [/#function]
+
+[#macro aws_function_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getFunctionState(occurrence, parent)]
+[/#macro]
 
 [#function getFunctionState occurrence parent]
     [#local core = occurrence.Core]

--- a/aws/templates/id/id_lb.ftl
+++ b/aws/templates/id/id_lb.ftl
@@ -242,6 +242,10 @@
         }
     }]
 
+[#macro aws_lb_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getLBState(occurrence)]
+[/#macro]
+
 [#function getLBState occurrence]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution ]
@@ -256,15 +260,15 @@
         [#case "application" ]
             [#assign resourceType = AWS_LB_APPLICATION_RESOURCE_TYPE ]
             [#break]
-        
+
         [#case "network" ]
             [#assign resourceType = AWS_LB_NETWORK_RESOURCE_TYPE ]
             [#break]
-        
+
         [#case "classic" ]
             [#assign resourceType = AWS_LB_CLASSIC_RESOURCE_TYPE ]
             [#break]
-        
+
         [#default]
             [#assign resourceType = "COTException: Unkown LB Engine" ]
     [/#switch]
@@ -290,6 +294,10 @@
         }
     ]
 [/#function]
+
+[#macro aws_lbport_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getLBPortState(occurrence, parent)]
+[/#macro]
 
 [#function getLBPortState occurrence parent]
     [#local core = occurrence.Core]
@@ -348,7 +356,7 @@
             [#local path = solution.Path ]
         [/#if]
     [/#if]
-    
+
     [#local url = scheme + "://" + fqdn  ]
     [#local internalUrl = scheme + "://" + internalFqdn ]
 

--- a/aws/templates/id/id_mobileapp.ftl
+++ b/aws/templates/id/id_mobileapp.ftl
@@ -8,7 +8,7 @@
 
 [#assign componentConfiguration +=
     {
-        MOBILEAPP_COMPONENT_TYPE : { 
+        MOBILEAPP_COMPONENT_TYPE : {
             "Properties" : [
                 {
                     "Type" : "Description",
@@ -50,6 +50,10 @@
         }
     }]
 
+[#macro aws_mobileapp_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getMobileAppState(occurrence)]
+[/#macro]
+
 [#function getMobileAppState occurrence]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
@@ -62,7 +66,7 @@
 
     [#local releaseChannel = getOccurrenceSettingValue(occurrence, "RELEASE_CHANNEL", true)?has_content?then(
             getOccurrenceSettingValue(occurrence, "RELEASE_CHANNEL", true),
-            environmentName 
+            environmentName
     )]
 
     [#local codeSrcBucket = getRegistryEndPoint("scripts", occurrence)]

--- a/aws/templates/id/id_mobilenotifier.ftl
+++ b/aws/templates/id/id_mobilenotifier.ftl
@@ -121,6 +121,10 @@
         }
     }]
 
+[#macro aws_mobilenotifier_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getMobileNotifierState(occurrence)]
+[/#macro]
+
 [#function getMobileNotifierState occurrence]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
@@ -153,6 +157,10 @@
             formatLogGroupId(name, failureId)
         ) ]
 [/#function]
+
+[#macro aws_mobilenotifierplatform_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getMobileNotifierPlatformState(occurrence)]
+[/#macro]
 
 [#function getMobileNotifierPlatformState occurrence]
     [#local core = occurrence.Core]

--- a/aws/templates/id/id_network.ftl
+++ b/aws/templates/id/id_network.ftl
@@ -190,6 +190,10 @@
         }
     }]
 
+[#macro aws_network_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getNetworkState(occurrence)]
+[/#macro]
+
 [#function getNetworkState occurrence]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
@@ -334,6 +338,10 @@
     [#return result ]
 [/#function]
 
+[#macro aws_networkroute_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getNetworkRouteTableState(occurrence)]
+[/#macro]
+
 [#function getNetworkRouteTableState occurrence ]
 
     [#local core = occurrence.Core]
@@ -394,6 +402,10 @@
         }
     ]
 [/#function]
+
+[#macro aws_networkacl_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getNetworkACLState(occurrence)]
+[/#macro]
 
 [#function getNetworkACLState occurrence ]
     [#local core = occurrence.Core]

--- a/aws/templates/id/id_networkgateway.ftl
+++ b/aws/templates/id/id_networkgateway.ftl
@@ -79,7 +79,7 @@
                     "Type" : ARRAY_OF_STRING_TYPE,
                     "Default" : []
                 },
-                { 
+                {
                     "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
@@ -87,6 +87,10 @@
             ]
         }
     }]
+
+[#macro aws_gateway_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getNetworkGatewayState(occurrence)]
+[/#macro]
 
 [#function getNetworkGatewayState occurrence ]
 
@@ -109,7 +113,7 @@
             [#list resourceZones as zone ]
                 [#local eipId = legacyVpc?then(
                                     formatResourceId(AWS_EIP_RESOURCE_TYPE, core.Tier.Id, core.Component.Id, zone.Id),
-                                    formatResourceId(AWS_EIP_RESOURCE_TYPE, core.Id, zone.Id))]    
+                                    formatResourceId(AWS_EIP_RESOURCE_TYPE, core.Id, zone.Id))]
                 [#local zoneResources = mergeObjects( zoneResources,
                         {
                             zone.Id : {
@@ -124,7 +128,7 @@
     [/#switch]
 
     [#switch engine ]
-        [#case "natgw"] 
+        [#case "natgw"]
 
             [#list resourceZones as zone]
                 [#local natGatewayId = legacyVpc?then(
@@ -171,20 +175,20 @@
                 }]
             [#break]
 
-        [#default]  
+        [#default]
             @cfException
                 mode=listMode
                 description="Unkown Engine Type"
                 context=occurrence.Configuration.Solution
             /]
-    [/#switch] 
+    [/#switch]
 
-    [#return 
+    [#return
         {
-            "Resources" : 
-                resources + 
-                { 
-                    "Zones" : zoneResources 
+            "Resources" :
+                resources +
+                {
+                    "Zones" : zoneResources
                 },
             "Attributes" : {
             },
@@ -196,6 +200,10 @@
     ]
 [/#function]
 
+[#macro aws_gatewaydestination_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getNetworkGatewayDestinationState(occurrence, parent)]
+[/#macro]
+
 [#function getNetworkGatewayDestinationState occurrence parent ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
@@ -203,7 +211,7 @@
     [#local parentCore = parent.Core]
     [#local parentSolution = parent.Configuration.Solution ]
     [#local engine = parentSolution.Engine ]
-    
+
     [#if multiAZ!false || engine == "vpcendpoint" ]
         [#local resourceZones = zones ]
     [#else]
@@ -229,7 +237,7 @@
                     [#local endpointZones += { id : endpointTypeZones + [ zone.Id ] }]
                     [#local resources = mergeObjects( resources, {
                         "vpcEndpoints" : {
-                            "vpcEndpoint" + id : { 
+                            "vpcEndpoint" + id : {
                                 "Id" : formatResourceId(AWS_VPC_ENDPOINNT_RESOURCE_TYPE, core.Id, replaceAlphaNumericOnly(id, "X")),
                                 "EndpointType" : networkEndpoint.Type?lower_case,
                                 "EndpointZones" : endpointZones[id],
@@ -242,7 +250,7 @@
             [/#list]
             [#break]
 
-        [#default]  
+        [#default]
             [@cfException
                 mode=listMode
                 description="Unkown Engine Type"
@@ -250,7 +258,7 @@
             /]
     [/#switch]
 
-    [#return 
+    [#return
         {
             "Resources" : resources,
             "Attributes" : {

--- a/aws/templates/id/id_rds.ftl
+++ b/aws/templates/id/id_rds.ftl
@@ -139,7 +139,7 @@
                 },
                 {
                     "Names" : "Profiles",
-                    "Children" : profileChildConfiguration + 
+                    "Children" : profileChildConfiguration +
                                     [
                                         {
                                             "Names" : "Processor",
@@ -183,6 +183,10 @@
             ]
     }
 }]
+
+[#macro aws_rds_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getRDSState(occurrence)]
+[/#macro]
 
 [#function getRDSState occurrence]
     [#local core = occurrence.Core]

--- a/aws/templates/id/id_s3.ftl
+++ b/aws/templates/id/id_s3.ftl
@@ -186,6 +186,10 @@
         }
     }]
 
+[#macro aws_s3_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getS3State(occurrence)]
+[/#macro]
+
 [#function getS3State occurrence]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]

--- a/aws/templates/id/id_serviceregistry.ftl
+++ b/aws/templates/id/id_serviceregistry.ftl
@@ -101,6 +101,10 @@
         }
     }]
 
+[#macro aws_serviceregistry_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getServiceRegistryState(occurrence)]
+[/#macro]
+
 [#function getServiceRegistryState occurrence ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
@@ -117,7 +121,7 @@
                     "DomainName" : domainName,
                     "Type" : AWS_CLOUDMAP_DNS_NAMESPACE_RESOURCE_TYPE
                 }
-            }, 
+            },
             "Attributes" : {
                 "DOMAIN_NAME" : domainName
             },
@@ -129,6 +133,9 @@
     ]
 [/#function]
 
+[#macro aws_serviceregistryservice_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getServiceRegistryServiceState(occurrence, parent)]
+[/#macro]
 
 [#function getServiceRegistryServiceState occurrence parent ]
     [#local core = occurrence.Core]
@@ -154,7 +161,7 @@
                     "ServiceName" : serviceHost,
                     "Type" : AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE
                 }
-            }, 
+            },
             "Attributes" : {
                 "FQDN" : hostName,
                 "RECORD_TYPES" : solution.RecordTypes?join(","),

--- a/aws/templates/id/id_spa.ftl
+++ b/aws/templates/id/id_spa.ftl
@@ -201,7 +201,11 @@
             ]
         }
     }]
-    
+
+[#macro aws_spa_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getSPAState(occurrence)]
+[/#macro]
+
 [#function getSPAState occurrence]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
@@ -241,16 +245,16 @@
                     "Id" : "spa",
                     "Type" : AWS_CLOUDFRONT_ORIGIN_RESOURCE_TYPE
                 },
-                "cforiginconfig" : { 
+                "cforiginconfig" : {
                     "Id" : "config",
                     "Type" : AWS_CLOUDFRONT_ORIGIN_RESOURCE_TYPE
                 },
-                "wafacl" : { 
+                "wafacl" : {
                     "Id" : formatDependentWAFAclId(cfId),
                     "Name" : formatComponentWAFAclName(core.Tier, core.Component, occurrence),
                     "Type" : AWS_WAF_ACL_RESOURCE_TYPE
                 }
-            } + 
+            } +
             attributeIfContent( "paths", pathResources ),
             "Attributes" : {
                 "FQDN" : fqdn,

--- a/aws/templates/id/id_sqs.ftl
+++ b/aws/templates/id/id_sqs.ftl
@@ -66,7 +66,11 @@
             ]
         }
     }]
-    
+
+[#macro aws_sqs_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getSQSState(occurrence, baseState)]
+[/#macro]
+
 [#function getSQSState occurrence baseState]
     [#local core = occurrence.Core]
 
@@ -97,17 +101,17 @@
         ]
     [#else]
         [#local solution = occurrence.Configuration.Solution]
-        
+
         [#local id = formatResourceId(AWS_SQS_RESOURCE_TYPE, core.Id) ]
         [#local name = core.FullName ]
-    
+
         [#local dlqId = formatDependentResourceId(AWS_SQS_RESOURCE_TYPE, id, "dlq") ]
         [#local dlqName = formatName(name, "dlq")]
 
         [#assign dlqRequired =
             isPresent(solution.DeadLetterQueue) ||
             ((environmentObject.Operations.DeadLetterQueue.Enabled)!false)]
-    
+
         [#return
             {
                 "Resources" : {
@@ -117,7 +121,7 @@
                         "Type" : AWS_SQS_RESOURCE_TYPE,
                         "Monitored" : true
                     }
-                } + 
+                } +
                 dlqRequired?then(
                     {
                         "dlq" : {

--- a/aws/templates/id/id_user.ftl
+++ b/aws/templates/id/id_user.ftl
@@ -26,7 +26,7 @@
                     "Type" : STRING_TYPE,
                     "Default" : ""
                 },
-                { 
+                {
                     "Names" : "Links",
                     "Subobjects" : true,
                     "Children" : linkChildrenConfiguration
@@ -85,6 +85,10 @@
             ]
         }
     }]
+
+[#macro aws_user_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getUserState(occurrence)]
+[/#macro]
 
 [#function getUserState occurrence]
     [#local core = occurrence.Core]

--- a/aws/templates/id/id_userpool.ftl
+++ b/aws/templates/id/id_userpool.ftl
@@ -306,6 +306,10 @@
         }
     }]
 
+[#macro aws_userpool_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getUserPoolState(occurrence, baseState)]
+[/#macro]
+
 [#function getUserPoolState occurrence baseState]
     [#local core = occurrence.Core]
 
@@ -463,6 +467,10 @@
     [/#if]
 [/#function]
 
+[#macro aws_userpoolclient_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getUserPoolClientState(occurrence, parent)]
+[/#macro]
+
 [#function getUserPoolClientState occurrence parent ]
     [#local core = occurrence.Core]
 
@@ -496,6 +504,10 @@
             }
         }]
 [/#function]
+
+[#macro aws_userpoolauthprovider_cf_state occurrence parent={} baseState={}  ]
+    [#assign componentState = getUserPoolAuthProviderState(occurrence)]
+[/#macro]
 
 [#function getUserPoolAuthProviderState occurrence ]
     [#local core = occurrence.Core]


### PR DESCRIPTION
Change state generation logic to use dynamic macro invocation rather
than a static switch table.

This is in preparation for support of multiple providers and deployment
frameworks.