### PR TITLE
<feature> Generation plans for all components

### DIFF
--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -378,7 +378,7 @@ function process_template_pass() {
 
   [[ "${pass_alternative}" == "primary" ]] && pass_alternative=""
   pass_alternative_prefix=""
-  if [[ -n "${pass_alternative}"]]; then
+  if [[ -n "${pass_alternative}" ]]; then
     args+=("-v" "alternative=${pass_alternative}")
     pass_alternative_prefix="${pass_alternative}-"
   fi
@@ -544,24 +544,21 @@ function process_template() {
   local deployment_mode="${1}"; shift
 
   # Defaults
-  local passes=("pregeneration" "prologue" "template" "epilogue")
+  local passes=("template")
   local template_alternatives=("primary")
   local cf_dir="${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
 
   case "${level}" in
     blueprint)
-      passes=("template")
       cf_dir="${PRODUCT_INFRASTRUCTURE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
       ;;
 
     buildblueprint)
-      passes=("template")
       # this is expected to run from an automation context
       cf_dir="${AUTOMATION_DATA_DIR:-${PRODUCT_INFRASTRUCTURE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}}/"
       ;;
 
     account)
-      passes=("${passes[@]}" "cli")
       cf_dir="${ACCOUNT_INFRASTRUCTURE_DIR}/cf/shared"
       ;;
 
@@ -570,14 +567,12 @@ function process_template() {
       ;;
 
     solution)
-      passes=("${passes[@]}" "cli")
       ;;
 
     segment)
       ;;
 
     application)
-      passes=("${passes[@]}" "cli" "config")
       ;;
 
     multiple)

--- a/aws/templates/account/account_apigateway.ftl
+++ b/aws/templates/account/account_apigateway.ftl
@@ -1,6 +1,14 @@
 [#-- API Gateway --]
 [#if deploymentUnit?contains("apigateway") || (allDeploymentUnits!false) ]
     [#assign cloudWatchRoleId = formatAccountRoleId("cloudwatch")]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+    [/#if]
+
     [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(cloudWatchRoleId)]
         [@createRole
             mode=listMode

--- a/aws/templates/account/account_audit.ftl
+++ b/aws/templates/account/account_audit.ftl
@@ -3,6 +3,14 @@
 
     [#if accountObject.Seed?has_content]
 
+        [#if deploymentSubsetRequired("genplan", false)]
+            [@cfScript
+                mode=listMode
+                content=
+                    getGenerationPlan(["template"])
+            /]
+        [/#if]
+
         [#if deploymentSubsetRequired("audit", true)]
             [#assign lifecycleRules = []]
 

--- a/aws/templates/account/account_cert.ftl
+++ b/aws/templates/account/account_cert.ftl
@@ -1,8 +1,16 @@
 [#-- Generate certificate --]
 [#if deploymentUnit?contains("cert") || (allDeploymentUnits!false) ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+    [/#if]
+
     [#if deploymentSubsetRequired("cert", true)]
         [#assign certificateId = formatCertificateId(accountDomainCertificateId)]
-    
+
         [@createCertificate
             mode=listMode
             id="certificate"

--- a/aws/templates/account/account_console.ftl
+++ b/aws/templates/account/account_console.ftl
@@ -1,5 +1,13 @@
 [#if deploymentUnit?contains("console") || (allDeploymentUnits!false) ]
 
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["epilogue", "cli"])
+        /]
+    [/#if]
+
     [#assign consoleLgId = formatLogGroupId( "console" )]
     [#assign consoleLgName = formatAbsolutePath("ssm", "session-trace" )]
     [#assign consoleRoleId = formatAccountRoleId( "console" )]
@@ -9,7 +17,7 @@
 
     [#assign consoleCliCommand = "setSSMSessionPreferences" ]
     [#assign consoleResourceId = "ssmPreferences" ]
-    
+
     [#if deploymentSubsetRequired("iam", true) &&
             isPartOfCurrentDeploymentUnit(consoleRoleId)]
         [@createRole
@@ -25,7 +33,7 @@
         /]
     [/#if]
 
-    [#if deploymentSubsetRequired("lg", true) && 
+    [#if deploymentSubsetRequired("lg", true) &&
             isPartOfCurrentDeploymentUnit(consoleLgId)]
         [@createLogGroup
             mode=listMode

--- a/aws/templates/account/account_roles.ftl
+++ b/aws/templates/account/account_roles.ftl
@@ -1,17 +1,25 @@
 [#-- Account level roles --]
 [#if deploymentUnit?contains("roles")  || (allDeploymentUnits!false) ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+    [/#if]
+
     [#if deploymentSubsetRequired("roles", true)]
         [#assign automationRoleId = formatAccountRoleId("automation")]
         [#assign administratorRoleId = formatAccountRoleId("administrator")]
         [#assign viewerRoleId = formatAccountRoleId("viewer")]
-    
+
         [#assign accessAccounts=[]]
         [#list accountObject.Access?values as accessAccount]
             [#if accessAccount?is_hash]
                 [#assign accessAccounts += [accessAccount.AWSId]]
             [/#if]
         [/#list]
-    
+
         [@createRole
             mode=listMode
             id=automationRoleId

--- a/aws/templates/account/account_s3.ftl
+++ b/aws/templates/account/account_s3.ftl
@@ -1,6 +1,14 @@
 [#-- Standard set of buckets for an account --]
 [#if deploymentUnit?contains("s3") || (allDeploymentUnits!false) ]
     [#if accountObject.Seed?has_content]
+        [#if deploymentSubsetRequired("genplan", false)]
+            [@cfScript
+                mode=listMode
+                content=
+                    getGenerationPlan(["template", "epilogue"])
+            /]
+        [/#if]
+
         [#if deploymentSubsetRequired("s3", true)]
 
             [#assign buckets = ["credentials", "code", "registry"] ]
@@ -95,10 +103,10 @@
                                 "fi"
                             ]]
                             [#break]
-                            
+
                         [#case "github" ]
                             [#assign scriptSyncContent += [
-                                "stage_dir=\"$\{tmpdir}/" + storePrefix + "\"", 
+                                "stage_dir=\"$\{tmpdir}/" + storePrefix + "\"",
                                 "mkdir -p \"$\{stage_dir}\"",
                                 "# Clone the Repo",
                                 "clone_git_repo \"github\" \"github.com\" \"" + scriptStore.Source.Repository +"\" \"" + scriptStore.Source.Branch + "\" \"$\{stage_dir}\" ||",
@@ -119,7 +127,7 @@
                     [
                         "function sync_code_bucket() {"
                     ] +
-                        scriptSyncContent + 
+                        scriptSyncContent +
                     [
                         "}",
                         "#",

--- a/aws/templates/account/account_sms.ftl
+++ b/aws/templates/account/account_sms.ftl
@@ -1,6 +1,14 @@
 [#-- SMS --]
 [#if deploymentUnit?contains("sms") || (allDeploymentUnits!false) ]
     [#assign cloudWatchRoleId = formatAccountRoleId("sms","cloudwatch")]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["epilogue", "cli"])
+        /]
+    [/#if]
+
     [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(cloudWatchRoleId)]
         [@createRole
             mode=listMode

--- a/aws/templates/account/account_waf.ftl
+++ b/aws/templates/account/account_waf.ftl
@@ -1,6 +1,14 @@
 [#-- WAF IP setup --]
 [#-- TODO(mfl): deprecate account level WAF in favour of environemnt specific WAF --]
 [#if deploymentUnit?contains("waf")  || (allDeploymentUnits!false) ]
+        [#if deploymentSubsetRequired("genplan", false)]
+            [@cfScript
+                mode=listMode
+                content=
+                    getGenerationPlan(["template"])
+            /]
+        [/#if]
+
     [#if deploymentSubsetRequired("waf", true)]
         [#list ipAddressGroups?values as group]
             [#assign ipSetId = formatWAFIPSetId(group)]

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -833,6 +833,7 @@ behaviour.
         [#if (.vars[stateMacro]!"")?is_directive]
             [@(.vars[stateMacro]) occurrence parentOccurrence result /]
             [#local result = componentState]
+            [@cfDebug listMode {"Macro" : stateMacro, "State": result} false /]
         [#else]
 
             [#switch core.Type!""]
@@ -845,6 +846,12 @@ behaviour.
                             }
                         }
                     ]
+                    [#break]
+                [#default]
+                    [@cfException
+                        mode=listMode
+                        description="No state macro available for type " + core.Type!""
+                        context=stateMacro /]
                     [#break]
 
             [/#switch]

--- a/aws/templates/resource/resource_rds.ftl
+++ b/aws/templates/resource/resource_rds.ftl
@@ -5,10 +5,10 @@
         REFERENCE_ATTRIBUTE_TYPE : {
             "UseRef" : true
         },
-        DNS_ATTRIBUTE_TYPE : { 
+        DNS_ATTRIBUTE_TYPE : {
             "Attribute" : "Endpoint.Address"
         },
-        PORT_ATTRIBUTE_TYPE : { 
+        PORT_ATTRIBUTE_TYPE : {
             "Attribute" : "Endpoint.Port"
         },
         REGION_ATTRIBUTE_TYPE : {
@@ -28,14 +28,14 @@
             "Namespace" : "AWS/RDS",
             "Dimensions" : {
                 "DBInstanceIdentifier" : {
-                    "Output" : "" 
+                    "Output" : ""
                 }
             }
         }
     }
 ]
 
-[#macro createRDSInstance mode id name 
+[#macro createRDSInstance mode id name
     engine
     engineVersion
     processor
@@ -52,18 +52,18 @@
     optionGroupId
     snapshotId
     securityGroupId
-    tier="" 
-    component=""     
-    dependencies="" 
+    tier=""
+    component=""
+    dependencies=""
     outputId=""
     autoMinorVersionUpgrade=true
     deleteAutomatedBackups=true
     deletionPolicy="Snapshot"
     updateReplacePolicy="Snapshot"
 ]
-    [@cfResource 
+    [@cfResource
     mode=listMode
-    id=rdsId
+    id=id
     type="AWS::RDS::DBInstance"
     deletionPolicy=deletionPolicy
     updateReplacePolicy=updateReplacePolicy
@@ -91,7 +91,7 @@
             {
                 "AvailabilityZone" : zones[0].AWSZone
             }
-        ) + 
+        ) +
         (!(snapshotId?has_content) && encrypted)?then(
             {
                 "StorageEncrypted" : true,
@@ -112,13 +112,13 @@
         )
 tags=
     getCfTemplateCoreTags(
-        rdsFullName,
+        name,
         tier,
         component)
 outputs=
     RDS_OUTPUT_MAPPINGS +
     {
-        DATABASENAME_ATTRIBUTE_TYPE : { 
+        DATABASENAME_ATTRIBUTE_TYPE : {
             "Value" : databaseName
         }
     } +

--- a/aws/templates/resource/start.ftl
+++ b/aws/templates/resource/start.ftl
@@ -646,8 +646,26 @@
         [@processComponents level /]
     [/#if]
 
-    [#if templateResources?has_content || exceptionResources?has_content
-    || debugResources?has_content]
+    [#if templateScript?has_content]
+      #!/bin/bash
+      #--COT-RequestReference=${requestReference}
+      #--COT-ConfigurationReference=${configurationReference}
+      #--COT-RunId=${runId}
+      [#list templateScript as line]
+          ${line}
+      [/#list]
+    [#elseif templateConfig?has_content || exceptionResources?has_content]
+        [@toJSON templateConfig  +
+            valueIfContent(
+                {
+                    "Exceptions" : exceptionResources
+                },
+                exceptionResources
+            ) /]
+    [#elseif templateCli?has_content]
+        [@toJSON templateCli /]
+    [#elseif templateResources?has_content || exceptionResources?has_content
+            || debugResources?has_content]
       [@toJSON
           {
               "AWSTemplateFormatVersion" : "2010-09-09",
@@ -677,23 +695,5 @@
               exceptionResources
           )
       /]
-    [#elseif templateScript?has_content]
-      #!/bin/bash
-      #--COT-RequestReference=${requestReference}
-      #--COT-ConfigurationReference=${configurationReference}
-      #--COT-RunId=${runId}
-      [#list templateScript as line]
-          ${line}
-      [/#list]
-    [#elseif templateConfig?has_content || exceptionResources?has_content]
-        [@toJSON templateConfig  +
-            valueIfContent(
-                {
-                    "Exceptions" : exceptionResources
-                },
-                exceptionResources
-            ) /]
-    [#elseif templateCli?has_content]
-        [@toJSON templateCli /]
     [/#if]
 [/#macro]

--- a/providers/aws/component/application/application_apigateway.ftl
+++ b/providers/aws/component/application/application_apigateway.ftl
@@ -2,6 +2,15 @@
 [#macro aws_apigateway_cf_application occurrence ]
     [@cfDebug listMode occurrence false /]
 
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["pregeneration", "prologue", "template", "epilogue", "config"])
+        /]
+        [#return]
+    [/#if]
+
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
     [#local resources = occurrence.State.Resources ]

--- a/providers/aws/component/application/application_apiusageplan.ftl
+++ b/providers/aws/component/application/application_apiusageplan.ftl
@@ -2,6 +2,15 @@
 [#macro aws_apiusageplan_cf_application occurrence ]
     [@cfDebug listMode occurrence false /]
 
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
     [#local resources = occurrence.State.Resources ]

--- a/providers/aws/component/application/application_computecluster.ftl
+++ b/providers/aws/component/application/application_computecluster.ftl
@@ -2,6 +2,15 @@
 [#macro aws_computecluster_cf_application occurrence ]
     [@cfDebug listMode occurrence false /]
 
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
     [#local resources = occurrence.State.Resources ]

--- a/providers/aws/component/application/application_contentnode.ftl
+++ b/providers/aws/component/application/application_contentnode.ftl
@@ -2,6 +2,15 @@
 [#macro aws_contentnode_cf_application occurrence ]
     [@cfDebug listMode occurrence false /]
 
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["prologue"])
+        /]
+        [#return]
+    [/#if]
+
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
     [#local resources = occurrence.State.Resources]

--- a/providers/aws/component/application/application_datapipeline.ftl
+++ b/providers/aws/component/application/application_datapipeline.ftl
@@ -2,6 +2,15 @@
 [#macro aws_datapipeline_cf_application occurrence ]
     [@cfDebug listMode occurrence false /]
 
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["prologue", "template", "epilogue", "cli", "config"])
+        /]
+        [#return]
+    [/#if]
+
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
     [#local settings = occurrence.Configuration.Settings]

--- a/providers/aws/component/application/application_ecs.ftl
+++ b/providers/aws/component/application/application_ecs.ftl
@@ -2,6 +2,15 @@
 [#macro aws_ecs_cf_application occurrence ]
     [@cfDebug listMode occurrence false /]
 
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["prologue", "template", "epilogue", "cli"])
+        /]
+        [#return]
+    [/#if]
+
     [#local parentResources = occurrence.State.Resources]
     [#local parentSolution = occurrence.Configuration.Solution ]
 

--- a/providers/aws/component/application/application_lambda.ftl
+++ b/providers/aws/component/application/application_lambda.ftl
@@ -2,6 +2,15 @@
 [#macro aws_lambda_cf_application occurrence ]
     [@cfDebug listMode occurrence false  /]
 
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["prologue", "template", "config"])
+        /]
+        [#return]
+    [/#if]
+
     [#local lambdaCore = occurrence.Core ]
     [#local lambdaSolution = occurrence.Configuration.Solution ]
 

--- a/providers/aws/component/application/application_mobileapp.ftl
+++ b/providers/aws/component/application/application_mobileapp.ftl
@@ -2,6 +2,15 @@
 [#macro aws_mobileapp_cf_application occurrence ]
     [@cfDebug listMode occurrence false /]
 
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["prologue", "config"])
+        /]
+        [#return]
+    [/#if]
+
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
     [#local resources = occurrence.State.Resources ]

--- a/providers/aws/component/application/application_spa.ftl
+++ b/providers/aws/component/application/application_spa.ftl
@@ -2,6 +2,15 @@
 [#macro aws_spa_cf_application occurrence ]
     [@cfDebug listMode occurrence false /]
 
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["prologue", "config"])
+        /]
+        [#return]
+    [/#if]
+
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
     [#local settings = occurrence.Configuration.Settings ]

--- a/providers/aws/component/application/application_user.ftl
+++ b/providers/aws/component/application/application_user.ftl
@@ -2,6 +2,15 @@
 [#macro aws_user_cf_application occurrence ]
     [@cfDebug listMode occurrence false /]
 
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["prologue", "template", "epilogue"])
+        /]
+        [#return]
+    [/#if]
+
     [#local core = occurrence.Core ]
     [#local resources = occurrence.State.Resources]
     [#local solution = occurrence.Configuration.Solution ]

--- a/providers/aws/component/segment/segment_baseline.ftl
+++ b/providers/aws/component/segment/segment_baseline.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_baseline_cf_segment occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["prologue", "template", "epilogue"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core ]

--- a/providers/aws/component/segment/segment_bastion.ftl
+++ b/providers/aws/component/segment/segment_bastion.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_bastion_cf_segment occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core ]

--- a/providers/aws/component/segment/segment_cert.ftl
+++ b/providers/aws/component/segment/segment_cert.ftl
@@ -1,5 +1,16 @@
 [#ftl]
 [#macro aws_cert_cf_segment occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
+    [@cfDebug listMode occurrence false /]
+
     [#if deploymentSubsetRequired("cert", true)]
         [#local certificateId = formatCertificateId(segmentDomainCertificateId)]
 

--- a/providers/aws/component/segment/segment_dashboard.ftl
+++ b/providers/aws/component/segment/segment_dashboard.ftl
@@ -1,6 +1,17 @@
 [#ftl]
 [#macro aws_dashboard_cf_segment occurrence ]
 
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
+    [@cfDebug listMode occurrence false /]
+
     [#if deploymentSubsetRequired("dashboard", true)]
         [@createDashboard
             mode=listMode

--- a/providers/aws/component/segment/segment_dns.ftl
+++ b/providers/aws/component/segment/segment_dns.ftl
@@ -1,5 +1,16 @@
 [#ftl]
 [#macro aws_dns_cf_segment occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
+    [@cfDebug listMode occurrence false /]
+
     [#if deploymentSubsetRequired("dns", true)]
         [@cfResource
             mode=listMode

--- a/providers/aws/component/segment/segment_gateway.ftl
+++ b/providers/aws/component/segment/segment_gateway.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_gateway_cf_segment occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local gwCore = occurrence.Core ]

--- a/providers/aws/component/segment/segment_network.ftl
+++ b/providers/aws/component/segment/segment_network.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_network_cf_segment occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core ]

--- a/providers/aws/component/solution/solution_cache.ftl
+++ b/providers/aws/component/solution/solution_cache.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_cache_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core ]

--- a/providers/aws/component/solution/solution_configstore.ftl
+++ b/providers/aws/component/solution/solution_configstore.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_configstore_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template", "epilogue", "cli"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local parentCore = occurrence.Core]

--- a/providers/aws/component/solution/solution_contenthub.ftl
+++ b/providers/aws/component/solution/solution_contenthub.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_contenthub_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["prologue"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core]

--- a/providers/aws/component/solution/solution_datafeed.ftl
+++ b/providers/aws/component/solution/solution_datafeed.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_datafeed_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core]

--- a/providers/aws/component/solution/solution_datavolume.ftl
+++ b/providers/aws/component/solution/solution_datavolume.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_datavolume_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template", "epilogue"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core]

--- a/providers/aws/component/solution/solution_ec2.ftl
+++ b/providers/aws/component/solution/solution_ec2.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_ec2_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core]

--- a/providers/aws/component/solution/solution_ecs.ftl
+++ b/providers/aws/component/solution/solution_ecs.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_ecs_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core ]

--- a/providers/aws/component/solution/solution_efs.ftl
+++ b/providers/aws/component/solution/solution_efs.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_efs_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core]

--- a/providers/aws/component/solution/solution_es.ftl
+++ b/providers/aws/component/solution/solution_es.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_es_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template", "epilogue", "cli"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core]

--- a/providers/aws/component/solution/solution_lb.ftl
+++ b/providers/aws/component/solution/solution_lb.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_lb_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["prologue", "template"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core ]

--- a/providers/aws/component/solution/solution_lg.ftl
+++ b/providers/aws/component/solution/solution_lg.ftl
@@ -1,5 +1,16 @@
 [#ftl]
 [#macro aws_lg_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
+    [@cfDebug listMode occurrence false /]
+
     [#local componentLogGroupId = formatComponentLogGroupId(tier, component)]
     [#if deploymentSubsetRequired("lg", true) &&
             isPartOfCurrentDeploymentUnit(componentLogGroupId)]

--- a/providers/aws/component/solution/solution_mobilenotifier.ftl
+++ b/providers/aws/component/solution/solution_mobilenotifier.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_mobilenotifier_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["prologue", "template", "epilogue", "cli"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core]

--- a/providers/aws/component/solution/solution_rds.ftl
+++ b/providers/aws/component/solution/solution_rds.ftl
@@ -1,7 +1,5 @@
 [#ftl]
 [#macro aws_rds_cf_solution occurrence ]
-    [@cfDebug listMode occurrence false /]
-
     [#if deploymentSubsetRequired("genplan", false)]
         [@cfScript
             mode=listMode
@@ -12,6 +10,8 @@
         /]
         [#return]
     [/#if]
+
+    [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]

--- a/providers/aws/component/solution/solution_s3.ftl
+++ b/providers/aws/component/solution/solution_s3.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_s3_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core ]

--- a/providers/aws/component/solution/solution_serviceregistry.ftl
+++ b/providers/aws/component/solution/solution_serviceregistry.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_serviceregistry_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core ]

--- a/providers/aws/component/solution/solution_spa.ftl
+++ b/providers/aws/component/solution/solution_spa.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_spa_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template", "epilogue"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core ]

--- a/providers/aws/component/solution/solution_sqs.ftl
+++ b/providers/aws/component/solution/solution_sqs.ftl
@@ -1,11 +1,15 @@
 [#ftl]
 [#macro aws_sqs_cf_solution occurrence ]
-    [@cfDebug listMode occurrence false /]
-
     [#if deploymentSubsetRequired("genplan", false)]
-        [@cfScript listMode getGenerationPlan("template") /]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
         [#return]
     [/#if]
+
+    [@cfDebug listMode occurrence false /]
 
     [#if deploymentSubsetRequired("sqs", true)]
 

--- a/providers/aws/component/solution/solution_userpool.ftl
+++ b/providers/aws/component/solution/solution_userpool.ftl
@@ -1,5 +1,14 @@
 [#ftl]
 [#macro aws_userpool_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["prologue", "template", "epilogue", "cli"])
+        /]
+        [#return]
+    [/#if]
+
     [@cfDebug listMode occurrence false /]
 
     [#local core = occurrence.Core]


### PR DESCRIPTION
Add explicit generation plans for all units, and simplify the defaults accordingly.

Rearrange the decision tree used to determine the output format required so that debug does not interfere with the generation of plans.

Fix a couple of variable references for RDS creation. The use of local only variables in component templates highlighted a couple of incorrect variables references that relied on global variables.