### PR TITLE
<feature> Static component dependencies

### DIFF
--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -17,9 +17,6 @@
 [@includeComponentConfiguration "baseline" /]
 [@includeComponentConfiguration "ec2" /]
 
-[#-- Required for user component to generate api key usage plan --]
-[@includeComponentConfiguration "apigateway" /]
-
 [#-- Name prefixes --]
 [#assign shortNamePrefixes = [] ]
 [#assign fullNamePrefixes = [] ]

--- a/providers/aws/service/apigateway.ftl
+++ b/providers/aws/service/apigateway.ftl
@@ -7,9 +7,7 @@
 [#assign AWS_APIGATEWAY_DOMAIN_RESOURCE_TYPE = "apiDomain"]
 [#assign AWS_APIGATEWAY_AUTHORIZER_RESOURCE_TYPE = "apiAuthorizer"]
 [#assign AWS_APIGATEWAY_BASEPATHMAPPING_RESOURCE_TYPE = "apiBasePathMapping"]
-[#assign AWS_APIGATEWAY_USAGEPLAN_RESOURCE_TYPE = "apiUsagePlan"]
 [#assign AWS_APIGATEWAY_APIKEY_RESOURCE_TYPE = "apiKey"]
-[#assign AWS_APIGATEWAY_USAGEPLAN_MEMBER_RESOURCE_TYPE = "apiUsagePlanMember"]
 
 [#function formatDependentAPIGatewayAuthorizerId resourceId extensions...]
     [#return formatDependentResourceId(
@@ -55,13 +53,6 @@
     }
 ]
 
-[#assign APIGATEWAY_USAGEPLAN_OUTPUT_MAPPINGS =
-    {
-        REFERENCE_ATTRIBUTE_TYPE : {
-            "UseRef" : true
-        }
-    }
-]
 [#assign APIGATEWAY_APIKEY_OUTPUT_MAPPINGS =
     {
         REFERENCE_ATTRIBUTE_TYPE : {
@@ -72,7 +63,6 @@
 [#assign outputMappings +=
     {
         AWS_APIGATEWAY_RESOURCE_TYPE : APIGATEWAY_OUTPUT_MAPPINGS,
-        AWS_APIGATEWAY_USAGEPLAN_RESOURCE_TYPE : APIGATEWAY_USAGEPLAN_OUTPUT_MAPPINGS,
         AWS_APIGATEWAY_APIKEY_RESOURCE_TYPE : APIGATEWAY_APIKEY_OUTPUT_MAPPINGS
     }
 ]
@@ -90,21 +80,6 @@
     ]
 [/#function]
 
-[#macro createAPIUsagePlan mode id name stages=[] dependencies="" ]
-    [@cfResource
-        mode=mode
-        id=id
-        type="AWS::ApiGateway::UsagePlan"
-        properties=
-            {
-                "ApiStages" : stages,
-                "UsagePlanName" : name
-            }
-        outputs=APIGATEWAY_USAGEPLAN_OUTPUT_MAPPINGS
-        dependencies=dependencies
-    /]
-[/#macro]
-
 [#macro createAPIKey mode id name enabled=true distinctId=false description="" dependencies="" ]
     [@cfResource
         mode=mode
@@ -118,22 +93,6 @@
             } +
             attributeIfContent("Description", description)
         outputs=APIGATEWAY_APIKEY_OUTPUT_MAPPINGS
-        dependencies=dependencies
-    /]
-[/#macro]
-
-[#macro createAPIUsagePlanMember mode id planId apikeyId dependencies="" ]
-    [@cfResource
-        mode=mode
-        id=id
-        type="AWS::ApiGateway::UsagePlanKey"
-        properties=
-            {
-                "KeyId" : getReference(apikeyId),
-                "KeyType" : "API_KEY",
-                "UsagePlanId" : getReference(planId)
-            }
-        outputs={}
         dependencies=dependencies
     /]
 [/#macro]

--- a/providers/aws/service/apiusageplan.ftl
+++ b/providers/aws/service/apiusageplan.ftl
@@ -1,0 +1,51 @@
+[#ftl]
+
+[#-- Resources --]
+[#assign AWS_APIGATEWAY_USAGEPLAN_RESOURCE_TYPE = "apiUsagePlan"]
+[#assign AWS_APIGATEWAY_USAGEPLAN_MEMBER_RESOURCE_TYPE = "apiUsagePlanMember"]
+
+[#assign APIGATEWAY_USAGEPLAN_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+
+[#assign outputMappings +=
+    {
+        AWS_APIGATEWAY_USAGEPLAN_RESOURCE_TYPE : APIGATEWAY_USAGEPLAN_OUTPUT_MAPPINGS,
+    }
+]
+
+[#macro createAPIUsagePlan mode id name stages=[] dependencies="" ]
+    [@cfResource
+        mode=mode
+        id=id
+        type="AWS::ApiGateway::UsagePlan"
+        properties=
+            {
+                "ApiStages" : stages,
+                "UsagePlanName" : name
+            }
+        outputs=APIGATEWAY_USAGEPLAN_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]
+
+[#macro createAPIUsagePlanMember mode id planId apikeyId dependencies="" ]
+    [@cfResource
+        mode=mode
+        id=id
+        type="AWS::ApiGateway::UsagePlanKey"
+        properties=
+            {
+                "KeyId" : getReference(apikeyId),
+                "KeyType" : "API_KEY",
+                "UsagePlanId" : getReference(planId)
+            }
+        outputs={}
+        dependencies=dependencies
+    /]
+[/#macro]
+

--- a/providers/shared/component/user.ftl
+++ b/providers/shared/component/user.ftl
@@ -17,6 +17,7 @@
                 "Value" : "application"
             }
         ]
+    dependencies=[APIGATEWAY_COMPONENT_TYPE, APIGATEWAY_USAGEPLAN_COMPONENT_TYPE]
 /]
 
 [@addComponentResourceGroup


### PR DESCRIPTION
Add ability to declare static dependencies of one component on
another.

In general, link processing should load all the component definitions
but this happens at run-time. As a result, when the code is loaded
and it is syntactically checked, any use of definitions from a link
component type will fail.

The suspicion is that such use needs to be reconsidered because it
implies an assumption on the part of the depending component as to
the provider of the dependent component. However, for now this feature
will get around this.