### PR TITLE
<fix> update _context variable to use global scope

### DIFF
--- a/providers/aws/component/application/application_apigateway.ftl
+++ b/providers/aws/component/application/application_apigateway.ftl
@@ -37,7 +37,7 @@
                                                 swaggerFileName)]
 
     [#local contextLinks = getLinkTargets(occurrence) ]
-    [#local _context =
+    [#assign _context =
         {
             "Id" : fragment,
             "Name" : fragment,

--- a/providers/aws/component/application/application_computecluster.ftl
+++ b/providers/aws/component/application/application_computecluster.ftl
@@ -115,7 +115,7 @@
     [#local fragment = getOccurrenceFragmentBase(occurrence) ]
 
     [#local contextLinks = getLinkTargets(occurrence, links) ]
-    [#local _context =
+    [#assign _context =
         {
             "Id" : fragment,
             "Name" : fragment,

--- a/providers/aws/component/application/application_datapipeline.ftl
+++ b/providers/aws/component/application/application_datapipeline.ftl
@@ -78,7 +78,7 @@
     [#-- Add in container specifics including override of defaults --]
     [#-- Allows for explicit policy or managed ARN's to be assigned to the user --]
     [#local contextLinks = getLinkTargets(occurrence) ]
-    [#local _context =
+    [#assign _context =
         {
             "Id" : fragment,
             "Name" : fragment,
@@ -100,7 +100,7 @@
         [#include fragmentList?ensure_starts_with("/")]
     [/#if]
 
-    [#local _context += getFinalEnvironment(occurrence, _context) ]
+    [#assign _context += getFinalEnvironment(occurrence, _context) ]
     [#local parameterValues += _context.Environment ]
 
     [#local myParameterValues = {}]

--- a/providers/aws/component/application/application_lambda.ftl
+++ b/providers/aws/component/application/application_lambda.ftl
@@ -47,7 +47,7 @@
         [#local fragment = getOccurrenceFragmentBase(fn) ]
 
         [#local contextLinks = getLinkTargets(fn) ]
-        [#local _context =
+        [#assign _context =
             {
                 "Id" : fragment,
                 "Name" : fragment,
@@ -143,7 +143,7 @@
 
         [#local finalEnvironment = getFinalEnvironment(fn, _context, solution.Environment) ]
         [#local finalAsFileEnvironment = getFinalEnvironment(fn, _context, solution.Environment + {"AsFile" : false}) ]
-        [#local _context += finalEnvironment ]
+        [#assign _context += finalEnvironment ]
 
         [#local roleId = formatDependentRoleId(fnId)]
         [#local managedPolicies =

--- a/providers/aws/component/application/application_mobileapp.ftl
+++ b/providers/aws/component/application/application_mobileapp.ftl
@@ -22,7 +22,7 @@
     [#local fragment = getOccurrenceFragmentBase(occurrence) ]
 
     [#local contextLinks = getLinkTargets(occurrence) ]
-    [#local _context =
+    [#assign _context =
         {
             "Id" : fragment,
             "Name" : fragment,

--- a/providers/aws/component/application/application_spa.ftl
+++ b/providers/aws/component/application/application_spa.ftl
@@ -19,7 +19,7 @@
     [#local fragment = getOccurrenceFragmentBase(occurrence) ]
 
     [#local contextLinks = getLinkTargets(occurrence) ]
-    [#local _context =
+    [#assign _context =
         {
             "Id" : fragment,
             "Name" : fragment,
@@ -39,7 +39,7 @@
     [#local fragmentId = formatFragmentId(_context)]
     [#include fragmentList?ensure_starts_with("/")]
 
-    [#local _context += getFinalEnvironment(occurrence, _context) ]
+    [#assign _context += getFinalEnvironment(occurrence, _context) ]
 
     [#if deploymentSubsetRequired("config", false)]
         [@cfConfig

--- a/providers/aws/component/application/application_user.ftl
+++ b/providers/aws/component/application/application_user.ftl
@@ -50,7 +50,7 @@
     [#-- Add in container specifics including override of defaults --]
     [#-- Allows for explicit policy or managed ARN's to be assigned to the user --]
     [#local contextLinks = getLinkTargets(occurrence) ]
-    [#local _context =
+    [#assign _context =
         {
             "Id" : fragment,
             "Name" : fragment,

--- a/providers/aws/component/segment/segment_bastion.ftl
+++ b/providers/aws/component/segment/segment_bastion.ftl
@@ -81,7 +81,7 @@
     [#local fragment = getOccurrenceFragmentBase(occurrence) ]
 
     [#local contextLinks = getLinkTargets(occurrence, links) ]
-    [#local _context =
+    [#assign _context =
         {
             "Id" : fragment,
             "Name" : fragment,

--- a/providers/aws/component/solution/solution_configstore.ftl
+++ b/providers/aws/component/solution/solution_configstore.ftl
@@ -83,7 +83,7 @@
 
         [#local contextLinks = getLinkTargets(subOccurrence)]
 
-        [#local _context =
+        [#assign _context =
             {
                 "Id" : fragment,
                 "Name" : fragment,
@@ -104,9 +104,9 @@
         [#include fragmentList?ensure_starts_with("/")]
 
         [#local finalEnvironment = getFinalEnvironment(subOccurrence, _context ) ]
-        [#local _context += finalEnvironment ]
+        [#assign _context += finalEnvironment ]
 
-        [#local _context +=
+        [#assign _context +=
             {
                 "Environment" : {
                                     "configStore" : parentCore.Id

--- a/providers/aws/component/solution/solution_ec2.ftl
+++ b/providers/aws/component/solution/solution_ec2.ftl
@@ -94,7 +94,7 @@
     [#local fragment = getOccurrenceFragmentBase(occurrence) ]
 
     [#local contextLinks = getLinkTargets(occurrence, links) ]
-    [#local _context =
+    [#assign _context =
         {
             "Id" : fragment,
             "Name" : fragment,
@@ -197,7 +197,7 @@
                         }
                     }]
                 [/#list]
-                [#local _context +=
+                [#assign _context +=
                     {
                         "DataVolumes" :
                             (_context.DataVolumes!{}) +

--- a/providers/aws/component/solution/solution_ecs.ftl
+++ b/providers/aws/component/solution/solution_ecs.ftl
@@ -72,7 +72,7 @@
     [#local fragment = getOccurrenceFragmentBase(occurrence) ]
 
     [#local contextLinks = getLinkTargets(occurrence) ]
-    [#local _context =
+    [#assign _context =
         {
             "Id" : fragment,
             "Name" : fragment,

--- a/providers/aws/component/solution/solution_spa.ftl
+++ b/providers/aws/component/solution/solution_spa.ftl
@@ -18,7 +18,7 @@
     [#local fragment = getOccurrenceFragmentBase(occurrence) ]
 
     [#local contextLinks = getLinkTargets(occurrence) ]
-    [#local _context =
+    [#assign _context =
         {
             "Id" : fragment,
             "Name" : fragment,
@@ -75,14 +75,14 @@
         [#if getLinkTarget(occurrence, cfRedirectLink.cfredirect )?has_content ]
             [#local eventHandlerLinks += cfRedirectLink]
 
-            [#local _context +=
+            [#assign _context +=
                 {
                     "ForwardHeaders" : (_context.ForwardHeaders![]) + [
                         "Host"
                     ]
                 }]
 
-            [#local _context +=
+            [#assign _context +=
                 {
                     "CustomOriginHeaders" : (_context.CustomOriginHeaders![]) + [
                         getCFHTTPHeader(


### PR DESCRIPTION
The _context variable is modified through a collection of macros in fragment files and so that they can update the context the scope needs to be made global rather than local 