### PR TITLE
<refactor> Use macros to create component config

### DIFF
--- a/providers/shared/component/apigateway.ftl
+++ b/providers/shared/component/apigateway.ftl
@@ -45,189 +45,170 @@ object.
 "documentation, the others redirect to the primary."
 ] ]
 
-[#assign componentConfiguration +=
-    {
-        APIGATEWAY_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" :
-                        [
-                            "Application level API proxy",
-                            ""
-                        ] + apiGatewayDescription
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "application"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : ["Fragment", "Container"],
-                    "Type" : STRING_TYPE,
-                    "Default" : ""
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "WAF",
-                    "Children" : wafChildConfiguration
-                },
-                {
-                    "Names" : "EndpointType",
-                    "Type" : STRING_TYPE,
-                    "Values" : ["EDGE", "REGIONAL"],
-                    "Default" : "EDGE"
-                },
-                {
-                    "Names" : "IPAddressGroups",
-                    "Type" : ARRAY_OF_STRING_TYPE,
-                    "Default" : []
-                },
-                {
-                    "Names" : "Authentication",
-                    "Type" : STRING_TYPE,
-                    "Values" : ["IP", "SIG4ORIP", "SIG4ANDIP"],
-                    "Default" : "IP"
-                },
-                {
-                    "Names" : "CloudFront",
-                    "Children" : [
-                        {
-                            "Names" : "AssumeSNI",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "EnableLogging",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "CountryGroups",
-                            "Type" : ARRAY_OF_STRING_TYPE,
-                            "Default" : []
-                        },
-                        {
-                            "Names" : "CustomHeaders",
-                            "Type" : ARRAY_OF_ANY_TYPE,
-                            "Default" : []
-                        },
-                        {
-                            "Names" : "Mapping",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : false
-                        },
-                        {
-                            "Names" : "Compress",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Certificate",
-                    "Children" : certificateChildConfiguration
-                },
-                {
-                    "Names" : "Publish",
-                    "Description" : "Deprecated - Please switch to the publishers configuration",
-                    "Children" : [
-                        {
-                            "Names" : "DnsNamePrefix",
-                            "Type" : STRING_TYPE,
-                            "Default" : "docs"
-                        },
-                        {
-                            "Names" : "IPAddressGroups",
-                            "Type" : ARRAY_OF_STRING_TYPE,
-                            "Default" : []
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Publishers",
-                    "Subobjects" : true,
-                    "Children" : [
-                        {
-                            "Names" : "Links",
-                            "Subobjects" : true,
-                            "Children" : linkChildrenConfiguration
-                        },
-                        {
-                            "Names" : "Path",
-                            "Children" : pathChildConfiguration
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Mapping",
-                    "Children" : [
-                        {
-                            "Names" : "IncludeStage",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration + [
-                        {
-                            "Names" : "Security",
-                            "Type" : STRING_TYPE,
-                            "Default" : "default"
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Alerts",
-                    "Subobjects" : true,
-                    "Children" : alertChildrenConfiguration
-                },
-                {
-                    "Names" : "LogMetrics",
-                    "Subobjects" : true,
-                    "Children" : logMetricChildrenConfiguration
-                },
-                {
-                    "Names" : "BasePathBehaviour",
-                    "Description" : "How to handle base paths provided in the spec",
-                    "Type" : STRING_TYPE,
-                    "Values" : [ "ignore", "prepend", "split" ],
-                    "Default" : "ignore"
-                }
-            ]
-        },
-        APIGATEWAY_USAGEPLAN_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "provides a metered link between an API gateway and an invoking client"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "application"
-                }
-            ],
-            "Attributes" : [
+[@addComponent
+    type=APIGATEWAY_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" :
+                    [
+                        "Application level API proxy",
+                        ""
+                    ] + apiGatewayDescription
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "application"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=APIGATEWAY_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : ["Fragment", "Container"],
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            },
             {
                 "Names" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "WAF",
+                "Children" : wafChildConfiguration
+            },
+            {
+                "Names" : "EndpointType",
+                "Type" : STRING_TYPE,
+                "Values" : ["EDGE", "REGIONAL"],
+                "Default" : "EDGE"
+            },
+            {
+                "Names" : "IPAddressGroups",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            },
+            {
+                "Names" : "Authentication",
+                "Type" : STRING_TYPE,
+                "Values" : ["IP", "SIG4ORIP", "SIG4ANDIP"],
+                "Default" : "IP"
+            },
+            {
+                "Names" : "CloudFront",
+                "Children" : [
+                    {
+                        "Names" : "AssumeSNI",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "EnableLogging",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "CountryGroups",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Default" : []
+                    },
+                    {
+                        "Names" : "CustomHeaders",
+                        "Type" : ARRAY_OF_ANY_TYPE,
+                        "Default" : []
+                    },
+                    {
+                        "Names" : "Mapping",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "Compress",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "Certificate",
+                "Children" : certificateChildConfiguration
+            },
+            {
+                "Names" : "Publish",
+                "Description" : "Deprecated - Please switch to the publishers configuration",
+                "Children" : [
+                    {
+                        "Names" : "DnsNamePrefix",
+                        "Type" : STRING_TYPE,
+                        "Default" : "docs"
+                    },
+                    {
+                        "Names" : "IPAddressGroups",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Default" : []
+                    }
+                ]
+            },
+            {
+                "Names" : "Publishers",
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Links",
+                        "Subobjects" : true,
+                        "Children" : linkChildrenConfiguration
+                    },
+                    {
+                        "Names" : "Path",
+                        "Children" : pathChildConfiguration
+                    }
+                ]
+            },
+            {
+                "Names" : "Mapping",
+                "Children" : [
+                    {
+                        "Names" : "IncludeStage",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration + [
+                    {
+                        "Names" : "Security",
+                        "Type" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
+            },
+            {
+                "Names" : "Alerts",
+                "Subobjects" : true,
+                "Children" : alertChildrenConfiguration
+            },
+            {
+                "Names" : "LogMetrics",
+                "Subobjects" : true,
+                "Children" : logMetricChildrenConfiguration
+            },
+            {
+                "Names" : "BasePathBehaviour",
+                "Description" : "How to handle base paths provided in the spec",
+                "Type" : STRING_TYPE,
+                "Values" : [ "ignore", "prepend", "split" ],
+                "Default" : "ignore"
             }
         ]
-        }
-    }]
+/]

--- a/providers/shared/component/apiusageplan.ftl
+++ b/providers/shared/component/apiusageplan.ftl
@@ -1,0 +1,32 @@
+[#ftl]
+
+[@addComponent
+    type=APIGATEWAY_USAGEPLAN_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "provides a metered link between an API gateway and an invoking client"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "application"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=APIGATEWAY_USAGEPLAN_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            }
+        ]
+/]

--- a/providers/shared/component/baseline.ftl
+++ b/providers/shared/component/baseline.ftl
@@ -6,142 +6,156 @@
     [#return formatSegmentResourceId(SEED_RESOURCE_TYPE)]
 [/#function]
 
-[#assign componentConfiguration +=
-    {
-        BASELINE_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "A set of resources required for every segment deployment"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "segment"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Active",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "Seed",
-                    "Children" : [
-                        {
-                            "Names" : "Length",
-                            "Type" : NUMBER_TYPE,
-                            "Default" : 10
-                        }
-                    ]
-                }
-            ],
-            "Components" : [
-                {
-                    "Type" : BASELINE_DATA_COMPONENT_TYPE,
-                    "Component" : "DataBuckets",
-                    "Link" : ["DataBucket"]
-                },
-                {
-                    "Type" : BASELINE_KEY_COMPONENT_TYPE,
-                    "Component" : "Keys",
-                    "Link" : ["Key"]
-                }
-            ]
-        },
-        BASELINE_DATA_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "A segment shared data store"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "segment"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Role",
-                    "Type" : STRING_TYPE,
-                    "Values" : [ "appdata", "operations" ],
-                    "Mandatory" : true
-                },
-                {
-                    "Names" : "Lifecycles",
-                    "Subobjects" : true,
-                    "Children" : [
-                        {
-                            "Names" : "Prefix",
-                            "Types" : STRING_TYPE,
-                            "Description" : "The prefix to apply the lifecycle to"
-                        }
-                        {
-                            "Names" : "Expiration",
-                            "Types" : [STRING_TYPE, NUMBER_TYPE],
-                            "Description" : "Provide either a date or a number of days",
-                            "Default" : "_operations"
-                        },
-                        {
-                            "Names" : "Offline",
-                            "Types" : [STRING_TYPE, NUMBER_TYPE],
-                            "Description" : "Provide either a date or a number of days",
-                            "Default" : "_operations"
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Versioning",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "Notifications",
-                    "Subobjects" : true,
-                    "Children" : s3NotificationChildConfiguration
-                }
-            ]
-        },
-        BASELINE_KEY_COMPONENT_TYPE : {
-                "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "Shared security keys for a segment"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "segment"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Engine",
-                    "Type" : STRING_TYPE,
-                    "Values" : [ "cmk", "ssh", "oai" ],
-                    "Mandatory" : true
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=BASELINE_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A set of resources required for every segment deployment"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "segment"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=BASELINE_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Active",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Seed",
+                "Children" : [
+                    {
+                        "Names" : "Length",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : 10
+                    }
+                ]
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=BASELINE_DATA_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "A segment shared data store"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "segment"
+            }
+        ]
+    parent=BASELINE_COMPONENT_TYPE
+    childAttribute="DataBuckets"
+    linkAttributes="DataBucket"
+/]
+
+[@addComponentResourceGroup
+    type=BASELINE_DATA_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Role",
+                "Type" : STRING_TYPE,
+                "Values" : [ "appdata", "operations" ],
+                "Mandatory" : true
+            },
+            {
+                "Names" : "Lifecycles",
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Prefix",
+                        "Types" : STRING_TYPE,
+                        "Description" : "The prefix to apply the lifecycle to"
+                    }
+                    {
+                        "Names" : "Expiration",
+                        "Types" : [STRING_TYPE, NUMBER_TYPE],
+                        "Description" : "Provide either a date or a number of days",
+                        "Default" : "_operations"
+                    },
+                    {
+                        "Names" : "Offline",
+                        "Types" : [STRING_TYPE, NUMBER_TYPE],
+                        "Description" : "Provide either a date or a number of days",
+                        "Default" : "_operations"
+                    }
+                ]
+            },
+            {
+                "Names" : "Versioning",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Notifications",
+                "Subobjects" : true,
+                "Children" : s3NotificationChildConfiguration
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=BASELINE_KEY_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "Shared security keys for a segment"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "segment"
+            }
+        ]
+    parent=BASELINE_COMPONENT_TYPE
+    childAttribute="Keys"
+    linkAttributes="Key"
+/]
+
+[@addComponentResourceGroup
+    type=BASELINE_KEY_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Engine",
+                "Type" : STRING_TYPE,
+                "Values" : [ "cmk", "ssh", "oai" ],
+                "Mandatory" : true
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            }
+        ]
+/]

--- a/providers/shared/component/bastion.ftl
+++ b/providers/shared/component/bastion.ftl
@@ -1,89 +1,93 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        BASTION_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "An bastion instance to manage vpc only components"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "segment"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Active",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "OS",
-                    "Type" : STRING_TYPE,
-                    "Values" : ["linux"],
-                    "Default" : "linux"
-                },
-                {
-                    "Names" : ["Fragment", "Container"],
-                    "Type" : STRING_TYPE,
-                    "Default" : ""
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration +
-                                    [
-                                        {
-                                            "Names" : "Processor",
-                                            "Type" : STRING_TYPE,
-                                            "Default" : "default"
-                                        }
-                                    ]
-                },
-                {
-                    "Names" : "AutoScaling",
-                    "Children" : autoScalingChildConfiguration
-                },
-                {
-                    "Names" : "Permissions",
-                    "Children" : [
-                        {
-                            "Names" : "Decrypt",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : false
-                        },
-                        {
-                            "Names" : "AsFile",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : false
-                        },
-                        {
-                            "Names" : "AppData",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : false
-                        },
-                        {
-                            "Names" : "AppPublic",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : false
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Role",
-                    "Description" : "Server configuration role",
-                    "Default" : ""
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=BASTION_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "An bastion instance to manage vpc only components"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "segment"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=BASTION_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Active",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "OS",
+                "Type" : STRING_TYPE,
+                "Values" : ["linux"],
+                "Default" : "linux"
+            },
+            {
+                "Names" : ["Fragment", "Container"],
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration +
+                                [
+                                    {
+                                        "Names" : "Processor",
+                                        "Type" : STRING_TYPE,
+                                        "Default" : "default"
+                                    }
+                                ]
+            },
+            {
+                "Names" : "AutoScaling",
+                "Children" : autoScalingChildConfiguration
+            },
+            {
+                "Names" : "Permissions",
+                "Children" : [
+                    {
+                        "Names" : "Decrypt",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "AsFile",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "AppData",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "AppPublic",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    }
+                ]
+            },
+            {
+                "Names" : "Role",
+                "Description" : "Server configuration role",
+                "Default" : ""
+            }
+        ]
+/]

--- a/providers/shared/component/cache.ftl
+++ b/providers/shared/component/cache.ftl
@@ -1,78 +1,82 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        CACHE_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "Managed in-memory cache services"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Engine",
-                    "Type" : STRING_TYPE,
-                    "Mandatory" : true
-                },
-                {
-                    "Names" : "EngineVersion",
-                    "Type" : STRING_TYPE
-                },
-                {
-                    "Names" : "Port",
-                    "Type" : STRING_TYPE
-                },
-                {
-                    "Names" : "Backup",
-                    "Children" : [
-                        {
-                            "Names" : "RetentionPeriod",
-                            "Type" : STRING_TYPE,
-                            "Default" : ""
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration +
-                                    [
-                                        {
-                                            "Names" : "Processor",
-                                            "Type" : STRING_TYPE,
-                                            "Default" : "default"
-                                        }
-                                    ]
-                },
-                {
-                    "Names" : "Hibernate",
-                    "Children" : [
-                        {
-                            "Names" : "Enabled",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : false
-                        },
-                        {
-                            "Names" : "StartUpMode",
-                            "Type" : STRING_TYPE,
-                            "Values" : ["replace"],
-                            "Default" : "replace"
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Alerts",
-                    "Subobjects" : true,
-                    "Children" : alertChildrenConfiguration
-                }
-            ]
-        }
-}]
+[@addComponent
+    type=CACHE_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "Managed in-memory cache services"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=CACHE_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Engine",
+                "Type" : STRING_TYPE,
+                "Mandatory" : true
+            },
+            {
+                "Names" : "EngineVersion",
+                "Type" : STRING_TYPE
+            },
+            {
+                "Names" : "Port",
+                "Type" : STRING_TYPE
+            },
+            {
+                "Names" : "Backup",
+                "Children" : [
+                    {
+                        "Names" : "RetentionPeriod",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    }
+                ]
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration +
+                                [
+                                    {
+                                        "Names" : "Processor",
+                                        "Type" : STRING_TYPE,
+                                        "Default" : "default"
+                                    }
+                                ]
+            },
+            {
+                "Names" : "Hibernate",
+                "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "StartUpMode",
+                        "Type" : STRING_TYPE,
+                        "Values" : ["replace"],
+                        "Default" : "replace"
+                    }
+                ]
+            },
+            {
+                "Names" : "Alerts",
+                "Subobjects" : true,
+                "Children" : alertChildrenConfiguration
+            }
+        ]
+/]

--- a/providers/shared/component/component.ftl
+++ b/providers/shared/component/component.ftl
@@ -327,7 +327,7 @@
         )]
 [/#macro]
 
-[#macro addComponentConfiguration type properties=[] ]
+[#macro addComponent type properties ]
     [@mergeComponentConfiguration
         type
         {
@@ -336,8 +336,9 @@
     /]
 [/#macro]
 
-[#macro addComponentResourceGroup type provider="common" resourceGroup="default" attributes=[] ]
-    [@mergeComponentConfiguration
+[#macro addComponentResourceGroup type attributes provider="shared" resourceGroup="default" ]
+    [#-- ready for resource group support --]
+    [#-- @mergeComponentConfiguration
         type
         {
             "ResourceGroups" : {
@@ -348,21 +349,31 @@
                 }
             }
         }
-    /]
-[/#macro]
+    / --]
 
-[#macro addComponentChildren type childType childAttribute linkAttribute ]
-    [#local components =
-        ((componentConfiguration[type].Components)![]) +
-        {
-            "Type" : childType,
-            "Component" : childAttribute,
-            "Link" : linkAttributes
-        } ]
     [@mergeComponentConfiguration
         type
         {
-            "Components" : components
+            "Attributes" : asArray(attributes)
+        }
+    /]
+[/#macro]
+
+[#macro addChildComponent type properties parent childAttribute linkAttributes ]
+    [@addComponent type properties /]
+    [#local children =
+        ((componentConfiguration[parent].Components)![]) +
+        [
+            {
+                "Type" : type,
+                "Component" : childAttribute,
+                "Link" : asArray(linkAttributes)
+            }
+        ] ]
+    [@mergeComponentConfiguration
+        parent
+        {
+            "Components" : children
         }
     /]
 [/#macro]

--- a/providers/shared/component/computecluster.ftl
+++ b/providers/shared/component/computecluster.ftl
@@ -1,78 +1,82 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        COMPUTECLUSTER_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "Auto-Scaling IaaS with code deployment"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "application"
-                }
-            ],
-            "Attributes" :  [
-                {
-                    "Names" : ["Fragment", "Container"],
-                    "Type" : STRING_TYPE,
-                    "Default" : ""
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration +
-                                    [
-                                        {
-                                            "Names" : "Processor",
-                                            "Type" : STRING_TYPE,
-                                            "Default" : "default"
-                                        }
-                                    ]
-                },
-                {
-                    "Names" : "UseInitAsService",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "AutoScaling",
-                    "Children" : autoScalingChildConfiguration
-                },
-                {
-                    "Names" : "DockerHost",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "Ports",
-                    "Subobjects" : true,
-                    "Children" : [
-                        {
-                            "Names" : "IPAddressGroups",
-                            "Type" : ARRAY_OF_STRING_TYPE,
-                            "Default" : []
-                        },
-                        {
-                            "Names" : "LB",
-                            "Children" : lbChildConfiguration
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Role",
-                    "Description" : "Server configuration role",
-                    "Default" : ""
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=COMPUTECLUSTER_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "Auto-Scaling IaaS with code deployment"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "application"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=COMPUTECLUSTER_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : ["Fragment", "Container"],
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration +
+                                [
+                                    {
+                                        "Names" : "Processor",
+                                        "Type" : STRING_TYPE,
+                                        "Default" : "default"
+                                    }
+                                ]
+            },
+            {
+                "Names" : "UseInitAsService",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "AutoScaling",
+                "Children" : autoScalingChildConfiguration
+            },
+            {
+                "Names" : "DockerHost",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Ports",
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "IPAddressGroups",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Default" : []
+                    },
+                    {
+                        "Names" : "LB",
+                        "Children" : lbChildConfiguration
+                    }
+                ]
+            },
+            {
+                "Names" : "Role",
+                "Description" : "Server configuration role",
+                "Default" : ""
+            }
+        ]
+/]

--- a/providers/shared/component/configstore.ftl
+++ b/providers/shared/component/configstore.ftl
@@ -1,81 +1,89 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        CONFIGSTORE_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "A configuration store to provide dynamic attributes"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : ["Fragment", "Container"],
-                    "Type" : STRING_TYPE,
-                    "Default" : ""
-                },
-                {
-                    "Names" : "Table",
-                    "Children" : dynamoDbTableChildConfiguration
-                },
-                {
-                    "Names" : "SecondaryKey",
-                    "Description" : "Uses the name of the branch to provide a secondary sort key on branches - id being the primary",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                }
-            ],
-            "Components" : [
-                {
-                    "Type" : CONFIGSTORE_BRANCH_COMPONENT_TYPE,
-                    "Component" : "Branches",
-                    "Link" : [ "Branch" ]
-                }
-            ]
-        },
-        CONFIGSTORE_BRANCH_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "A branch of configuration which belongs to a config store"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "States",
-                    "Descrption" : "A writable attribute in the config branch",
-                    "Subobjects" : true,
-                    "Children" : [
-                        {
-                            "Names" : "InitialValue",
-                            "Description" : "The initial value that will be applied to the state",
-                            "Type" : STRING_TYPE,
-                            "Default" : "-"
-                        }
-                    ]
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=CONFIGSTORE_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A configuration store to provide dynamic attributes"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=CONFIGSTORE_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : ["Fragment", "Container"],
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            },
+            {
+                "Names" : "Table",
+                "Children" : dynamoDbTableChildConfiguration
+            },
+            {
+                "Names" : "SecondaryKey",
+                "Description" : "Uses the name of the branch to provide a secondary sort key on branches - id being the primary",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=CONFIGSTORE_BRANCH_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "A branch of configuration which belongs to a config store"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+    parent=CONFIGSTORE_COMPONENT_TYPE
+    childAttribute="Branches"
+    linkAttributes="Branch"
+/]
+
+[@addComponentResourceGroup
+    type=CONFIGSTORE_BRANCH_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "States",
+                "Descrption" : "A writable attribute in the config branch",
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "InitialValue",
+                        "Description" : "The initial value that will be applied to the state",
+                        "Type" : STRING_TYPE,
+                        "Default" : "-"
+                    }
+                ]
+            }
+        ]
+/]

--- a/providers/shared/component/contenthub.ftl
+++ b/providers/shared/component/contenthub.ftl
@@ -1,70 +1,47 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        CONTENTHUB_HUB_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "Hub for decentralised content hosting with centralised publishing"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "github" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "application"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Prefix",
-                    "Type" : STRING_TYPE,
-                    "Mandatory" : true
-                },
-                {
-                    "Names" : "Engine",
-                    "Type" : STRING_TYPE,
-                    "Default" : "github"
-                },
-                {
-                    "Names" : "Branch",
-                    "Type" : STRING_TYPE,
-                    "Default" : "master"
-                },
-                {
-                    "Names" : "Repository",
-                    "Type" : STRING_TYPE,
-                    "Default" : ""
-                }
-            ]
-        },
-        CONTENTHUB_NODE_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "Node for decentralised content hosting with centralised publishing"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "github" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "application"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Path",
-                    "Children" : pathChildConfiguration
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=CONTENTHUB_HUB_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "Hub for decentralised content hosting with centralised publishing"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "github" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "application"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=CONTENTHUB_HUB_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Prefix",
+                "Type" : STRING_TYPE,
+                "Mandatory" : true
+            },
+            {
+                "Names" : "Engine",
+                "Type" : STRING_TYPE,
+                "Default" : "github"
+            },
+            {
+                "Names" : "Branch",
+                "Type" : STRING_TYPE,
+                "Default" : "master"
+            },
+            {
+                "Names" : "Repository",
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            }
+        ]
+/]

--- a/providers/shared/component/contentnode.ftl
+++ b/providers/shared/component/contentnode.ftl
@@ -1,0 +1,36 @@
+[#ftl]
+
+[@addComponent
+    type=CONTENTHUB_NODE_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "Node for decentralised content hosting with centralised publishing"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "github" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "application"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=CONTENTHUB_NODE_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Path",
+                "Children" : pathChildConfiguration
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            }
+        ]
+/]

--- a/providers/shared/component/datafeed.ftl
+++ b/providers/shared/component/datafeed.ftl
@@ -1,119 +1,122 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        DATAFEED_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "A service which feeds data into the ES index currently based on kineses data firehose"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "ElasticSearch",
-                    "Children" : [
-                        {
-                            "Names" : "IndexPrefix",
-                            "Type" : STRING_TYPE,
-                            "Description" : "The prefix applied to generate the index name ( if not using roll over this will be the index name)",
-                            "Mandatory" : true
-                        },
-                        {
-                            "Names" : "IndexRotation",
-                            "Type" : STRING_TYPE,
-                            "Description" : "When to rotate the index ( the timestamp will be appended to the indexprefix)",
-                            "Values" : [ "NoRotation", "OneDay", "OneHour", "OneMonth", "OneWeek" ],
-                            "Default" : "OneMonth"
-                        },
-                        {
-                            "Names" : "DocumentType",
-                            "Type" : STRING_TYPE,
-                            "Description" : "The document type used when creating the document",
-                            "Mandatory" : true
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Buffering",
-                    "Description" : "How long data should be bufferred before being deliverd to ES",
-                    "Children" : [
-                        {
-                            "Names" : "Interval",
-                            "Type" : NUMBER_TYPE,
-                            "Description" : "The time in seconds before data should be delivered",
-                            "Default" : 60
-                        },
-                        {
-                            "Names" : "Size",
-                            "Type" : NUMBER_TYPE,
-                            "Description" : "The size in MB before data should be delivered",
-                            "Default" : 1
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Logging",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : true
-                },
-                {
-                    "Names" : "Encrypted",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                }
-                {
-                    "Names" : "Backup",
-                    "Children" : [
-                        {
-                            "Names" : "FailureDuration",
-                            "Type" : NUMBER_TYPE,
-                            "Description" : "The time in seconds that the data feed will attempt to deliver the data before it is sent to backup",
-                            "Default" : 3600
-                        },
-                        {
-                            "Names" : "Policy",
-                            "Type" : STRING_TYPE,
-                            "Description" : "The backup policy to apply to records",
-                            "Values" : [ "AllDocuments", "FailedDocumentsOnly" ],
-                            "Default" : "FailedDocumentsOnly"
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Destination",
-                    "Children" : [
-                        {
-                            "Names" : "Link",
-                            "Children" : linkChildrenConfiguration,
-                            "Mandatory" : true
-                        }
-                    ]
-                }
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "Alerts",
-                    "Subobjects" : true,
-                    "Children" : alertChildrenConfiguration
-                },
-                {
-                    "Names" : "LogWatchers",
-                    "Subobjects" : true,
-                    "Children" : logWatcherChildrenConfiguration
-                }
-            ]
-        }
-    }
-]
+[@addComponent
+    type=DATAFEED_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "A service which feeds data into the ES index currently based on kineses data firehose"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=DATAFEED_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "ElasticSearch",
+                "Children" : [
+                    {
+                        "Names" : "IndexPrefix",
+                        "Type" : STRING_TYPE,
+                        "Description" : "The prefix applied to generate the index name ( if not using roll over this will be the index name)",
+                        "Mandatory" : true
+                    },
+                    {
+                        "Names" : "IndexRotation",
+                        "Type" : STRING_TYPE,
+                        "Description" : "When to rotate the index ( the timestamp will be appended to the indexprefix)",
+                        "Values" : [ "NoRotation", "OneDay", "OneHour", "OneMonth", "OneWeek" ],
+                        "Default" : "OneMonth"
+                    },
+                    {
+                        "Names" : "DocumentType",
+                        "Type" : STRING_TYPE,
+                        "Description" : "The document type used when creating the document",
+                        "Mandatory" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "Buffering",
+                "Description" : "How long data should be bufferred before being deliverd to ES",
+                "Children" : [
+                    {
+                        "Names" : "Interval",
+                        "Type" : NUMBER_TYPE,
+                        "Description" : "The time in seconds before data should be delivered",
+                        "Default" : 60
+                    },
+                    {
+                        "Names" : "Size",
+                        "Type" : NUMBER_TYPE,
+                        "Description" : "The size in MB before data should be delivered",
+                        "Default" : 1
+                    }
+                ]
+            },
+            {
+                "Names" : "Logging",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "Encrypted",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            }
+            {
+                "Names" : "Backup",
+                "Children" : [
+                    {
+                        "Names" : "FailureDuration",
+                        "Type" : NUMBER_TYPE,
+                        "Description" : "The time in seconds that the data feed will attempt to deliver the data before it is sent to backup",
+                        "Default" : 3600
+                    },
+                    {
+                        "Names" : "Policy",
+                        "Type" : STRING_TYPE,
+                        "Description" : "The backup policy to apply to records",
+                        "Values" : [ "AllDocuments", "FailedDocumentsOnly" ],
+                        "Default" : "FailedDocumentsOnly"
+                    }
+                ]
+            },
+            {
+                "Names" : "Destination",
+                "Children" : [
+                    {
+                        "Names" : "Link",
+                        "Children" : linkChildrenConfiguration,
+                        "Mandatory" : true
+                    }
+                ]
+            }
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Alerts",
+                "Subobjects" : true,
+                "Children" : alertChildrenConfiguration
+            },
+            {
+                "Names" : "LogWatchers",
+                "Subobjects" : true,
+                "Children" : logWatcherChildrenConfiguration
+            }
+        ]
+/]

--- a/providers/shared/component/datapipeline.ftl
+++ b/providers/shared/component/datapipeline.ftl
@@ -1,69 +1,73 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        DATAPIPELINE_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "Managed Data ETL Processing"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "application"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : ["Fragment", "Container"],
-                    "Type" : STRING_TYPE,
-                    "Default" : ""
-                },
-                {
-                    "Names" : "Permissions",
-                    "Children" : [
-                        {
-                            "Names" : "Decrypt",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "AsFile",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "AppData",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "AppPublic",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration +
-                                    [
-                                        {
-                                            "Names" : "Processor",
-                                            "Type" : STRING_TYPE,
-                                            "Default" : "default"
-                                        }
-                                    ]
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=DATAPIPELINE_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "Managed Data ETL Processing"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "application"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=DATAPIPELINE_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : ["Fragment", "Container"],
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            },
+            {
+                "Names" : "Permissions",
+                "Children" : [
+                    {
+                        "Names" : "Decrypt",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "AsFile",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "AppData",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "AppPublic",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration +
+                                [
+                                    {
+                                        "Names" : "Processor",
+                                        "Type" : STRING_TYPE,
+                                        "Default" : "default"
+                                    }
+                                ]
+            }
+        ]
+/]

--- a/providers/shared/component/dataset.ftl
+++ b/providers/shared/component/dataset.ftl
@@ -1,45 +1,49 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        DATASET_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "A data aretefact that is managed in a similar way to a code unit"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "application"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Engine",
-                    "Type" : STRING_TYPE,
-                    "Values" : ["s3", "rds"],
-                    "Mandatory" : true
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "Prefix",
-                    "Type" : STRING_TYPE,
-                    "Default" : ""
-                },
-                {
-                    "Names" : "BuildEnvironment",
-                    "Type" : ARRAY_OF_STRING_TYPE,
-                    "Description" : "The environments used to build the dataset",
-                    "Mandatory" : true
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=DATASET_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "A data aretefact that is managed in a similar way to a code unit"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "application"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=DATASET_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Engine",
+                "Type" : STRING_TYPE,
+                "Values" : ["s3", "rds"],
+                "Mandatory" : true
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Prefix",
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            },
+            {
+                "Names" : "BuildEnvironment",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Description" : "The environments used to build the dataset",
+                "Mandatory" : true
+            }
+        ]
+/]

--- a/providers/shared/component/datavolume.ftl
+++ b/providers/shared/component/datavolume.ftl
@@ -1,83 +1,87 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        DATAVOLUME_COMPONENT_TYPE  : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "A persistant disk volume independent of compute"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Engine",
-                    "Type" : STRING_TYPE,
-                    "Values" : [ "ebs" ],
-                    "Default" : "ebs"
-                },
-                {
-                    "Names" : "Encrypted",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "Size",
-                    "Type" : NUMBER_TYPE,
-                    "Default" : 20
-                },
-                {
-                    "Names" : "VolumeType",
-                    "Type" : STRING_TYPE,
-                    "Default" : "gp2",
-                    "Values" : [ "standard", "io1", "gp2", "sc1", "st1" ]
-                },
-                {
-                    "Names" : "ProvisionedIops",
-                    "Type" : NUMBER_TYPE,
-                    "Default" : 100
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
-                },
-                {
-                    "Names" : "Backup",
-                    "Children" : [
-                        {
-                            "Names" : "Enabled",
-                            "Type" : BOOLEAN_TYPE,
-                            "Description" : "Create scheduled snapshots of the data volume",
-                            "Default" : true
-                        }
-                        {
-                            "Names" : "Schedule",
-                            "Type" : STRING_TYPE,
-                            "Description" : "Schedule in rate() or cron() formats",
-                            "Default" : "rate(1 day)"
-                        },
-                        {
-                            "Names" : "ScheduleTimeZone",
-                            "Type" : STRING_TYPE,
-                            "Description" : "When using a cron expression in Schedule sets the time zone to base it from",
-                            "Default" : "Etc/UTC"
-                        },
-                        {
-                            "Names" : "RetentionPeriod",
-                            "Type" : NUMBER_TYPE,
-                            "Description" : "How long to keep snapshot for in days",
-                            "Default" : 35
-                        }
-                    ]
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=DATAVOLUME_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "A persistant disk volume independent of compute"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=DATAVOLUME_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Engine",
+                "Type" : STRING_TYPE,
+                "Values" : [ "ebs" ],
+                "Default" : "ebs"
+            },
+            {
+                "Names" : "Encrypted",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Size",
+                "Type" : NUMBER_TYPE,
+                "Default" : 20
+            },
+            {
+                "Names" : "VolumeType",
+                "Type" : STRING_TYPE,
+                "Default" : "gp2",
+                "Values" : [ "standard", "io1", "gp2", "sc1", "st1" ]
+            },
+            {
+                "Names" : "ProvisionedIops",
+                "Type" : NUMBER_TYPE,
+                "Default" : 100
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration
+            },
+            {
+                "Names" : "Backup",
+                "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Type" : BOOLEAN_TYPE,
+                        "Description" : "Create scheduled snapshots of the data volume",
+                        "Default" : true
+                    }
+                    {
+                        "Names" : "Schedule",
+                        "Type" : STRING_TYPE,
+                        "Description" : "Schedule in rate() or cron() formats",
+                        "Default" : "rate(1 day)"
+                    },
+                    {
+                        "Names" : "ScheduleTimeZone",
+                        "Type" : STRING_TYPE,
+                        "Description" : "When using a cron expression in Schedule sets the time zone to base it from",
+                        "Default" : "Etc/UTC"
+                    },
+                    {
+                        "Names" : "RetentionPeriod",
+                        "Type" : NUMBER_TYPE,
+                        "Description" : "How long to keep snapshot for in days",
+                        "Default" : 35
+                    }
+                ]
+            }
+        ]
+/]

--- a/providers/shared/component/ec2.ftl
+++ b/providers/shared/component/ec2.ftl
@@ -1,74 +1,78 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        EC2_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "A single virtual machine with no code deployment "
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "FixedIP",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "DockerHost",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : ["Fragment", "Container"],
-                    "Type" : "string",
-                    "Default" : ""
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration +
-                                    [
-                                        {
-                                            "Names" : "Processor",
-                                            "Type" : STRING_TYPE,
-                                            "Default" : "default"
-                                        }
-                                    ]
-                },
-                {
-                    "Names" : "Ports",
-                    "Subobjects" : true,
-                    "Children" : [
-                        {
-                            "Names" : "IPAddressGroups",
-                            "Type" : ARRAY_OF_STRING_TYPE,
-                            "Default" : []
-                        },
-                        {
-                            "Names" : "LB",
-                            "Children" : lbChildConfiguration
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Role",
-                    "Description" : "Server configuration role",
-                    "Default" : ""
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=EC2_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "A single virtual machine with no code deployment "
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=EC2_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "FixedIP",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "DockerHost",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : ["Fragment", "Container"],
+                "Type" : "string",
+                "Default" : ""
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration +
+                                [
+                                    {
+                                        "Names" : "Processor",
+                                        "Type" : STRING_TYPE,
+                                        "Default" : "default"
+                                    }
+                                ]
+            },
+            {
+                "Names" : "Ports",
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "IPAddressGroups",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Default" : []
+                    },
+                    {
+                        "Names" : "LB",
+                        "Children" : lbChildConfiguration
+                    }
+                ]
+            },
+            {
+                "Names" : "Role",
+                "Description" : "Server configuration role",
+                "Default" : ""
+            }
+        ]
+/]

--- a/providers/shared/component/ecs.ftl
+++ b/providers/shared/component/ecs.ftl
@@ -96,341 +96,355 @@
     ]
 ]
 
-[#assign componentConfiguration +=
-    {
-        ECS_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "An autoscaling container host cluster"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : ["Fragment", "Container"],
-                    "Type" : "string",
-                    "Default" : ""
-                },
-                {
-                    "Names" : "FixedIP",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "LogDriver",
-                    "Type" : STRING_TYPE,
-                    "Values" : ["awslogs", "json-file", "fluentd"],
-                    "Default" : "awslogs"
-                },
-                {
-                    "Names" : "VolumeDrivers",
-                    "Type" : ARRAY_OF_STRING_TYPE,
-                    "Values" : [ "ebs" ],
-                    "Default" : []
-                },
-                {
-                    "Names" : "ClusterLogGroup",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : true
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration +
-                                    [
-                                        {
-                                            "Names" : "Processor",
-                                            "Type" : STRING_TYPE,
-                                            "Default" : "default"
-                                        }
-                                    ]
-                },
-                {
-                    "Names" : "AutoScaling",
-                    "Children" : autoScalingChildConfiguration
-                },
-                {
-                    "Names" : "DockerUsers",
-                    "Subobjects" : true,
-                    "Children" : [
-                        {
-                            "Names" : "UserName",
-                            "Type" : STRING_TYPE
-                        },
-                        {
-                            "Names" : "UID",
-                            "Type" : NUMBER_TYPE,
-                            "Mandatory" : true
-                        }
-                    ]
-                },
-                {
-                    "Names" : "LogMetrics",
-                    "Subobjects" : true,
-                    "Children" : logMetricChildrenConfiguration
-                },
-                {
-                    "Names" : "Alerts",
-                    "Subobjects" : true,
-                    "Children" : alertChildrenConfiguration
-                },
-                {
-                    "Names" : "Hibernate",
-                    "Children" : [
-                        {
-                            "Names" : "Enabled",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : false
-                        },
-                        {
-                            "Names" : "StartUpMode",
-                            "Type" : STRING_TYPE,
-                            "Values" : ["replace"],
-                            "Default" : "replace"
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Role",
-                    "Description" : "Server configuration role",
-                    "Default" : ""
-                }
-            ],
-            "Components" : [
-                {
-                    "Type" : ECS_SERVICE_COMPONENT_TYPE,
-                    "Component" : "Services",
-                    "Link" : "Service"
-                },
-                {
-                    "Type" : ECS_TASK_COMPONENT_TYPE,
-                    "Component" : "Tasks",
-                    "Link" : "Task"
-                }
-            ]
-        },
-        ECS_SERVICE_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "An orchestrated container with always on scheduling"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "application"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Engine",
-                    "Type" : STRING_TYPE,
-                    "Values" : [ "ec2", "fargate" ],
-                    "Default" : "ec2"
-                },
-                {
-                    "Names" : "Containers",
-                    "Subobjects" : true,
-                    "Children" : containerChildrenConfiguration
-                },
-                {
-                    "Names" : "DesiredCount",
-                    "Type" : NUMBER_TYPE,
-                    "Default" : -1
-                },
-                {
-                    "Names" : "UseTaskRole",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : true
-                },
-                {
-                    "Names" : "Permissions",
-                    "Children" : [
-                        {
-                            "Names" : "Decrypt",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "AsFile",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "AppData",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "AppPublic",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        }
-                    ]
-                },
-                {
-                    "Names" : "TaskLogGroup",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : true
-                },
-                {
-                    "Names" : "LogMetrics",
-                    "Subobjects" : true,
-                    "Children" : logMetricChildrenConfiguration
-                },
-                {
-                    "Names" : "Alerts",
-                    "Subobjects" : true,
-                    "Children" : alertChildrenConfiguration
-                },
-                {
-                    "Names" : "NetworkMode",
-                    "Type" : STRING_TYPE,
-                    "Values" : ["none", "bridge", "awsvpc", "host"],
-                    "Default" : ""
-                },
-                {
-                    "Names" : "ContainerNetworkLinks",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "Placement",
-                    "Children" : [
-                        {
-                            "Names" : "Strategy",
-                            "Type" : STRING_TYPE,
-                            "Values" : [ "", "daemon"],
-                            "Description" : "How to place containers on the cluster",
-                            "Default" : ""
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
-                }
-            ]
-        },
-        ECS_TASK_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "A container defintion which is invoked on demand"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "application"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Engine",
-                    "Type" : STRING_TYPE,
-                    "Values" : [ "ec2", "fargate" ],
-                    "Default" : "ec2"
-                },
-                {
-                    "Names" : "Containers",
-                    "Subobjects" : true,
-                    "Children" : containerChildrenConfiguration
-                },
-                {
-                    "Names" : "UseTaskRole",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : true
-                },
-                {
-                    "Names" : "Permissions",
-                    "Children" : [
-                        {
-                            "Names" : "Decrypt",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "AsFile",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "AppData",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "AppPublic",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        }
-                    ]
-                },
-                {
-                    "Names" : "TaskLogGroup",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : true
-                },
-                {
-                    "Names" : "LogMetrics",
-                    "Subobjects" : true,
-                    "Children" : logMetricChildrenConfiguration
-                },
-                {
-                    "Names" : "Alerts",
-                    "Subobjects" : true,
-                    "Children" : alertChildrenConfiguration
-                },
-                {
-                    "Names" : "NetworkMode",
-                    "Type" : STRING_TYPE,
-                    "Values" : ["none", "bridge", "awsvpc", "host"],
-                    "Default" : ""
-                },
-                {
-                    "Names" : "FixedName",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
-                },
-                {
-                    "Names" : "Schedules",
-                    "Subobjects" : true,
-                    "Children" : [
-                        {
-                            "Names" : "Expression",
-                            "Type" : STRING_TYPE,
-                            "Default" : "rate(1 hours)"
-                        },
-                        {
-                            "Names" : "TaskCount",
-                            "Description" : "The number of tasks to run on the schedule",
-                            "Type" : NUMBER_TYPE,
-                            "Default" : 1
-                        }
-                    ]
-                }
-            ]
-        }
-    } ]
+[@addComponent
+    type=ECS_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "An autoscaling container host cluster"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=ECS_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : ["Fragment", "Container"],
+                "Type" : "string",
+                "Default" : ""
+            },
+            {
+                "Names" : "FixedIP",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "LogDriver",
+                "Type" : STRING_TYPE,
+                "Values" : ["awslogs", "json-file", "fluentd"],
+                "Default" : "awslogs"
+            },
+            {
+                "Names" : "VolumeDrivers",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Values" : [ "ebs" ],
+                "Default" : []
+            },
+            {
+                "Names" : "ClusterLogGroup",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration +
+                                [
+                                    {
+                                        "Names" : "Processor",
+                                        "Type" : STRING_TYPE,
+                                        "Default" : "default"
+                                    }
+                                ]
+            },
+            {
+                "Names" : "AutoScaling",
+                "Children" : autoScalingChildConfiguration
+            },
+            {
+                "Names" : "DockerUsers",
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "UserName",
+                        "Type" : STRING_TYPE
+                    },
+                    {
+                        "Names" : "UID",
+                        "Type" : NUMBER_TYPE,
+                        "Mandatory" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "LogMetrics",
+                "Subobjects" : true,
+                "Children" : logMetricChildrenConfiguration
+            },
+            {
+                "Names" : "Alerts",
+                "Subobjects" : true,
+                "Children" : alertChildrenConfiguration
+            },
+            {
+                "Names" : "Hibernate",
+                "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "StartUpMode",
+                        "Type" : STRING_TYPE,
+                        "Values" : ["replace"],
+                        "Default" : "replace"
+                    }
+                ]
+            },
+            {
+                "Names" : "Role",
+                "Description" : "Server configuration role",
+                "Default" : ""
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=ECS_SERVICE_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "An orchestrated container with always on scheduling"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "application"
+            }
+        ]
+    parent=ECS_COMPONENT_TYPE
+    childAttribute="Services"
+    linkAttributes="Service"
+/]
+
+[@addComponentResourceGroup
+    type=ECS_SERVICE_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Engine",
+                "Type" : STRING_TYPE,
+                "Values" : [ "ec2", "fargate" ],
+                "Default" : "ec2"
+            },
+            {
+                "Names" : "Containers",
+                "Subobjects" : true,
+                "Children" : containerChildrenConfiguration
+            },
+            {
+                "Names" : "DesiredCount",
+                "Type" : NUMBER_TYPE,
+                "Default" : -1
+            },
+            {
+                "Names" : "UseTaskRole",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "Permissions",
+                "Children" : [
+                    {
+                        "Names" : "Decrypt",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "AsFile",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "AppData",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "AppPublic",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "TaskLogGroup",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "LogMetrics",
+                "Subobjects" : true,
+                "Children" : logMetricChildrenConfiguration
+            },
+            {
+                "Names" : "Alerts",
+                "Subobjects" : true,
+                "Children" : alertChildrenConfiguration
+            },
+            {
+                "Names" : "NetworkMode",
+                "Type" : STRING_TYPE,
+                "Values" : ["none", "bridge", "awsvpc", "host"],
+                "Default" : ""
+            },
+            {
+                "Names" : "ContainerNetworkLinks",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Placement",
+                "Children" : [
+                    {
+                        "Names" : "Strategy",
+                        "Type" : STRING_TYPE,
+                        "Values" : [ "", "daemon"],
+                        "Description" : "How to place containers on the cluster",
+                        "Default" : ""
+                    }
+                ]
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=ECS_TASK_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "A container defintion which is invoked on demand"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "application"
+            }
+        ]
+    parent=ECS_COMPONENT_TYPE
+    childAttribute="Tasks"
+    linkAttributes="Task"
+/]
+
+[@addComponentResourceGroup
+    type=ECS_TASK_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Engine",
+                "Type" : STRING_TYPE,
+                "Values" : [ "ec2", "fargate" ],
+                "Default" : "ec2"
+            },
+            {
+                "Names" : "Containers",
+                "Subobjects" : true,
+                "Children" : containerChildrenConfiguration
+            },
+            {
+                "Names" : "UseTaskRole",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "Permissions",
+                "Children" : [
+                    {
+                        "Names" : "Decrypt",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "AsFile",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "AppData",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "AppPublic",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "TaskLogGroup",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "LogMetrics",
+                "Subobjects" : true,
+                "Children" : logMetricChildrenConfiguration
+            },
+            {
+                "Names" : "Alerts",
+                "Subobjects" : true,
+                "Children" : alertChildrenConfiguration
+            },
+            {
+                "Names" : "NetworkMode",
+                "Type" : STRING_TYPE,
+                "Values" : ["none", "bridge", "awsvpc", "host"],
+                "Default" : ""
+            },
+            {
+                "Names" : "FixedName",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration
+            },
+            {
+                "Names" : "Schedules",
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Expression",
+                        "Type" : STRING_TYPE,
+                        "Default" : "rate(1 hours)"
+                    },
+                    {
+                        "Names" : "TaskCount",
+                        "Description" : "The number of tasks to run on the schedule",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : 1
+                    }
+                ]
+            }
+        ]
+/]

--- a/providers/shared/component/efs.ftl
+++ b/providers/shared/component/efs.ftl
@@ -1,62 +1,70 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        EFS_COMPONENT_TYPE  : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "A managed network attached file share"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Encrypted",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : true
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
-                }
-            ],
-            "Components" : [
-                {
-                    "Type" : EFS_MOUNT_COMPONENT_TYPE,
-                    "Component" : "Mounts",
-                    "Link" : "Mount"
-                }
-            ]
-        },
-        EFS_MOUNT_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "A specific directory on the share for OS mounting"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Directory",
-                    "Type" : STRING_TYPE,
-                    "Mandatory" : true
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=EFS_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "A managed network attached file share"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=EFS_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Encrypted",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=EFS_MOUNT_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "A specific directory on the share for OS mounting"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+    parent=EFS_COMPONENT_TYPE
+    childAttribute="Mounts"
+    linkAttributes="Mount"
+/]
+
+[@addComponentResourceGroup
+    type=EFS_MOUNT_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Directory",
+                "Type" : STRING_TYPE,
+                "Mandatory" : true
+            }
+        ]
+/]

--- a/providers/shared/component/es.ftl
+++ b/providers/shared/component/es.ftl
@@ -1,87 +1,91 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        ES_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "A managed ElasticSearch instance"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Authentication",
-                    "Type" : STRING_TYPE,
-                    "Values" : ["IP", "SIG4ORIP", "SIG4ANDIP"],
-                    "Default" : "IP"
-                },
-                {
-                    "Names" : "Accounts",
-                    "Description" : "A list of accounts which will be permitted to access the ES index",
-                    "Type" : ARRAY_OF_STRING_TYPE,
-                    "Default" : [ "_environment" ]
-                },
-                {
-                    "Names" : "IPAddressGroups",
-                    "Description" : "A list of IP Address Groups which will be permitted to access the ES index",
-                    "Type" : ARRAY_OF_STRING_TYPE,
-                    "Mandatory" : true
-                },
-                {
-                    "Names" : "AdvancedOptions",
-                    "Type" : ARRAY_OF_STRING_TYPE,
-                    "Default" : []
-                },
-                {
-                    "Names" : "Version",
-                    "Type" : STRING_TYPE,
-                    "Mandatory" : true
-                },
-                {
-                    "Names" : "Encrypted",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "Snapshot",
-                    "Children" : [
-                        {
-                            "Names" : "Hour",
-                            "Type" : STRING_TYPE,
-                            "Default" : ""
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration +
-                                    [
-                                        {
-                                            "Names" : "Processor",
-                                            "Type" : STRING_TYPE,
-                                            "Default" : "default"
-                                        }
-                                    ]
-                },
-                {
-                    "Names" : "Alerts",
-                    "Subobjects" : true,
-                    "Children" : alertChildrenConfiguration
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=ES_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "A managed ElasticSearch instance"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=ES_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Authentication",
+                "Type" : STRING_TYPE,
+                "Values" : ["IP", "SIG4ORIP", "SIG4ANDIP"],
+                "Default" : "IP"
+            },
+            {
+                "Names" : "Accounts",
+                "Description" : "A list of accounts which will be permitted to access the ES index",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : [ "_environment" ]
+            },
+            {
+                "Names" : "IPAddressGroups",
+                "Description" : "A list of IP Address Groups which will be permitted to access the ES index",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Mandatory" : true
+            },
+            {
+                "Names" : "AdvancedOptions",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            },
+            {
+                "Names" : "Version",
+                "Type" : STRING_TYPE,
+                "Mandatory" : true
+            },
+            {
+                "Names" : "Encrypted",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Snapshot",
+                "Children" : [
+                    {
+                        "Names" : "Hour",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    }
+                ]
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration +
+                                [
+                                    {
+                                        "Names" : "Processor",
+                                        "Type" : STRING_TYPE,
+                                        "Default" : "default"
+                                    }
+                                ]
+            },
+            {
+                "Names" : "Alerts",
+                "Subobjects" : true,
+                "Children" : alertChildrenConfiguration
+            }
+        ]
+/]

--- a/providers/shared/component/gateway.ftl
+++ b/providers/shared/component/gateway.ftl
@@ -1,87 +1,95 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        NETWORK_GATEWAY_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "A service providing a route to another network"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "segment"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Active",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "Engine",
-                    "Type" : STRING_TYPE,
-                    "Values" : [ "natgw", "igw", "vpcendpoint" ],
-                    "Required" : true
-                },
-                {
-                    "Names" : "SourceIPAddressGroups",
-                    "Description" : "IP Address Groups which can access this gateway",
-                    "Type" : ARRAY_OF_STRING_TYPE,
-                    "Default" : [ "_localnet" ]
-                }
-            ],
-            "Components" : [
-                {
-                    "Type" : NETWORK_GATEWAY_DESTINATION_COMPONENT_TYPE,
-                    "Component" : "Destinations",
-                    "Link" : "Destination"
-                }
-            ]
-        },
-        NETWORK_GATEWAY_DESTINATION_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "A network destination offerred by the Gateway"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "segment"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Active",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "IPAddressGroups",
-                    "Description" : "An IP Address Group reference",
-                    "Type" : ARRAY_OF_STRING_TYPE,
-                    "Default" : []
-                },
-                {
-                    "Names" : "NetworkEndpointGroups",
-                    "Description" : "A cloud provider service group reference",
-                    "Type" : ARRAY_OF_STRING_TYPE,
-                    "Default" : []
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=NETWORK_GATEWAY_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A service providing a route to another network"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "segment"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=NETWORK_GATEWAY_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Active",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Engine",
+                "Type" : STRING_TYPE,
+                "Values" : [ "natgw", "igw", "vpcendpoint" ],
+                "Required" : true
+            },
+            {
+                "Names" : "SourceIPAddressGroups",
+                "Description" : "IP Address Groups which can access this gateway",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : [ "_localnet" ]
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=NETWORK_GATEWAY_DESTINATION_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A network destination offerred by the Gateway"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "segment"
+            }
+        ]
+    parent=NETWORK_GATEWAY_COMPONENT_TYPE
+    childAttribute="Destinations"
+    linkAttributes="Destination"
+/]
+
+[@addComponentResourceGroup
+    type=NETWORK_GATEWAY_DESTINATION_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Active",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "IPAddressGroups",
+                "Description" : "An IP Address Group reference",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            },
+            {
+                "Names" : "NetworkEndpointGroups",
+                "Description" : "A cloud provider service group reference",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            }
+        ]
+/]

--- a/providers/shared/component/lambda.ftl
+++ b/providers/shared/component/lambda.ftl
@@ -1,180 +1,187 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        LAMBDA_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "Container for a Function as a Service deployment"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "application"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "DeploymentType",
-                    "Type" : STRING_TYPE,
-                    "Values" : ["EDGE", "REGIONAL"],
-                    "Default" : "REGIONAL"
-                }
-            ],
-            "Components" : [
-                {
-                    "Type" : LAMBDA_FUNCTION_COMPONENT_TYPE,
-                    "Component" : "Functions",
-                    "Link" : "Function"
-                }
-            ]
-        },
-        LAMBDA_FUNCTION_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "A specific entry point for the lambda deployment"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "application"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : ["Fragment", "Container"],
-                    "Type" : STRING_TYPE,
-                    "Default" : ""
-                },
-                {
-                    "Names" : "Handler",
-                    "Type" : STRING_TYPE,
-                    "Mandatory" : true
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
-                },
-                {
-                    "Names" : "LogMetrics",
-                    "Subobjects" : true,
-                    "Children" : logMetricChildrenConfiguration
-                },
-                {
-                    "Names" : "LogWatchers",
-                    "Subobjects" : true,
-                    "Children" : logWatcherChildrenConfiguration
-                },
-                {
-                    "Names" : "Alerts",
-                    "Subobjects" : true,
-                    "Children" : alertChildrenConfiguration
-                },
-                {
-                    "Names" : ["Memory", "MemorySize"],
-                    "Type" : NUMBER_TYPE,
-                    "Default" : 0
-                },
-                {
-                    "Names" : "RunTime",
-                    "Type" : STRING_TYPE,
-                    "Values" : ["nodejs", "nodejs4.3", "nodejs6.10", "nodejs8.10", "java8", "python2.7", "python3.6", "dotnetcore1.0", "dotnetcore2.0", "dotnetcore2.1", "nodejs4.3-edge", "go1.x"],
-                    "Mandatory" : true
-                },
-                {
-                    "Names" : "Schedules",
-                    "Subobjects" : true,
-                    "Children" : [
-                        {
-                            "Names" : "Expression",
-                            "Type" : STRING_TYPE,
-                            "Default" : "rate(6 minutes)"
-                        },
-                        {
-                            "Names" : "InputPath",
-                            "Type" : STRING_TYPE,
-                            "Default" : "/healthcheck"
-                        },
-                        {
-                            "Names" : "Input",
-                            "Type" : OBJECT_TYPE,
-                            "Default" : {}
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Timeout",
-                    "Type" : NUMBER_TYPE,
-                    "Default" : 0
-                },
-                {
-                    "Names" : "VPCAccess",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : true
-                },
-                {
-                    "Names" : "UseSegmentKey",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "Permissions",
-                    "Children" : [
-                        {
-                            "Names" : "Decrypt",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "AsFile",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "AppData",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "AppPublic",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        }
-                    ]
-                },
-                {
-                    "Names" : "PredefineLogGroup",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "Environment",
-                    "Children" : settingsChildConfiguration
-                },
-                {
-                    "Names" : "FixedCodeVersion",
-                    "Children" : [
-                        {
-                            "Names" : "CodeHash",
-                            "Description" : "A sha256 hash of the code zip file",
-                            "Default" : ""
-                        }
-                    ]
-                }
-            ]
-        }
-    }
-]
+[@addComponent
+    type=LAMBDA_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "Container for a Function as a Service deployment"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "application"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=LAMBDA_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "DeploymentType",
+                "Type" : STRING_TYPE,
+                "Values" : ["EDGE", "REGIONAL"],
+                "Default" : "REGIONAL"
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=LAMBDA_FUNCTION_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A specific entry point for the lambda deployment"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "application"
+            }
+        ]
+    parent=LAMBDA_COMPONENT_TYPE
+    childAttribute="Functions"
+    linkAttributes="Function"
+/]
+
+[@addComponentResourceGroup
+    type=LAMBDA_FUNCTION_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : ["Fragment", "Container"],
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            },
+            {
+                "Names" : "Handler",
+                "Type" : STRING_TYPE,
+                "Mandatory" : true
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration
+            },
+            {
+                "Names" : "LogMetrics",
+                "Subobjects" : true,
+                "Children" : logMetricChildrenConfiguration
+            },
+            {
+                "Names" : "LogWatchers",
+                "Subobjects" : true,
+                "Children" : logWatcherChildrenConfiguration
+            },
+            {
+                "Names" : "Alerts",
+                "Subobjects" : true,
+                "Children" : alertChildrenConfiguration
+            },
+            {
+                "Names" : ["Memory", "MemorySize"],
+                "Type" : NUMBER_TYPE,
+                "Default" : 0
+            },
+            {
+                "Names" : "RunTime",
+                "Type" : STRING_TYPE,
+                "Values" : ["nodejs", "nodejs4.3", "nodejs6.10", "nodejs8.10", "java8", "python2.7", "python3.6", "dotnetcore1.0", "dotnetcore2.0", "dotnetcore2.1", "nodejs4.3-edge", "go1.x"],
+                "Mandatory" : true
+            },
+            {
+                "Names" : "Schedules",
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Expression",
+                        "Type" : STRING_TYPE,
+                        "Default" : "rate(6 minutes)"
+                    },
+                    {
+                        "Names" : "InputPath",
+                        "Type" : STRING_TYPE,
+                        "Default" : "/healthcheck"
+                    },
+                    {
+                        "Names" : "Input",
+                        "Type" : OBJECT_TYPE,
+                        "Default" : {}
+                    }
+                ]
+            },
+            {
+                "Names" : "Timeout",
+                "Type" : NUMBER_TYPE,
+                "Default" : 0
+            },
+            {
+                "Names" : "VPCAccess",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "UseSegmentKey",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Permissions",
+                "Children" : [
+                    {
+                        "Names" : "Decrypt",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "AsFile",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "AppData",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "AppPublic",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "PredefineLogGroup",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Environment",
+                "Children" : settingsChildConfiguration
+            },
+            {
+                "Names" : "FixedCodeVersion",
+                "Children" : [
+                    {
+                        "Names" : "CodeHash",
+                        "Description" : "A sha256 hash of the code zip file",
+                        "Default" : ""
+                    }
+                ]
+            }
+        ]
+/]

--- a/providers/shared/component/lb.ftl
+++ b/providers/shared/component/lb.ftl
@@ -1,224 +1,232 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        LB_COMPONENT_TYPE   : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "A load balancer for virtual network based components"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                },
-                {
-                    "Type" : "Note",
-                    "Value" : "Requires second deployment to complete configuration",
-                    "Severity" : "warning"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Logs",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "Engine",
-                    "Type" : STRING_TYPE,
-                    "Values" : ["application", "network", "classic"],
-                    "Default" : "application"
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration + [
-                        {
-                            "Names" : "Security",
-                            "Type" : STRING_TYPE,
-                            "Default" : "default"
-                        }
-                    ]
-                },
-                {
-                    "Names" : "IdleTimeout",
-                    "Type" : NUMBER_TYPE,
-                    "Default" : 60
-                }
-                {
-                    "Names" : "HealthCheckPort",
-                    "Type" : STRING_TYPE,
-                    "Default" : ""
-                },
-                {
-                    "Names" : "Alerts",
-                    "Subobjects" : true,
-                    "Children" : alertChildrenConfiguration
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                }
-            ],
-            "Components" : [
-                {
-                    "Type" : LB_PORT_COMPONENT_TYPE,
-                    "Component" : "PortMappings",
-                    "Link" : ["PortMapping","Port"]
-                }
-            ]
-        },
-        LB_PORT_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "A specifc listener based on the client side network port"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "IPAddressGroups",
-                    "Type" : ARRAY_OF_STRING_TYPE,
-                    "Default" : []
-                },
-                {
-                    "Names" : "Certificate",
-                    "Children" : certificateChildConfiguration
-                },
-                {
-                    "Names" : "HostFilter",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "Mapping",
-                    "Type" : STRING_TYPE
-                },
-                {
-                    "Names" : "Path",
-                    "Type" : STRING_TYPE,
-                    "Default" : "default"
-                },
-                {
-                    "Names" : "Priority",
-                    "Type" : NUMBER_TYPE,
-                    "Default" : 100
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "Authentication",
-                    "Children" : [
-                        {
-                            "Names" : "SessionCookieName",
-                            "Type" : STRING_TYPE,
-                            "Default" : "AWSELBAuthSessionCookie"
-                        },
-                        {
-                            "Names" : "SessionTimeout",
-                            "Type" : NUMBER_TYPE,
-                            "Default" : 604800
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Redirect",
-                    "Children" : [
-                        {
-                            "Names" : "Protocol",
-                            "Type" : STRING_TYPE,
-                            "Values" : ["HTTPS", "#\{protocol}" ],
-                            "Default" : "HTTPS"
-                        },
-                        {
-                            "Names" : "Port",
-                            "Type" : STRING_TYPE,
-                            "Default" : "443"
-                        },
-                        {
-                            "Names" : "Host",
-                            "Type" : STRING_TYPE,
-                            "Default" : "#\{host}"
-                        },
-                        {
-                            "Names" : "Path",
-                            "Type" : STRING_TYPE,
-                            "Default" : "/#\{path}"
-                        },
-                        {
-                            "Names" : "Query",
-                            "Type" : STRING_TYPE,
-                            "Default" : "#\{query}"
-                        },
-                        {
-                            "Names" : "Permanent",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Fixed",
-                    "Children" : [
-                        {
-                            "Names" : "Message",
-                            "Type" : STRING_TYPE,
-                            "Default" : "This application is currently unavailable. Please try again later."
-                        },
-                        {
-                            "Names" : "ContentType",
-                            "Type" : STRING_TYPE,
-                            "Default" : "text/plain"
-                        },
-                        {
-                            "Names" : "StatusCode",
-                            "Type" : STRING_TYPE,
-                            "Default" : "404"
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Forward",
-                    "Children" : [
-                        {
-                            "Names" : "TargetType",
-                            "Type" : STRING_TYPE,
-                            "Values" : ["instance", "ip"],
-                            "Default" : "instance"
-                        },
-                        {
-                            "Names" : "SlowStartTime",
-                            "Type" : NUMBER_TYPE,
-                            "Default" : -1
-                        },
-                        {
-                            "Names" : "StickinessTime",
-                            "Type" : NUMBER_TYPE,
-                            "Default" : -1
-                        },
-                        {
-                            "Names" : "DeregistrationTimeout",
-                            "Type" : NUMBER_TYPE,
-                            "Default" : 30
-                        }
-                    ]
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=LB_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A load balancer for virtual network based components"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            },
+            {
+                "Type" : "Note",
+                "Value" : "Requires second deployment to complete configuration",
+                "Severity" : "warning"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=LB_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Logs",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Engine",
+                "Type" : STRING_TYPE,
+                "Values" : ["application", "network", "classic"],
+                "Default" : "application"
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration + [
+                    {
+                        "Names" : "Security",
+                        "Type" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
+            },
+            {
+                "Names" : "IdleTimeout",
+                "Type" : NUMBER_TYPE,
+                "Default" : 60
+            }
+            {
+                "Names" : "HealthCheckPort",
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            },
+            {
+                "Names" : "Alerts",
+                "Subobjects" : true,
+                "Children" : alertChildrenConfiguration
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=LB_PORT_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A specifc listener based on the client side network port"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+    parent=LB_COMPONENT_TYPE
+    childAttribute="PortMappings"
+    linkAttributes=["PortMapping","Port"]
+/]
+
+[@addComponentResourceGroup
+    type=LB_PORT_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "IPAddressGroups",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            },
+            {
+                "Names" : "Certificate",
+                "Children" : certificateChildConfiguration
+            },
+            {
+                "Names" : "HostFilter",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Mapping",
+                "Type" : STRING_TYPE
+            },
+            {
+                "Names" : "Path",
+                "Type" : STRING_TYPE,
+                "Default" : "default"
+            },
+            {
+                "Names" : "Priority",
+                "Type" : NUMBER_TYPE,
+                "Default" : 100
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Authentication",
+                "Children" : [
+                    {
+                        "Names" : "SessionCookieName",
+                        "Type" : STRING_TYPE,
+                        "Default" : "AWSELBAuthSessionCookie"
+                    },
+                    {
+                        "Names" : "SessionTimeout",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : 604800
+                    }
+                ]
+            },
+            {
+                "Names" : "Redirect",
+                "Children" : [
+                    {
+                        "Names" : "Protocol",
+                        "Type" : STRING_TYPE,
+                        "Values" : ["HTTPS", "#\{protocol}" ],
+                        "Default" : "HTTPS"
+                    },
+                    {
+                        "Names" : "Port",
+                        "Type" : STRING_TYPE,
+                        "Default" : "443"
+                    },
+                    {
+                        "Names" : "Host",
+                        "Type" : STRING_TYPE,
+                        "Default" : "#\{host}"
+                    },
+                    {
+                        "Names" : "Path",
+                        "Type" : STRING_TYPE,
+                        "Default" : "/#\{path}"
+                    },
+                    {
+                        "Names" : "Query",
+                        "Type" : STRING_TYPE,
+                        "Default" : "#\{query}"
+                    },
+                    {
+                        "Names" : "Permanent",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "Fixed",
+                "Children" : [
+                    {
+                        "Names" : "Message",
+                        "Type" : STRING_TYPE,
+                        "Default" : "This application is currently unavailable. Please try again later."
+                    },
+                    {
+                        "Names" : "ContentType",
+                        "Type" : STRING_TYPE,
+                        "Default" : "text/plain"
+                    },
+                    {
+                        "Names" : "StatusCode",
+                        "Type" : STRING_TYPE,
+                        "Default" : "404"
+                    }
+                ]
+            },
+            {
+                "Names" : "Forward",
+                "Children" : [
+                    {
+                        "Names" : "TargetType",
+                        "Type" : STRING_TYPE,
+                        "Values" : ["instance", "ip"],
+                        "Default" : "instance"
+                    },
+                    {
+                        "Names" : "SlowStartTime",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : -1
+                    },
+                    {
+                        "Names" : "StickinessTime",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : -1
+                    },
+                    {
+                        "Names" : "DeregistrationTimeout",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : 30
+                    }
+                ]
+            }
+        ]
+/]

--- a/providers/shared/component/mobileapp.ftl
+++ b/providers/shared/component/mobileapp.ftl
@@ -1,45 +1,49 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        MOBILEAPP_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "mobile apps with over the air update hosting"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "application"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Engine",
-                    "Type" : STRING_TYPE,
-                    "Default" : "expo",
-                    "Values" : ["expo"]
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "BuildFormats",
-                    "Type" : ARRAY_OF_STRING_TYPE,
-                    "Default" : [ "ios", "android" ],
-                    "Values" : [ "ios", "android" ]
-                },
-                {
-                    "Names" : ["Fragment", "Container"],
-                    "Type" : STRING_TYPE,
-                    "Default" : ""
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=MOBILEAPP_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "mobile apps with over the air update hosting"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "application"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=MOBILEAPP_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Engine",
+                "Type" : STRING_TYPE,
+                "Default" : "expo",
+                "Values" : ["expo"]
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "BuildFormats",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : [ "ios", "android" ],
+                "Values" : [ "ios", "android" ]
+            },
+            {
+                "Names" : ["Fragment", "Container"],
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            }
+        ]
+/]

--- a/providers/shared/component/mobilenotifier.ftl
+++ b/providers/shared/component/mobilenotifier.ftl
@@ -3,117 +3,125 @@
 [#-- Engines --]
 [#assign MOBILENOTIFIER_SMS_ENGINE = "SMS" ]
 
-[#assign componentConfiguration +=
-    {
-        MOBILENOTIFIER_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "A managed mobile notification proxy"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "SuccessSampleRate",
-                    "Type" : STRING_TYPE,
-                    "Default" : "100"
-                },
-                {
-                    "Names" : "Credentials",
-                    "Children" : [
-                        {
-                            "Names" : "EncryptionScheme",
-                            "Type" : STRING_TYPE,
-                            "Values" : ["base64"],
-                            "Default" : "base64"
-                        }
-                    ]
-                }
-            ],
-            "Components" : [
-                {
-                    "Type" : MOBILENOTIFIER_PLATFORM_COMPONENT_TYPE,
-                    "Component" : "Platforms",
-                    "Link" : [ "Platform" ]
-                }
-            ]
-        },
-        MOBILENOTIFIER_PLATFORM_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "A specific mobile platform notification proxy"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                },
-                {
-                    "Type" : "Note",
-                    "Value" : "SMS Engine requires account level configuration for AWS provider",
-                    "Severity" : "warning"
-                },
-                {
-                    "Type" : "Note",
-                    "Value" : "Platform specific credentials are required and must be provided as credentials",
-                    "Severity" : "info"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Engine",
-                    "Type" : STRING_TYPE
-                },
-                {
-                    "Names" : "SuccessSampleRate",
-                    "Type" : STRING_TYPE
-                },
-                {
-                    "Names" : "Credentials",
-                    "Children" : [
-                        {
-                            "Names" : "EncryptionScheme",
-                            "Type" : STRING_TYPE,
-                            "Values" : ["base64"]
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
-                },
-                {
-                    "Names" : "LogMetrics",
-                    "Subobjects" : true,
-                    "Children" : logMetricChildrenConfiguration
-                },
-                {
-                    "Names" : "Alerts",
-                    "Subobjects" : true,
-                    "Children" : alertChildrenConfiguration
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=MOBILENOTIFIER_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A managed mobile notification proxy"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=MOBILENOTIFIER_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "SuccessSampleRate",
+                "Type" : STRING_TYPE,
+                "Default" : "100"
+            },
+            {
+                "Names" : "Credentials",
+                "Children" : [
+                    {
+                        "Names" : "EncryptionScheme",
+                        "Type" : STRING_TYPE,
+                        "Values" : ["base64"],
+                        "Default" : "base64"
+                    }
+                ]
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=MOBILENOTIFIER_PLATFORM_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A specific mobile platform notification proxy"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            },
+            {
+                "Type" : "Note",
+                "Value" : "SMS Engine requires account level configuration for AWS provider",
+                "Severity" : "warning"
+            },
+            {
+                "Type" : "Note",
+                "Value" : "Platform specific credentials are required and must be provided as credentials",
+                "Severity" : "info"
+            }
+        ]
+    parent=MOBILENOTIFIER_COMPONENT_TYPE
+    childAttribute="Platforms"
+    linkAttributes="Platform"
+/]
+
+[@addComponentResourceGroup
+    type=MOBILENOTIFIER_PLATFORM_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Engine",
+                "Type" : STRING_TYPE
+            },
+            {
+                "Names" : "SuccessSampleRate",
+                "Type" : STRING_TYPE
+            },
+            {
+                "Names" : "Credentials",
+                "Children" : [
+                    {
+                        "Names" : "EncryptionScheme",
+                        "Type" : STRING_TYPE,
+                        "Values" : ["base64"]
+                    }
+                ]
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration
+            },
+            {
+                "Names" : "LogMetrics",
+                "Subobjects" : true,
+                "Children" : logMetricChildrenConfiguration
+            },
+            {
+                "Names" : "Alerts",
+                "Subobjects" : true,
+                "Children" : alertChildrenConfiguration
+            }
+        ]
+/]

--- a/providers/shared/component/network.ftl
+++ b/providers/shared/component/network.ftl
@@ -1,188 +1,202 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        NETWORK_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "A virtual network segment used by private resources"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "segment"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Active",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "Logging",
-                    "Children" : [
-                        {
-                            "Names" : "EnableFlowLogs",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        }
-                    ]
-                },
-                {
-                    "Names" : "DNS",
-                    "Children" : [
-                        {
-                            "Names" : "UseProvider",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "GenerateHostNames",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Address",
-                    "Children" : [
-                        {
-                            "Names" : "CIDR",
-                            "Type" : STRING_TYPE,
-                            "Default" : "10.0.0.0/16"
-                        }
-                    ]
-                }
-            ],
-            "Components" : [
-                {
-                    "Type" : NETWORK_ROUTE_TABLE_COMPONENT_TYPE,
-                    "Component" : "RouteTables",
-                    "Link" : "RouteTable"
-                },
-                {
-                    "Type" : NETWORK_ACL_COMPONENT_TYPE,
-                    "Component" : "NetworkACLs",
-                    "Link" : "NetworkACL"
-                }
-            ]
-        },
-        NETWORK_ROUTE_TABLE_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "A network routing table providing acess to resources outside of the network"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "segment"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Active",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "Public",
-                    "Description" : "Does the route table require Public IP internet access",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
-                }
-            ]
-        },
-        NETWORK_ACL_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "A tier/subnet level network access control policy"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "segment"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Active",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "Rules",
-                    "Subobjects" : true,
-                    "Children" : [
-                        {
-                            "Names" : "Priority",
-                            "Type" : NUMBER_TYPE,
-                            "Required" : true
-                        }
-                        {
-                            "Names" : "Action",
-                            "Type" : STRING_TYPE,
-                            "Default" : "deny",
-                            "Values" : [ "allow", "deny" ]
-                        },
-                        {
-                            "Names" : "Source",
-                            "Description" : "Source of the network traffic",
-                            "Children" : [
-                                {
-                                    "Names" : "IPAddressGroups",
-                                    "Type" : ARRAY_OF_STRING_TYPE,
-                                    "Required" : true
-                                },
-                                {
-                                    "Names" : "Port",
-                                    "Description" : "Port or port range the source is coming from",
-                                    "Type" : STRING_TYPE,
-                                    "Default" : "ephemeraltcp"
-                                }
-                            ]
-                        },
-                        {
-                            "Names" : "Destination",
-                            "Description" : "Destination of the network traffic",
-                            "Children" : [
-                                {
-                                    "Names" : "IPAddressGroups",
-                                    "Type" : ARRAY_OF_STRING_TYPE,
-                                    "Required" : true
-                                },
-                                {
-                                    "Names" : "Port",
-                                    "Description" : "Port or port range the source is trying to access",
-                                    "Type" : STRING_TYPE,
-                                    "Required" : true
-                                }
-                            ]
-                        },
-                        {
-                            "Names" : "ReturnTraffic",
-                            "Description" : "If ACL is stateless add a return rule",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        }
-                    ]
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=NETWORK_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A virtual network segment used by private resources"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "segment"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=NETWORK_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Active",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Logging",
+                "Children" : [
+                    {
+                        "Names" : "EnableFlowLogs",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "DNS",
+                "Children" : [
+                    {
+                        "Names" : "UseProvider",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "GenerateHostNames",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "Address",
+                "Children" : [
+                    {
+                        "Names" : "CIDR",
+                        "Type" : STRING_TYPE,
+                        "Default" : "10.0.0.0/16"
+                    }
+                ]
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=NETWORK_ROUTE_TABLE_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A network routing table providing acess to resources outside of the network"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "segment"
+            }
+        ]
+    parent=NETWORK_COMPONENT_TYPE
+    childAttribute="RouteTables"
+    linkAttributes="RouteTable"
+/]
+
+[@addComponentResourceGroup
+    type=NETWORK_ROUTE_TABLE_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Active",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Public",
+                "Description" : "Does the route table require Public IP internet access",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=NETWORK_ACL_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A tier/subnet level network access control policy"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "segment"
+            }
+        ]
+    parent=NETWORK_COMPONENT_TYPE
+    childAttribute="NetworkACLs"
+    linkAttributes="NetworkACL"
+/]
+
+[@addComponentResourceGroup
+    type=NETWORK_ACL_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Active",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Rules",
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Priority",
+                        "Type" : NUMBER_TYPE,
+                        "Required" : true
+                    }
+                    {
+                        "Names" : "Action",
+                        "Type" : STRING_TYPE,
+                        "Default" : "deny",
+                        "Values" : [ "allow", "deny" ]
+                    },
+                    {
+                        "Names" : "Source",
+                        "Description" : "Source of the network traffic",
+                        "Children" : [
+                            {
+                                "Names" : "IPAddressGroups",
+                                "Type" : ARRAY_OF_STRING_TYPE,
+                                "Required" : true
+                            },
+                            {
+                                "Names" : "Port",
+                                "Description" : "Port or port range the source is coming from",
+                                "Type" : STRING_TYPE,
+                                "Default" : "ephemeraltcp"
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "Destination",
+                        "Description" : "Destination of the network traffic",
+                        "Children" : [
+                            {
+                                "Names" : "IPAddressGroups",
+                                "Type" : ARRAY_OF_STRING_TYPE,
+                                "Required" : true
+                            },
+                            {
+                                "Names" : "Port",
+                                "Description" : "Port or port range the source is trying to access",
+                                "Type" : STRING_TYPE,
+                                "Required" : true
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "ReturnTraffic",
+                        "Description" : "If ACL is stateless add a return rule",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                ]
+            }
+        ]
+/]

--- a/providers/shared/component/rds.ftl
+++ b/providers/shared/component/rds.ftl
@@ -1,160 +1,164 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        RDS_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "A managed SQL database instance"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Engine",
-                    "Mandatory" : true
-                },
-                {
-                    "Names" : "EngineVersion",
-                    "Type" : STRING_TYPE
-                },
-                {
-                    "Names" : "Port",
-                    "Type" : STRING_TYPE
-                },
-                {
-                    "Names" : "Encrypted",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "GenerateCredentials",
-                    "Children" : [
-                        {
-                            "Names" : "Enabled",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : false
-                        },
-                        {
-                            "Names" : "MasterUserName",
-                            "Type" : STRING_TYPE,
-                            "Default" : "root"
-                        },
-                        {
-                            "Names" : "CharacterLength",
-                            "Type" : NUMBER_TYPE,
-                            "Default" : 20
-                        },
-                        {
-                            "Names" : "EncryptionScheme",
-                            "Type" : STRING_TYPE,
-                            "Values" : ["base64"],
-                            "Default" : ""
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Size",
-                    "Type" : NUMBER_TYPE,
-                    "Default" : 20
-                },
-                {
-                    "Names" : "Backup",
-                    "Children" : [
-                        {
-                            "Names" : "RetentionPeriod",
-                            "Type" : NUMBER_TYPE,
-                            "Default" : 35
-                        },
-                        {
-                            "Names" : "SnapshotOnDeploy",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "DeleteAutoBackups",
-                            "Type" : BOOLEAN_TYPE,
-                            "Description" : "Delete automated snapshots when the instance is deleted",
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "DeletionPolicy",
-                            "Type" : STRING_TYPE,
-                            "Values" : [ "Snapshot", "Delete", "Retain" ],
-                            "Default" : "Snapshot"
-                        },
-                        {
-                            "Names" : "UpdateReplacePolicy",
-                            "Type" : STRING_TYPE,
-                            "Values" : [ "Snapshot", "Delete", "Retain" ],
-                            "Default" : "Snapshot"
-                        }
-                    ]
-                },
-                {
-                    "Names" : "AutoMinorVersionUpgrade",
-                    "Type" : BOOLEAN_TYPE
-                },
-                {
-                    "Names" : "DatabaseName",
-                    "Type" : STRING_TYPE
-                },
-                {
-                    "Names" : "DBParameters",
-                    "Type" : OBJECT_TYPE,
-                    "Default" : {}
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration +
-                                    [
-                                        {
-                                            "Names" : "Processor",
-                                            "Type" : STRING_TYPE,
-                                            "Default" : "default"
-                                        }
-                                    ]
-                },
-                {
-                    "Names" : "Hibernate",
-                    "Children" : [
-                        {
-                            "Names" : "Enabled",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : false
-                        },
-                        {
-                            "Names" : "StartUpMode",
-                            "Type" : STRING_TYPE,
-                            "Values" : ["restore", "replace"],
-                            "Default" : "restore"
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Alerts",
-                    "Subobjects" : true,
-                    "Children" : alertChildrenConfiguration
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "AlwaysCreateFromSnapshot",
-                    "Description" : "Always create the database from a snapshot",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                }
-            ]
-    }
-}]
+[@addComponent
+    type=RDS_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A managed SQL database instance"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=RDS_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Engine",
+                "Mandatory" : true
+            },
+            {
+                "Names" : "EngineVersion",
+                "Type" : STRING_TYPE
+            },
+            {
+                "Names" : "Port",
+                "Type" : STRING_TYPE
+            },
+            {
+                "Names" : "Encrypted",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "GenerateCredentials",
+                "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "MasterUserName",
+                        "Type" : STRING_TYPE,
+                        "Default" : "root"
+                    },
+                    {
+                        "Names" : "CharacterLength",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : 20
+                    },
+                    {
+                        "Names" : "EncryptionScheme",
+                        "Type" : STRING_TYPE,
+                        "Values" : ["base64"],
+                        "Default" : ""
+                    }
+                ]
+            },
+            {
+                "Names" : "Size",
+                "Type" : NUMBER_TYPE,
+                "Default" : 20
+            },
+            {
+                "Names" : "Backup",
+                "Children" : [
+                    {
+                        "Names" : "RetentionPeriod",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : 35
+                    },
+                    {
+                        "Names" : "SnapshotOnDeploy",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "DeleteAutoBackups",
+                        "Type" : BOOLEAN_TYPE,
+                        "Description" : "Delete automated snapshots when the instance is deleted",
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "DeletionPolicy",
+                        "Type" : STRING_TYPE,
+                        "Values" : [ "Snapshot", "Delete", "Retain" ],
+                        "Default" : "Snapshot"
+                    },
+                    {
+                        "Names" : "UpdateReplacePolicy",
+                        "Type" : STRING_TYPE,
+                        "Values" : [ "Snapshot", "Delete", "Retain" ],
+                        "Default" : "Snapshot"
+                    }
+                ]
+            },
+            {
+                "Names" : "AutoMinorVersionUpgrade",
+                "Type" : BOOLEAN_TYPE
+            },
+            {
+                "Names" : "DatabaseName",
+                "Type" : STRING_TYPE
+            },
+            {
+                "Names" : "DBParameters",
+                "Type" : OBJECT_TYPE,
+                "Default" : {}
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration +
+                                [
+                                    {
+                                        "Names" : "Processor",
+                                        "Type" : STRING_TYPE,
+                                        "Default" : "default"
+                                    }
+                                ]
+            },
+            {
+                "Names" : "Hibernate",
+                "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "StartUpMode",
+                        "Type" : STRING_TYPE,
+                        "Values" : ["restore", "replace"],
+                        "Default" : "restore"
+                    }
+                ]
+            },
+            {
+                "Names" : "Alerts",
+                "Subobjects" : true,
+                "Children" : alertChildrenConfiguration
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "AlwaysCreateFromSnapshot",
+                "Description" : "Always create the database from a snapshot",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            }
+        ]
+/]

--- a/providers/shared/component/s3.ftl
+++ b/providers/shared/component/s3.ftl
@@ -1,124 +1,128 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        S3_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "HTTP based object storage service"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Lifecycle",
-                    "Children" : [
-                        {
-                            "Names" : "Expiration",
-                            "Types" : [STRING_TYPE, NUMBER_TYPE],
-                            "Description" : "Provide either a date or a number of days"
-                        },
-                        {
-                            "Names" : "Offline",
-                            "Types" : [STRING_TYPE, NUMBER_TYPE],
-                            "Description" : "Provide either a date or a number of days"
-                        },
-                        {
-                            "Names" : "Versioning",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : false
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Website",
-                    "Children" : [
-                        {
-                            "Names": "Index",
-                            "Type" : STRING_TYPE,
-                            "Default": "index.html"
-                        },
-                        {
-                            "Names": "Error",
-                            "Type" : STRING_TYPE,
-                            "Default": ""
-                        }
-                    ]
-                },
-                {
-                    "Names" : "PublicAccess",
-                    "Subobjects" : true,
-                    "Children" : [
-                        {
-                            "Names" : "Enabled",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : false
-                        },
-                        {
-                            "Names" : "Permissions",
-                            "Type" : STRING_TYPE,
-                            "Values" : ["ro", "wo", "rw"],
-                            "Default" : "ro"
-                        },
-                        {
-                            "Names" : "IPAddressGroups",
-                            "Type" : ARRAY_OF_STRING_TYPE,
-                            "Default" : [ "_localnet" ]
-                        },
-                        {
-                            "Names" : "Paths",
-                            "Type" : ARRAY_OF_STRING_TYPE,
-                            "Default" : [ ]
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Style",
-                    "Type" : STRING_TYPE,
-                    "Description" : "TODO(mfl): Think this can be removed"
-                },
-                {
-                    "Names" : "Notifications",
-                    "Subobjects" : true,
-                    "Children" : s3NotificationChildConfiguration
-                },
-                {
-                    "Names" : "CORSBehaviours",
-                    "Type" : ARRAY_OF_STRING_TYPE,
-                    "Default" : []
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
-                },
-                {
-                    "Names" : "Replication",
-                    "Children" : [
-                        {
-                            "Names" : "Prefixes",
-                            "Type" : ARRAY_OF_STRING_TYPE,
-                            "Default" : [ "" ]
-                        },
-                        {
-                            "Names" : "Enabled",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=S3_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "HTTP based object storage service"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=S3_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Lifecycle",
+                "Children" : [
+                    {
+                        "Names" : "Expiration",
+                        "Types" : [STRING_TYPE, NUMBER_TYPE],
+                        "Description" : "Provide either a date or a number of days"
+                    },
+                    {
+                        "Names" : "Offline",
+                        "Types" : [STRING_TYPE, NUMBER_TYPE],
+                        "Description" : "Provide either a date or a number of days"
+                    },
+                    {
+                        "Names" : "Versioning",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    }
+                ]
+            },
+            {
+                "Names" : "Website",
+                "Children" : [
+                    {
+                        "Names": "Index",
+                        "Type" : STRING_TYPE,
+                        "Default": "index.html"
+                    },
+                    {
+                        "Names": "Error",
+                        "Type" : STRING_TYPE,
+                        "Default": ""
+                    }
+                ]
+            },
+            {
+                "Names" : "PublicAccess",
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "Permissions",
+                        "Type" : STRING_TYPE,
+                        "Values" : ["ro", "wo", "rw"],
+                        "Default" : "ro"
+                    },
+                    {
+                        "Names" : "IPAddressGroups",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Default" : [ "_localnet" ]
+                    },
+                    {
+                        "Names" : "Paths",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Default" : [ ]
+                    }
+                ]
+            },
+            {
+                "Names" : "Style",
+                "Type" : STRING_TYPE,
+                "Description" : "TODO(mfl): Think this can be removed"
+            },
+            {
+                "Names" : "Notifications",
+                "Subobjects" : true,
+                "Children" : s3NotificationChildConfiguration
+            },
+            {
+                "Names" : "CORSBehaviours",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration
+            },
+            {
+                "Names" : "Replication",
+                "Children" : [
+                    {
+                        "Names" : "Prefixes",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Default" : [ "" ]
+                    },
+                    {
+                        "Names" : "Enabled",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            }
+        ]
+/]

--- a/providers/shared/component/serviceregistry.ftl
+++ b/providers/shared/component/serviceregistry.ftl
@@ -1,127 +1,103 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        SERVICE_REGISTRY_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "DNS based service registry"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "Namespace",
-                    "Children" : domainNameChildConfiguration
-                }
-            ],
-            "Components" : [
-                {
-                    "Type" : SERVICE_REGISTRY_SERVICE_COMPONENT_TYPE,
-                    "Component" : "RegistryServices",
-                    "Link" : ["RegistryService" ]
-                }
-            ]
-        },
-        SERVICE_REGISTRY_SERVICE_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "An individual service in the registry"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "ServiceName",
-                    "Description" : "The hostname portion of the DNS record which will identify this service",
-                    "Children" : hostNameChildConfiguration
-                },
-                {
-                    "Names" : "RecordTypes",
-                    "Description" : "The types of DNS records that an instance can register with the service",
-                    "Type" : ARRAY_OF_STRING_TYPE,
-                    "Values" : [ "A", "AAAA", "CNAME", "SRV" ],
-                    "Default" : [ "A" ]
-                },
-                {
-                    "Names" : "RecordTTL",
-                    "Description" : "DNS record TTL ( in seconds)",
-                    "Type" : NUMBER_TYPE,
-                    "Default" : 300
-                },
-                {
-                    "Names" : "RoutingPolicy",
-                    "Description" : "How the service returns records to the client",
-                    "Values" : [ "AllAtOnce", "OnlyOne" ],
-                    "Type" : STRING_TYPE,
-                    "Default" : "OnlyOne"
-                }
-            ]
-        }
-    }]
-
-[#macro aws_serviceregistry_cf_state occurrence parent={} baseState={}  ]
-    [#assign componentState = getServiceRegistryState(occurrence)]
-[/#macro]
-
-[#function getServiceRegistryState occurrence ]
-    [#local core = occurrence.Core]
-    [#local solution = occurrence.Configuration.Solution]
-
-    [#local domainObject = getCertificateObject(solution.Namespace, segmentQualifiers)]
-    [#local domainName = getCertificatePrimaryDomain(domainObject).Name ]
-
-    [#return
-        {
-            "Resources" : {
-                "namespace" : {
-                    "Id" : formatResourceId(AWS_CLOUDMAP_DNS_NAMESPACE_RESOURCE_TYPE, core.Id),
-                    "Name" : core.FullName,
-                    "DomainName" : domainName,
-                    "Type" : AWS_CLOUDMAP_DNS_NAMESPACE_RESOURCE_TYPE
-                }
+[@addComponent
+    type=SERVICE_REGISTRY_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "DNS based service registry"
             },
-            "Attributes" : {
-                "DOMAIN_NAME" : domainName
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
             },
-            "Roles" : {
-                "Inbound" : {},
-                "Outbound" : {}
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
             }
-        }
-    ]
-[/#function]
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=SERVICE_REGISTRY_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Namespace",
+                "Children" : domainNameChildConfiguration
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=SERVICE_REGISTRY_SERVICE_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "An individual service in the registry"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+    parent=SERVICE_REGISTRY_COMPONENT_TYPE
+    childAttribute="RegistryServices"
+    linkAttributes="RegistryService"
+/]
+
+[@addComponentResourceGroup
+    type=SERVICE_REGISTRY_SERVICE_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "ServiceName",
+                "Description" : "The hostname portion of the DNS record which will identify this service",
+                "Children" : hostNameChildConfiguration
+            },
+            {
+                "Names" : "RecordTypes",
+                "Description" : "The types of DNS records that an instance can register with the service",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Values" : [ "A", "AAAA", "CNAME", "SRV" ],
+                "Default" : [ "A" ]
+            },
+            {
+                "Names" : "RecordTTL",
+                "Description" : "DNS record TTL ( in seconds)",
+                "Type" : NUMBER_TYPE,
+                "Default" : 300
+            },
+            {
+                "Names" : "RoutingPolicy",
+                "Description" : "How the service returns records to the client",
+                "Values" : [ "AllAtOnce", "OnlyOne" ],
+                "Type" : STRING_TYPE,
+                "Default" : "OnlyOne"
+            }
+        ]
+/]

--- a/providers/shared/component/spa.ftl
+++ b/providers/shared/component/spa.ftl
@@ -1,200 +1,204 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        SPA_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "Object stored hosted web application with content distribution management"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "application"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : ["Fragment", "Container"],
-                    "Type" : STRING_TYPE,
-                    "Default" : ""
-                },
-                {
-                    "Names" : "Links",
-                    "Type" : OBJECT_TYPE,
-                    "Default" : {}
-                },
-                {
-                    "Names" : "WAF",
-                    "Children" : wafChildConfiguration
-                },
-                {
-                    "Names" : "CloudFront",
-                    "Children" : [
-                        {
-                            "Names" : "AssumeSNI",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "EnableLogging",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "CountryGroups",
-                            "Type" : ARRAY_OF_STRING_TYPE,
-                            "Default" : []
-                        },
-                        {
-                            "Names" : "ErrorPage",
-                            "Type" : STRING_TYPE,
-                            "Default" : "/index.html"
-                        },
-                        {
-                            "Names" : "DeniedPage",
-                            "Type" : STRING_TYPE,
-                            "Default" : ""
-                        },
-                        {
-                            "Names" : "NotFoundPage",
-                            "Type" : STRING_TYPE,
-                            "Default" : ""
-                        },
-                        {
-                            "Names" : "CachingTTL",
-                            "Children" : [
-                                {
-                                    "Names" : "Default",
-                                    "Type" : NUMBER_TYPE,
-                                    "Default" : 600
-                                },
-                                {
-                                    "Names" : "Maximum",
-                                    "Type" : NUMBER_TYPE,
-                                    "Default" : 31536000
-                                },
-                                {
-                                    "Names" : "Minimum",
-                                    "Type" : NUMBER_TYPE,
-                                    "Default" : 0
-                                }
-                            ]
-                        },
-                        {
-                            "Names" : "Compress",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "RedirectAliases",
-                            "Description" : "Redirect secondary domains to the primary domain name",
-                            "Children" : [
-                                {
-                                    "Names" : "RedirectVersion",
-                                    "Type" : STRING_TYPE,
-                                    "Default" : "v1"
-                                }
-                            ]
-                        },
-                        {
-                            "Names" : "EventHandlers",
-                            "Description" : "Attach a function to a stage in the Cloudfront Processing",
-                            "Subobjects" : true,
-                            "Children" : [
-                                {
-                                    "Names" : "Tier",
-                                    "Type" : STRING_TYPE,
-                                    "Mandatory" : true
-                                },
-                                {
-                                    "Names" : "Component",
-                                    "Type" : STRING_TYPE,
-                                    "Mandatory" : true
-                                },
-                                {
-                                    "Names" : "Function",
-                                    "Type" : STRING_TYPE,
-                                    "Mandatory" : true
-                                },
-                                {
-                                    "Names" : "Instance",
-                                    "Type" : STRING_TYPE
-                                },
-                                {
-                                    "Names" : "Version",
-                                    "Type" : STRING_TYPE
-                                },
-                                {
-                                    "Names" : "Action",
-                                    "Type" : STRING_TYPE,
-                                    "Values" : [ "viewer-request", "viewer-response", "origin-request", "origin-response" ],
-                                    "Mandatory" : true
-                                }
-                            ]
-                        },
-                        {
-                            "Names" : "Paths",
-                            "Subobjects" : true,
-                            "Description" : "Additional path based routes to other components",
-                            "Children" : [
-                                {
-                                    "Names" : "PathPattern",
-                                    "Type" : STRING_TYPE,
-                                    "Mandatory" : true
-                                },
-                                {
-                                    "Names" : "Link",
-                                    "Children" : linkChildrenConfiguration,
-                                    "Mandatory" : true
-                                },
-                                {
-                                    "Names" : "CachingTTL",
-                                    "Children" : [
-                                        {
-                                            "Names" : "Default",
-                                            "Type" : NUMBER_TYPE,
-                                            "Default" : 600
-                                        },
-                                        {
-                                            "Names" : "Maximum",
-                                            "Type" : NUMBER_TYPE,
-                                            "Default" : 31536000
-                                        },
-                                        {
-                                            "Names" : "Minimum",
-                                            "Type" : NUMBER_TYPE,
-                                            "Default" : 0
-                                        }
-                                    ]
-                                },
-                                {
-                                    "Names" : "Compress",
-                                    "Type" : BOOLEAN_TYPE,
-                                    "Default" : false
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Certificate",
-                    "Children" : certificateChildConfiguration
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration + [
-                        {
-                            "Names" : "Security",
-                            "Type" : STRING_TYPE,
-                            "Default" : "default"
-                        }
-                    ]
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=SPA_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "Object stored hosted web application with content distribution management"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "application"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=SPA_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : ["Fragment", "Container"],
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            },
+            {
+                "Names" : "Links",
+                "Type" : OBJECT_TYPE,
+                "Default" : {}
+            },
+            {
+                "Names" : "WAF",
+                "Children" : wafChildConfiguration
+            },
+            {
+                "Names" : "CloudFront",
+                "Children" : [
+                    {
+                        "Names" : "AssumeSNI",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "EnableLogging",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "CountryGroups",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Default" : []
+                    },
+                    {
+                        "Names" : "ErrorPage",
+                        "Type" : STRING_TYPE,
+                        "Default" : "/index.html"
+                    },
+                    {
+                        "Names" : "DeniedPage",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "NotFoundPage",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "CachingTTL",
+                        "Children" : [
+                            {
+                                "Names" : "Default",
+                                "Type" : NUMBER_TYPE,
+                                "Default" : 600
+                            },
+                            {
+                                "Names" : "Maximum",
+                                "Type" : NUMBER_TYPE,
+                                "Default" : 31536000
+                            },
+                            {
+                                "Names" : "Minimum",
+                                "Type" : NUMBER_TYPE,
+                                "Default" : 0
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "Compress",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "RedirectAliases",
+                        "Description" : "Redirect secondary domains to the primary domain name",
+                        "Children" : [
+                            {
+                                "Names" : "RedirectVersion",
+                                "Type" : STRING_TYPE,
+                                "Default" : "v1"
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "EventHandlers",
+                        "Description" : "Attach a function to a stage in the Cloudfront Processing",
+                        "Subobjects" : true,
+                        "Children" : [
+                            {
+                                "Names" : "Tier",
+                                "Type" : STRING_TYPE,
+                                "Mandatory" : true
+                            },
+                            {
+                                "Names" : "Component",
+                                "Type" : STRING_TYPE,
+                                "Mandatory" : true
+                            },
+                            {
+                                "Names" : "Function",
+                                "Type" : STRING_TYPE,
+                                "Mandatory" : true
+                            },
+                            {
+                                "Names" : "Instance",
+                                "Type" : STRING_TYPE
+                            },
+                            {
+                                "Names" : "Version",
+                                "Type" : STRING_TYPE
+                            },
+                            {
+                                "Names" : "Action",
+                                "Type" : STRING_TYPE,
+                                "Values" : [ "viewer-request", "viewer-response", "origin-request", "origin-response" ],
+                                "Mandatory" : true
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "Paths",
+                        "Subobjects" : true,
+                        "Description" : "Additional path based routes to other components",
+                        "Children" : [
+                            {
+                                "Names" : "PathPattern",
+                                "Type" : STRING_TYPE,
+                                "Mandatory" : true
+                            },
+                            {
+                                "Names" : "Link",
+                                "Children" : linkChildrenConfiguration,
+                                "Mandatory" : true
+                            },
+                            {
+                                "Names" : "CachingTTL",
+                                "Children" : [
+                                    {
+                                        "Names" : "Default",
+                                        "Type" : NUMBER_TYPE,
+                                        "Default" : 600
+                                    },
+                                    {
+                                        "Names" : "Maximum",
+                                        "Type" : NUMBER_TYPE,
+                                        "Default" : 31536000
+                                    },
+                                    {
+                                        "Names" : "Minimum",
+                                        "Type" : NUMBER_TYPE,
+                                        "Default" : 0
+                                    }
+                                ]
+                            },
+                            {
+                                "Names" : "Compress",
+                                "Type" : BOOLEAN_TYPE,
+                                "Default" : false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "Names" : "Certificate",
+                "Children" : certificateChildConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration + [
+                    {
+                        "Names" : "Security",
+                        "Type" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
+            }
+        ]
+/]

--- a/providers/shared/component/sqs.ftl
+++ b/providers/shared/component/sqs.ftl
@@ -1,62 +1,66 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        SQS_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "Managed worker queue engine"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "DelaySeconds",
-                    "Type" : NUMBER_TYPE
-                },
-                {
-                    "Names" : "MaximumMessageSize",
-                    "Type" : NUMBER_TYPE
-                },
-                {
-                    "Names" : "MessageRetentionPeriod",
-                    "Type" : NUMBER_TYPE
-                },
-                {
-                    "Names" : "ReceiveMessageWaitTimeSeconds",
-                    "Type" : NUMBER_TYPE
-                },
-                {
-                    "Names" : "DeadLetterQueue",
-                    "Children" : [
-                        {
-                            "Names" : "MaxReceives",
-                            "Type" : NUMBER_TYPE,
-                            "Default" : 0
-                        }
-                    ]
-                },
-                {
-                    "Names" : "VisibilityTimeout",
-                    "Type" : NUMBER_TYPE
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
-                },
-                {
-                    "Names" : "Alerts",
-                    "Subobjects" : true,
-                    "Children" : alertChildrenConfiguration
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=SQS_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "Managed worker queue engine"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=SQS_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "DelaySeconds",
+                "Type" : NUMBER_TYPE
+            },
+            {
+                "Names" : "MaximumMessageSize",
+                "Type" : NUMBER_TYPE
+            },
+            {
+                "Names" : "MessageRetentionPeriod",
+                "Type" : NUMBER_TYPE
+            },
+            {
+                "Names" : "ReceiveMessageWaitTimeSeconds",
+                "Type" : NUMBER_TYPE
+            },
+            {
+                "Names" : "DeadLetterQueue",
+                "Children" : [
+                    {
+                        "Names" : "MaxReceives",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : 0
+                    }
+                ]
+            },
+            {
+                "Names" : "VisibilityTimeout",
+                "Type" : NUMBER_TYPE
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration
+            },
+            {
+                "Names" : "Alerts",
+                "Subobjects" : true,
+                "Children" : alertChildrenConfiguration
+            }
+        ]
+/]

--- a/providers/shared/component/user.ftl
+++ b/providers/shared/component/user.ftl
@@ -1,84 +1,88 @@
 [#ftl]
 
-[#assign componentConfiguration +=
-    {
-        USER_COMPONENT_TYPE : {
-            "Properties"  : [
-                {
-                    "Type"  : "Description",
-                    "Value" : "A user with permissions on components deployed in the solution"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "application"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : ["Fragment", "Container"],
-                    "Type" : STRING_TYPE,
-                    "Default" : ""
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
-                },
-                {
-                    "Names" : "GenerateCredentials",
-                    "Children" : [
-                        {
-                            "Names" : "Formats",
-                            "Type" : ARRAY_OF_STRING_TYPE,
-                            "Values" : ["system", "console"],
-                            "Default"  : [ "system" ]
-                        }
-                        {
-                            "Names" : "EncryptionScheme",
-                            "Type" : STRING_TYPE,
-                            "Values" : ["base64"],
-                            "Default" : ""
-                        },
-                        {
-                            "Names" : "CharacterLength",
-                            "Type" : NUMBER_TYPE,
-                            "Default" : 20
-                        }
-                    ]
-                },
-                {
-                "Names" : "Permissions",
+[@addComponent
+    type=USER_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A user with permissions on components deployed in the solution"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "application"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=USER_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : ["Fragment", "Container"],
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration
+            },
+            {
+                "Names" : "GenerateCredentials",
                 "Children" : [
-                        {
-                            "Names" : "Decrypt",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "AsFile",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "AppData",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "AppPublic",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        }
-                    ]
-                }
-            ]
-        }
-    }]
+                    {
+                        "Names" : "Formats",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Values" : ["system", "console"],
+                        "Default"  : [ "system" ]
+                    }
+                    {
+                        "Names" : "EncryptionScheme",
+                        "Type" : STRING_TYPE,
+                        "Values" : ["base64"],
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "CharacterLength",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : 20
+                    }
+                ]
+            },
+            {
+            "Names" : "Permissions",
+            "Children" : [
+                    {
+                        "Names" : "Decrypt",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "AsFile",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "AppData",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "AppPublic",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                ]
+            }
+        ]
+/]

--- a/providers/shared/component/userpool.ftl
+++ b/providers/shared/component/userpool.ftl
@@ -3,292 +3,306 @@
 [#assign USERPOOL_COMPONENT_ROLE_UNAUTH_EXTENSTION = "unauth" ]
 [#assign USERPOOL_COMPONENT_ROLE_AUTH_EXTENSTION = "auth" ]
 
-[#assign componentConfiguration +=
-    {
-        USERPOOL_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "Managed identity service"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                },
-                {
-                    "Type" : "Note",
-                    "Value" : "Make sure to plan your schema before initial deployment. Updating shema attributes causes a replaccement of the userpool",
-                    "Severity" : "warning"
-                },
-                {
-                    "Type" : "Note",
-                    "Value" : "Please read https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-add-custom-domain.html before enabling custom domains on userpool hosted UI. An A Record is required in your base domain",
-                    "Severity" : "warning"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "MFA",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "AdminCreatesUser",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : true
-                },
-                {
-                    "Names" : "UnusedAccountTimeout",
-                    "Type" : NUMBER_TYPE,
-                    "Default" : 7
-                },
-                {
-                    "Names" : "VerifyEmail",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : true
-                },
-                {
-                    "Names" : "VerifyPhone",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "LoginAliases",
-                    "Type" : ARRAY_OF_STRING_TYPE,
-                    "Default" : ["email"]
-                },
-                {
-                    "Names" : "AllowUnauthenticatedIds",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "AuthorizationHeader",
-                    "Type" : STRING_TYPE,
-                    "Default" : "Authorization"
-                },
-                {
-                    "Names" : "PasswordPolicy",
-                    "Children" : [
-                        {
-                            "Names" : "MinimumLength",
-                            "Type" : NUMBER_TYPE,
-                            "Default" : 10
-                        },
-                        {
-                            "Names" : "Lowercase",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "Uppercase",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "Numbers",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "SpecialCharacters",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                },
-                {
-                    "Names" : "Profiles",
-                    "Children" : profileChildConfiguration
-                },
-                {
-                    "Names" : "DefaultClient",
-                    "Type" : BOOLEAN_TYPE,
-                    "Description" : "Enable default client mode which creates app client for the user pool and aligns with legacy config",
-                    "Default" : true
-                },
-                {
-                    "Names" : "Schema",
-                    "Subobjects" : true,
-                    "Children" :    [
-                        {
-                            "Names" : "DataType",
-                            "Values" : [ "String", "Number", "DateTime","Boolean"],
-                            "Type" : STRING_TYPE,
-                            "Default" : "String"
-                        },
-                        {
-                            "Names" : "Mutable",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        },
-                        {
-                            "Names" : "Required",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        }
-                    ]
-                },
-                {
-                    "Names" : "HostedUI",
-                    "Description" : "Provision a managed endpoint for login and oauth endpoints",
-                    "Children" : [
-                        {
-                            "Names" : "Certificate",
-                            "Children" : certificateChildConfiguration
-                        }
-                    ]
-                }
-            ],
-            "Components" : [
-                {
-                    "Type" : USERPOOL_CLIENT_COMPONENT_TYPE,
-                    "Component" : "Clients",
-                    "Link" : [ "Client" ]
-                },
-                {
-                    "Type" : USERPOOL_AUTHPROVIDER_COMPONENT_TYPE,
-                    "Component" : "AuthProviders",
-                    "Link" : [ "AuthProvider" ]
-                }
-            ]
-        },
-        USERPOOL_CLIENT_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "A oauth app client which belongs to the userpool"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "OAuth",
-                    "Children" : [
-                        {
-                            "Names" : "Scopes",
-                            "Type" : ARRAY_OF_STRING_TYPE,
-                            "Values" : [ "phone", "email", "openid", "aws.cognito.signin.user.admin", "profile" ],
-                            "Default" : [ "email", "openid" ]
-                        },
-                        {
-                            "Names" : "Flows",
-                            "Type" : ARRAY_OF_STRING_TYPE,
-                            "Values" : [ "code", "implicit", "client_credentials" ],
-                            "Default" : [ "code" ]
-                        }
-                    ]
-                },
-                {
-                    "Names" : "ClientGenerateSecret",
-                    "Description" : "Generate a client secret which musht be provided in auth calls",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "ClientTokenValidity",
-                    "Description" : "Time in days that the refresh token is valid for",
-                    "Type" : NUMBER_TYPE,
-                    "Default" : 30
-                },
-                {
-                    "Names" : "IdentityPoolAccess",
-                    "Description" : "Enable the use of the identity pool for this client",
-                    "Type" : BOOLEAN_TYPE,
-                    "Default" : true
-                },
-                {
-                    "Names" : "AuthProviders",
-                    "Description" : "A list of user pool auth providers which can use this client",
-                    "Type" : ARRAY_OF_STRING_TYPE,
-                    "Default" : [ "COGNITO" ]
-                },
-                {
-                    "Names" : "Links",
-                    "Subobjects" : true,
-                    "Children" : linkChildrenConfiguration
-                }
-            ]
-        },
-        USERPOOL_AUTHPROVIDER_COMPONENT_TYPE : {
-            "Properties" : [
-                {
-                    "Type" : "Description",
-                    "Value" : "An external auth provider which will federate with the user pool"
-                },
-                {
-                    "Type" : "Providers",
-                    "Value" : [ "aws" ]
-                },
-                {
-                    "Type" : "ComponentLevel",
-                    "Value" : "solution"
-                }
-            ],
-            "Attributes" : [
-                {
-                    "Names" : "Engine",
-                    "Description" : "The authentication provider type",
-                    "Type" : STRING_TYPE,
-                    "Values" : [ "SAML", "OIDC" ],
-                    "Mandatory" : true
-                },
-                {
-                    "Names" : "AttributeMappings",
-                    "Subobjects" : true,
-                    "Children" : [
-                        {
-                            "Names" : "UserPoolAttribute",
-                            "Description" : "The name of the attribute in the user pool schema - the id of the mapping will be used if not provided",
-                            "Type" : STRING_TYPE,
-                            "Default" : ""
-                        },
-                        {
-                            "Names" : "ProviderAttribute",
-                            "Description" : "The provider attribute which will be mapped",
-                            "Type" : STRING_TYPE,
-                            "Mandatory" : true
-                        }
-                    ]
-                },
-                {
-                    "Names" : "IDPIdentifiers",
-                    "Type" : ARRAY_OF_STRING_TYPE,
-                    "Description" : "A list of identifiers that can be used to automatically pick the IDP - E.g. email domain"
-                },
-                {
-                    "Names" : "SAML",
-                    "Children" : [
-                        {
-                            "Names" : "MetadataUrl",
-                            "Description" : "The SAML metadataUrl endpoint",
-                            "Type" : STRING_TYPE,
-                            "Default" : ""
-                        },
-                        {
-                            "Names" : "EnableIDPSignOut",
-                            "Description" : "Enable the IDP Signout Flow",
-                            "Type" : BOOLEAN_TYPE,
-                            "Default" : true
-                        }
-                    ]
-                }
-            ]
-        }
-    }]
+[@addComponent
+    type=USERPOOL_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "Managed identity service"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            },
+            {
+                "Type" : "Note",
+                "Value" : "Make sure to plan your schema before initial deployment. Updating shema attributes causes a replaccement of the userpool",
+                "Severity" : "warning"
+            },
+            {
+                "Type" : "Note",
+                "Value" : "Please read https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-add-custom-domain.html before enabling custom domains on userpool hosted UI. An A Record is required in your base domain",
+                "Severity" : "warning"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=USERPOOL_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "MFA",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "AdminCreatesUser",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "UnusedAccountTimeout",
+                "Type" : NUMBER_TYPE,
+                "Default" : 7
+            },
+            {
+                "Names" : "VerifyEmail",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "VerifyPhone",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "LoginAliases",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : ["email"]
+            },
+            {
+                "Names" : "AllowUnauthenticatedIds",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "AuthorizationHeader",
+                "Type" : STRING_TYPE,
+                "Default" : "Authorization"
+            },
+            {
+                "Names" : "PasswordPolicy",
+                "Children" : [
+                    {
+                        "Names" : "MinimumLength",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : 10
+                    },
+                    {
+                        "Names" : "Lowercase",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "Uppercase",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "Numbers",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "SpecialCharacters",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration
+            },
+            {
+                "Names" : "DefaultClient",
+                "Type" : BOOLEAN_TYPE,
+                "Description" : "Enable default client mode which creates app client for the user pool and aligns with legacy config",
+                "Default" : true
+            },
+            {
+                "Names" : "Schema",
+                "Subobjects" : true,
+                "Children" :    [
+                    {
+                        "Names" : "DataType",
+                        "Values" : [ "String", "Number", "DateTime","Boolean"],
+                        "Type" : STRING_TYPE,
+                        "Default" : "String"
+                    },
+                    {
+                        "Names" : "Mutable",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "Required",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "HostedUI",
+                "Description" : "Provision a managed endpoint for login and oauth endpoints",
+                "Children" : [
+                    {
+                        "Names" : "Certificate",
+                        "Children" : certificateChildConfiguration
+                    }
+                ]
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=USERPOOL_CLIENT_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "A oauth app client which belongs to the userpool"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+    parent=USERPOOL_COMPONENT_TYPE
+    childAttribute="Clients"
+    linkAttributes="Client"
+/]
+
+[@addComponentResourceGroup
+    type=USERPOOL_CLIENT_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "OAuth",
+                "Children" : [
+                    {
+                        "Names" : "Scopes",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Values" : [ "phone", "email", "openid", "aws.cognito.signin.user.admin", "profile" ],
+                        "Default" : [ "email", "openid" ]
+                    },
+                    {
+                        "Names" : "Flows",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Values" : [ "code", "implicit", "client_credentials" ],
+                        "Default" : [ "code" ]
+                    }
+                ]
+            },
+            {
+                "Names" : "ClientGenerateSecret",
+                "Description" : "Generate a client secret which musht be provided in auth calls",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "ClientTokenValidity",
+                "Description" : "Time in days that the refresh token is valid for",
+                "Type" : NUMBER_TYPE,
+                "Default" : 30
+            },
+            {
+                "Names" : "IdentityPoolAccess",
+                "Description" : "Enable the use of the identity pool for this client",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "AuthProviders",
+                "Description" : "A list of user pool auth providers which can use this client",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : [ "COGNITO" ]
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=USERPOOL_AUTHPROVIDER_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "An external auth provider which will federate with the user pool"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+    parent=USERPOOL_COMPONENT_TYPE
+    childAttribute="AuthProviders"
+    linkAttributes="AuthProvider"
+/]
+
+[@addComponentResourceGroup
+    type=USERPOOL_AUTHPROVIDER_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Engine",
+                "Description" : "The authentication provider type",
+                "Type" : STRING_TYPE,
+                "Values" : [ "SAML", "OIDC" ],
+                "Mandatory" : true
+            },
+            {
+                "Names" : "AttributeMappings",
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "UserPoolAttribute",
+                        "Description" : "The name of the attribute in the user pool schema - the id of the mapping will be used if not provided",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "ProviderAttribute",
+                        "Description" : "The provider attribute which will be mapped",
+                        "Type" : STRING_TYPE,
+                        "Mandatory" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "IDPIdentifiers",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Description" : "A list of identifiers that can be used to automatically pick the IDP - E.g. email domain"
+            },
+            {
+                "Names" : "SAML",
+                "Children" : [
+                    {
+                        "Names" : "MetadataUrl",
+                        "Description" : "The SAML metadataUrl endpoint",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "EnableIDPSignOut",
+                        "Description" : "Enable the IDP Signout Flow",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                ]
+            }
+        ]
+/]


### PR DESCRIPTION
As a first step to introduction of resource groups, several macros have
been added to abstract the actual structure of the component
configuration.

The macro definition can now be modified to restructure the component
configuration without affecting the existing component definitions.