### PR TITLE
<fix> apigw dependency on userpool component

### DIFF
--- a/providers/shared/component/apigateway.ftl
+++ b/providers/shared/component/apigateway.ftl
@@ -66,6 +66,7 @@ object.
                 "Value" : "application"
             }
         ]
+    dependencies=[USERPOOL_COMPONENT_TYPE]
 /]
 
 [@addComponentResourceGroup


### PR DESCRIPTION
Add static dependency on userpools for api gateway otherwise state routine isn't available for userpools