### PR TITLE
<bugfix> External link template inclusion

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1581,6 +1581,10 @@ behaviour.
     [/#if]
 
     [#if link.Tier?lower_case == "external"]
+        [#-- If a type is provided, ensure it has been included --]
+        [#if link.Type??]
+            [@includeComponentConfiguration link.Type /]
+        [/#if]
         [#local targetOccurrence =
             {
                 "Core" : {

--- a/providers/shared/component/apigateway.ftl
+++ b/providers/shared/component/apigateway.ftl
@@ -66,7 +66,6 @@ object.
                 "Value" : "application"
             }
         ]
-    dependencies=[USERPOOL_COMPONENT_TYPE]
 /]
 
 [@addComponentResourceGroup


### PR DESCRIPTION
If an external link is specified with type, attempt to load the corresponding template information.

With this fix, remove the static inclusion of userpool into apigateway.