### PR TITLE
<fix> baseline legacy handling

### DIFF
--- a/providers/aws/component/baseline/setup.ftl
+++ b/providers/aws/component/baseline/setup.ftl
@@ -379,22 +379,23 @@
                     [#local OAIName = subResources["originAccessId"].Name ]
                     [#local legacyKey = false]
 
-                    [#-- legacy OAI lookup --]
-                    [#local opsDataLink = {
-                                "Tier" : "mgmt",
-                                "Component" : "baseline",
-                                "Instance" : "",
-                                "Version" : "",
-                                "DataBucket" : "opsdata"
-                        }]
+                    [#if subCore.SubComponent.Id == "oai" ]
 
-                    [#local opsDataLinkTarget = getLinkTarget({}, opsDataLink )]
+                        [#-- legacy OAI lookup --]
+                        [#local opsDataLink = {
+                                    "Tier" : "mgmt",
+                                    "Component" : "baseline",
+                                    "Instance" : "",
+                                    "Version" : "",
+                                    "DataBucket" : "opsdata"
+                            }]
 
-                    [#if opsDataLinkTarget?has_content ]
-                        [#local opsDataBucketId = opsDataLinkTarget.State.Resources["bucket"].Id ]
-                        [#local legacyOAIId = formatDependentCFAccessId(opsDataBucketId)]
+                        [#local opsDataLinkTarget = getLinkTarget({}, opsDataLink )]
 
-                        [#if subCore.SubComponent.Id == "oai" ]
+                        [#if opsDataLinkTarget?has_content ]
+                            [#local opsDataBucketId = opsDataLinkTarget.State.Resources["bucket"].Id ]
+                            [#local legacyOAIId = formatDependentCFAccessId(opsDataBucketId)]
+
                             [#if (getExistingReference(legacyOAIId!"", CANONICAL_ID_ATTRIBUTE_TYPE))?has_content ]
                                 [#local legacyKey = true]
                                 [#local OAIId = legacyOAIId ]

--- a/providers/aws/component/baseline/setup.ftl
+++ b/providers/aws/component/baseline/setup.ftl
@@ -390,14 +390,16 @@
 
                     [#local opsDataLinkTarget = getLinkTarget({}, opsDataLink )]
 
-                    [#local opsDataBucketId = opsDataLinkTarget.State.Resources["bucket"].Id ]
-                    [#local legacyOAIId = formatDependentCFAccessId(opsDataBucketId)]
+                    [#if opsDataLinkTarget?has_content ]
+                        [#local opsDataBucketId = opsDataLinkTarget.State.Resources["bucket"].Id ]
+                        [#local legacyOAIId = formatDependentCFAccessId(opsDataBucketId)]
 
-                    [#if subCore.SubComponent.Id == "oai" ]
-                        [#if (getExistingReference(legacyOAIId!"", CANONICAL_ID_ATTRIBUTE_TYPE))?has_content ]
-                            [#local legacyKey = true]
-                            [#local OAIId = legacyOAIId ]
-                            [#local OAIName = formatSegmentFullName()]
+                        [#if subCore.SubComponent.Id == "oai" ]
+                            [#if (getExistingReference(legacyOAIId!"", CANONICAL_ID_ATTRIBUTE_TYPE))?has_content ]
+                                [#local legacyKey = true]
+                                [#local OAIId = legacyOAIId ]
+                                [#local OAIName = formatSegmentFullName()]
+                            [/#if]
                         [/#if]
                     [/#if]
 


### PR DESCRIPTION
fix an issue with new deployments which don't have an existing ops bucket when generate oai credentials