### PR TITLE
<fix>user: resource lookup

### DIFF
--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -17,6 +17,9 @@
 [@includeComponentConfiguration "baseline" /]
 [@includeComponentConfiguration "ec2" /]
 
+[#-- Required for user component to generate api key usage plan --]
+[@includeComponentConfiguration "apigateway" /]
+
 [#-- Name prefixes --]
 [#assign shortNamePrefixes = [] ]
 [#assign fullNamePrefixes = [] ]


### PR DESCRIPTION
Add workaround to include apigateway in default resource lookups 

This is to get around a requirement for this setup in `user/setup.ftl`

```
[@createAPIUsagePlanMember
       mode=listMode
       id=formatDependentResourceId(AWS_APIGATEWAY_USAGEPLAN_MEMBER_RESOURCE_TYPE, apikeyId, link.Id)
```