### PR TITLE
<fix> ECS task variable scope

### DIFF
--- a/aws/templates/commonApplication.ftl
+++ b/aws/templates/commonApplication.ftl
@@ -632,7 +632,7 @@
                 containerLgId,
                 container.ContainerLogGroup,
                 valueIfTrue(
-                    resources["lg"].Id!"",
+                    task.State.Resources["lg"].Id!"",
                     solution.TaskLogGroup,
                     valueIfTrue(
                         ecs.State.Resources["lg"].Id!"",


### PR DESCRIPTION
task was using global version of resources instead of local 