### PR TITLE
<feature> Resource Groups and placements

### DIFF
--- a/aws/data/masterData.json
+++ b/aws/data/masterData.json
@@ -1353,7 +1353,7 @@
                   }
                 },
                 "Links" : {
-                  "cf_key" : { 
+                  "cf_key" : {
                     "Tier" : "mgmt",
                     "Component" : "baseline",
                     "Instance" : "",
@@ -2963,6 +2963,15 @@
             }
           }
         }
+    }
+  },
+  "PlacementProfiles" : {
+    "default" : {
+      "default" : {
+        "Provider" : "aws",
+        "Region" : "ap-southeast-2",
+        "DeploymentFramework" : "cf"
+      }
     }
   },
   "NetworkEndpointGroups" : {

--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1407,7 +1407,7 @@ behaviour.
                     [#local placementProfile = getPlacementProfile(profiles.Placement, segmentQualifiers) ]
 
                     [#-- Add resource group placements to the occurrence --]
-                    [#list getComponentResourceGroups(type) as key, value]
+                    [#list getComponentResourceGroups(type)?keys as key]
                         [#local occurrence =
                             mergeObjects(
                                 occurrence,
@@ -1415,7 +1415,7 @@ behaviour.
                                     "State" : {
                                         "ResourceGroups" : {
                                             key : {
-                                                "Placement" : getResourceGroupPlacement(value, placementProfile)
+                                                "Placement" : getResourceGroupPlacement(key, placementProfile)
                                             }
                                         }
                                     }
@@ -1926,6 +1926,9 @@ behaviour.
     [/#if]
     [#if !profile?has_content]
         [#local profile = (tenantObject.Profiles.Placement)!""]
+    [/#if]
+    [#if !profile?has_content]
+        [#local profile = DEFAULT_PLACEMENT_PROFILE]
     [/#if]
 
     [#if profile?is_hash]

--- a/aws/templates/resource/start.ftl
+++ b/aws/templates/resource/start.ftl
@@ -551,6 +551,7 @@
             [#assign exceptionResources +=
                 [
                     {
+                        "Timestamp" : .now?iso_utc,
                         "Description" : description,
                         "Context" : context
                     } +

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -2,20 +2,12 @@
 [#include "base.ftl"]
 [#include "engine.ftl"]
 
-[#-- Bootstrap the component inclusion process --]
-[#assign componentBootstrapLoaded = includeTemplate("/shared/component/component.ftl", true) ]
-
 [#include idList]
 [#include nameList]
 [#include policyList]
 [#include resourceList]
 [#include "common.ftl"]
 [#include "swagger.ftl"]
-
-[#-- Include a few key components --]
-[#-- TODO(mfl): Refactor to remove provider dependencies --]
-[@includeComponentConfiguration "baseline" /]
-[@includeComponentConfiguration "ec2" /]
 
 [#-- Name prefixes --]
 [#assign shortNamePrefixes = [] ]
@@ -215,6 +207,21 @@
         [/#if]
 
     [/#if]
+
+    [#-- Cludge for now to get placement profiles working --]
+    [#assign placementProfiles =
+        mergeObjects(
+            (productObject.PlacementProfiles)!{},
+            (tenantObject.PlacementProfiles)!{}
+        ) ]
+
+    [#-- Bootstrap the component inclusion process --]
+    [#assign componentBootstrapLoaded = includeTemplate("/shared/component/component.ftl", true) ]
+
+    [#-- Include a few key components --]
+    [#-- TODO(mfl): Refactor to remove provider dependencies --]
+    [@includeComponentConfiguration "baseline" /]
+    [@includeComponentConfiguration "ec2" /]
 
     [#assign segmentSeed = getExistingReference(formatSegmentSeedId()) ]
 

--- a/aws/templates/setContext.ftl
+++ b/aws/templates/setContext.ftl
@@ -210,6 +210,7 @@
 
     [#-- Cludge for now to get placement profiles working --]
     [#assign placementProfiles =
+        (blueprintObject.PlacementProfiles)!{} +
         mergeObjects(
             (productObject.PlacementProfiles)!{},
             (tenantObject.PlacementProfiles)!{}

--- a/providers/aws/aws.ftl
+++ b/providers/aws/aws.ftl
@@ -1,0 +1,5 @@
+[#ftl]
+
+[#assign AWS_PROVIDER = "aws"]
+
+[#assign CLOUD_FORMATION_DEPLOYMENT_FRAMEWORK = "cf"]

--- a/providers/shared/component/apigateway.ftl
+++ b/providers/shared/component/apigateway.ftl
@@ -66,10 +66,6 @@ object.
                 "Value" : "application"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=APIGATEWAY_COMPONENT_TYPE
     attributes=
         [
             {
@@ -185,7 +181,7 @@ object.
             },
             {
                 "Names" : "Profiles",
-                "Children" : profileChildConfiguration + [
+                "Children" : [
                     {
                         "Names" : "Security",
                         "Type" : STRING_TYPE,
@@ -211,4 +207,5 @@ object.
                 "Default" : "ignore"
             }
         ]
+    dependencies=[APIGATEWAY_USAGEPLAN_COMPONENT_TYPE, USERPOOL_COMPONENT_TYPE]
 /]

--- a/providers/shared/component/apiusageplan.ftl
+++ b/providers/shared/component/apiusageplan.ftl
@@ -17,10 +17,6 @@
                 "Value" : "application"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=APIGATEWAY_USAGEPLAN_COMPONENT_TYPE
     attributes=
         [
             {

--- a/providers/shared/component/baseline.ftl
+++ b/providers/shared/component/baseline.ftl
@@ -23,10 +23,6 @@
                 "Value" : "segment"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=BASELINE_COMPONENT_TYPE
     attributes=
         [
             {
@@ -64,13 +60,6 @@
                 "Value" : "segment"
             }
         ]
-    parent=BASELINE_COMPONENT_TYPE
-    childAttribute="DataBuckets"
-    linkAttributes="DataBucket"
-/]
-
-[@addComponentResourceGroup
-    type=BASELINE_DATA_COMPONENT_TYPE
     attributes=
         [
             {
@@ -118,6 +107,9 @@
                 "Children" : s3NotificationChildConfiguration
             }
         ]
+    parent=BASELINE_COMPONENT_TYPE
+    childAttribute="DataBuckets"
+    linkAttributes="DataBucket"
 /]
 
 [@addChildComponent
@@ -137,13 +129,6 @@
                 "Value" : "segment"
             }
         ]
-    parent=BASELINE_COMPONENT_TYPE
-    childAttribute="Keys"
-    linkAttributes="Key"
-/]
-
-[@addComponentResourceGroup
-    type=BASELINE_KEY_COMPONENT_TYPE
     attributes=
         [
             {
@@ -158,4 +143,7 @@
                 "Children" : linkChildrenConfiguration
             }
         ]
+    parent=BASELINE_COMPONENT_TYPE
+    childAttribute="Keys"
+    linkAttributes="Key"
 /]

--- a/providers/shared/component/bastion.ftl
+++ b/providers/shared/component/bastion.ftl
@@ -17,10 +17,6 @@
                 "Value" : "segment"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=BASTION_COMPONENT_TYPE
     attributes=
         [
             {
@@ -46,14 +42,14 @@
             },
             {
                 "Names" : "Profiles",
-                "Children" : profileChildConfiguration +
-                                [
-                                    {
-                                        "Names" : "Processor",
-                                        "Type" : STRING_TYPE,
-                                        "Default" : "default"
-                                    }
-                                ]
+                "Children" :
+                    [
+                        {
+                            "Names" : "Processor",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        }
+                    ]
             },
             {
                 "Names" : "AutoScaling",

--- a/providers/shared/component/cache.ftl
+++ b/providers/shared/component/cache.ftl
@@ -17,10 +17,6 @@
                 "Value" : "solution"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=CACHE_COMPONENT_TYPE
     attributes=
         [
             {
@@ -48,14 +44,14 @@
             },
             {
                 "Names" : "Profiles",
-                "Children" : profileChildConfiguration +
-                                [
-                                    {
-                                        "Names" : "Processor",
-                                        "Type" : STRING_TYPE,
-                                        "Default" : "default"
-                                    }
-                                ]
+                "Children" :
+                    [
+                        {
+                            "Names" : "Processor",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        }
+                    ]
             },
             {
                 "Names" : "Hibernate",

--- a/providers/shared/component/computecluster.ftl
+++ b/providers/shared/component/computecluster.ftl
@@ -17,10 +17,6 @@
                 "Value" : "application"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=COMPUTECLUSTER_COMPONENT_TYPE
     attributes=
         [
             {
@@ -35,14 +31,14 @@
             },
             {
                 "Names" : "Profiles",
-                "Children" : profileChildConfiguration +
-                                [
-                                    {
-                                        "Names" : "Processor",
-                                        "Type" : STRING_TYPE,
-                                        "Default" : "default"
-                                    }
-                                ]
+                "Children" :
+                    [
+                        {
+                            "Names" : "Processor",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        }
+                    ]
             },
             {
                 "Names" : "UseInitAsService",

--- a/providers/shared/component/configstore.ftl
+++ b/providers/shared/component/configstore.ftl
@@ -17,10 +17,6 @@
                 "Value" : "solution"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=CONFIGSTORE_COMPONENT_TYPE
     attributes=
         [
             {
@@ -58,13 +54,6 @@
                 "Value" : "solution"
             }
         ]
-    parent=CONFIGSTORE_COMPONENT_TYPE
-    childAttribute="Branches"
-    linkAttributes="Branch"
-/]
-
-[@addComponentResourceGroup
-    type=CONFIGSTORE_BRANCH_COMPONENT_TYPE
     attributes=
         [
             {
@@ -86,4 +75,7 @@
                 ]
             }
         ]
+    parent=CONFIGSTORE_COMPONENT_TYPE
+    childAttribute="Branches"
+    linkAttributes="Branch"
 /]

--- a/providers/shared/component/contenthub.ftl
+++ b/providers/shared/component/contenthub.ftl
@@ -17,10 +17,6 @@
                 "Value" : "application"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=CONTENTHUB_HUB_COMPONENT_TYPE
     attributes=
         [
             {

--- a/providers/shared/component/contentnode.ftl
+++ b/providers/shared/component/contentnode.ftl
@@ -17,10 +17,6 @@
                 "Value" : "application"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=CONTENTHUB_NODE_COMPONENT_TYPE
     attributes=
         [
             {

--- a/providers/shared/component/datafeed.ftl
+++ b/providers/shared/component/datafeed.ftl
@@ -17,10 +17,6 @@
                 "Value" : "solution"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=DATAFEED_COMPONENT_TYPE
     attributes=
         [
             {

--- a/providers/shared/component/datapipeline.ftl
+++ b/providers/shared/component/datapipeline.ftl
@@ -17,10 +17,6 @@
                 "Value" : "application"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=DATAPIPELINE_COMPONENT_TYPE
     attributes=
         [
             {
@@ -60,14 +56,14 @@
             },
             {
                 "Names" : "Profiles",
-                "Children" : profileChildConfiguration +
-                                [
-                                    {
-                                        "Names" : "Processor",
-                                        "Type" : STRING_TYPE,
-                                        "Default" : "default"
-                                    }
-                                ]
+                "Children" :
+                    [
+                        {
+                            "Names" : "Processor",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        }
+                    ]
             }
         ]
 /]

--- a/providers/shared/component/dataset.ftl
+++ b/providers/shared/component/dataset.ftl
@@ -17,10 +17,6 @@
                 "Value" : "application"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=DATASET_COMPONENT_TYPE
     attributes=
         [
             {

--- a/providers/shared/component/datavolume.ftl
+++ b/providers/shared/component/datavolume.ftl
@@ -17,10 +17,6 @@
                 "Value" : "solution"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=DATAVOLUME_COMPONENT_TYPE
     attributes=
         [
             {
@@ -49,10 +45,6 @@
                 "Names" : "ProvisionedIops",
                 "Type" : NUMBER_TYPE,
                 "Default" : 100
-            },
-            {
-                "Names" : "Profiles",
-                "Children" : profileChildConfiguration
             },
             {
                 "Names" : "Backup",

--- a/providers/shared/component/ec2.ftl
+++ b/providers/shared/component/ec2.ftl
@@ -17,10 +17,6 @@
                 "Value" : "solution"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=EC2_COMPONENT_TYPE
     attributes=
         [
             {
@@ -45,14 +41,14 @@
             },
             {
                 "Names" : "Profiles",
-                "Children" : profileChildConfiguration +
-                                [
-                                    {
-                                        "Names" : "Processor",
-                                        "Type" : STRING_TYPE,
-                                        "Default" : "default"
-                                    }
-                                ]
+                "Children" :
+                    [
+                        {
+                            "Names" : "Processor",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        }
+                    ]
             },
             {
                 "Names" : "Ports",

--- a/providers/shared/component/ecs.ftl
+++ b/providers/shared/component/ecs.ftl
@@ -113,10 +113,6 @@
                 "Value" : "solution"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=ECS_COMPONENT_TYPE
     attributes=
         [
             {
@@ -153,14 +149,14 @@
             },
             {
                 "Names" : "Profiles",
-                "Children" : profileChildConfiguration +
-                                [
-                                    {
-                                        "Names" : "Processor",
-                                        "Type" : STRING_TYPE,
-                                        "Default" : "default"
-                                    }
-                                ]
+                "Children" :
+                    [
+                        {
+                            "Names" : "Processor",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        }
+                    ]
             },
             {
                 "Names" : "AutoScaling",
@@ -232,13 +228,6 @@
                 "Value" : "application"
             }
         ]
-    parent=ECS_COMPONENT_TYPE
-    childAttribute="Services"
-    linkAttributes="Service"
-/]
-
-[@addComponentResourceGroup
-    type=ECS_SERVICE_COMPONENT_TYPE
     attributes=
         [
             {
@@ -324,12 +313,11 @@
                         "Default" : ""
                     }
                 ]
-            },
-            {
-                "Names" : "Profiles",
-                "Children" : profileChildConfiguration
             }
         ]
+    parent=ECS_COMPONENT_TYPE
+    childAttribute="Services"
+    linkAttributes="Service"
 /]
 
 [@addChildComponent
@@ -349,13 +337,6 @@
                 "Value" : "application"
             }
         ]
-    parent=ECS_COMPONENT_TYPE
-    childAttribute="Tasks"
-    linkAttributes="Task"
-/]
-
-[@addComponentResourceGroup
-    type=ECS_TASK_COMPONENT_TYPE
     attributes=
         [
             {
@@ -426,10 +407,6 @@
                 "Default" : false
             },
             {
-                "Names" : "Profiles",
-                "Children" : profileChildConfiguration
-            },
-            {
                 "Names" : "Schedules",
                 "Subobjects" : true,
                 "Children" : [
@@ -447,4 +424,7 @@
                 ]
             }
         ]
+    parent=ECS_COMPONENT_TYPE
+    childAttribute="Tasks"
+    linkAttributes="Task"
 /]

--- a/providers/shared/component/efs.ftl
+++ b/providers/shared/component/efs.ftl
@@ -17,20 +17,12 @@
                 "Value" : "solution"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=EFS_COMPONENT_TYPE
     attributes=
         [
             {
                 "Names" : "Encrypted",
                 "Type" : BOOLEAN_TYPE,
                 "Default" : true
-            },
-            {
-                "Names" : "Profiles",
-                "Children" : profileChildConfiguration
             }
         ]
 /]
@@ -52,13 +44,6 @@
                 "Value" : "solution"
             }
         ]
-    parent=EFS_COMPONENT_TYPE
-    childAttribute="Mounts"
-    linkAttributes="Mount"
-/]
-
-[@addComponentResourceGroup
-    type=EFS_MOUNT_COMPONENT_TYPE
     attributes=
         [
             {
@@ -67,4 +52,7 @@
                 "Mandatory" : true
             }
         ]
+    parent=EFS_COMPONENT_TYPE
+    childAttribute="Mounts"
+    linkAttributes="Mount"
 /]

--- a/providers/shared/component/es.ftl
+++ b/providers/shared/component/es.ftl
@@ -17,10 +17,6 @@
                 "Value" : "solution"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=ES_COMPONENT_TYPE
     attributes=
         [
             {
@@ -73,14 +69,14 @@
             },
             {
                 "Names" : "Profiles",
-                "Children" : profileChildConfiguration +
-                                [
-                                    {
-                                        "Names" : "Processor",
-                                        "Type" : STRING_TYPE,
-                                        "Default" : "default"
-                                    }
-                                ]
+                "Children" :
+                    [
+                        {
+                            "Names" : "Processor",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        }
+                    ]
             },
             {
                 "Names" : "Alerts",

--- a/providers/shared/component/gateway.ftl
+++ b/providers/shared/component/gateway.ftl
@@ -17,10 +17,6 @@
                 "Value" : "segment"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=NETWORK_GATEWAY_COMPONENT_TYPE
     attributes=
         [
             {
@@ -60,13 +56,6 @@
                 "Value" : "segment"
             }
         ]
-    parent=NETWORK_GATEWAY_COMPONENT_TYPE
-    childAttribute="Destinations"
-    linkAttributes="Destination"
-/]
-
-[@addComponentResourceGroup
-    type=NETWORK_GATEWAY_DESTINATION_COMPONENT_TYPE
     attributes=
         [
             {
@@ -92,4 +81,7 @@
                 "Children" : linkChildrenConfiguration
             }
         ]
+    parent=NETWORK_GATEWAY_COMPONENT_TYPE
+    childAttribute="Destinations"
+    linkAttributes="Destination"
 /]

--- a/providers/shared/component/lambda.ftl
+++ b/providers/shared/component/lambda.ftl
@@ -17,10 +17,6 @@
                 "Value" : "application"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=LAMBDA_COMPONENT_TYPE
     attributes=
         [
             {
@@ -49,13 +45,6 @@
                 "Value" : "application"
             }
         ]
-    parent=LAMBDA_COMPONENT_TYPE
-    childAttribute="Functions"
-    linkAttributes="Function"
-/]
-
-[@addComponentResourceGroup
-    type=LAMBDA_FUNCTION_COMPONENT_TYPE
     attributes=
         [
             {
@@ -72,10 +61,6 @@
                 "Names" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration
-            },
-            {
-                "Names" : "Profiles",
-                "Children" : profileChildConfiguration
             },
             {
                 "Names" : "LogMetrics",
@@ -184,4 +169,7 @@
                 ]
             }
         ]
+    parent=LAMBDA_COMPONENT_TYPE
+    childAttribute="Functions"
+    linkAttributes="Function"
 /]

--- a/providers/shared/component/lb.ftl
+++ b/providers/shared/component/lb.ftl
@@ -22,10 +22,6 @@
                 "Severity" : "warning"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=LB_COMPONENT_TYPE
     attributes=
         [
             {
@@ -41,7 +37,7 @@
             },
             {
                 "Names" : "Profiles",
-                "Children" : profileChildConfiguration + [
+                "Children" : [
                     {
                         "Names" : "Security",
                         "Type" : STRING_TYPE,
@@ -89,13 +85,6 @@
                 "Value" : "solution"
             }
         ]
-    parent=LB_COMPONENT_TYPE
-    childAttribute="PortMappings"
-    linkAttributes=["PortMapping","Port"]
-/]
-
-[@addComponentResourceGroup
-    type=LB_PORT_COMPONENT_TYPE
     attributes=
         [
             {
@@ -229,4 +218,7 @@
                 ]
             }
         ]
+    parent=LB_COMPONENT_TYPE
+    childAttribute="PortMappings"
+    linkAttributes=["PortMapping","Port"]
 /]

--- a/providers/shared/component/mobileapp.ftl
+++ b/providers/shared/component/mobileapp.ftl
@@ -17,10 +17,6 @@
                 "Value" : "application"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=MOBILEAPP_COMPONENT_TYPE
     attributes=
         [
             {

--- a/providers/shared/component/mobilenotifier.ftl
+++ b/providers/shared/component/mobilenotifier.ftl
@@ -20,10 +20,6 @@
                 "Value" : "solution"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=MOBILENOTIFIER_COMPONENT_TYPE
     attributes=
         [
             {
@@ -77,13 +73,6 @@
                 "Severity" : "info"
             }
         ]
-    parent=MOBILENOTIFIER_COMPONENT_TYPE
-    childAttribute="Platforms"
-    linkAttributes="Platform"
-/]
-
-[@addComponentResourceGroup
-    type=MOBILENOTIFIER_PLATFORM_COMPONENT_TYPE
     attributes=
         [
             {
@@ -110,10 +99,6 @@
                 "Children" : linkChildrenConfiguration
             },
             {
-                "Names" : "Profiles",
-                "Children" : profileChildConfiguration
-            },
-            {
                 "Names" : "LogMetrics",
                 "Subobjects" : true,
                 "Children" : logMetricChildrenConfiguration
@@ -124,4 +109,7 @@
                 "Children" : alertChildrenConfiguration
             }
         ]
+    parent=MOBILENOTIFIER_COMPONENT_TYPE
+    childAttribute="Platforms"
+    linkAttributes="Platform"
 /]

--- a/providers/shared/component/network.ftl
+++ b/providers/shared/component/network.ftl
@@ -17,10 +17,6 @@
                 "Value" : "segment"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=NETWORK_COMPONENT_TYPE
     attributes=
         [
             {
@@ -83,13 +79,6 @@
                 "Value" : "segment"
             }
         ]
-    parent=NETWORK_COMPONENT_TYPE
-    childAttribute="RouteTables"
-    linkAttributes="RouteTable"
-/]
-
-[@addComponentResourceGroup
-    type=NETWORK_ROUTE_TABLE_COMPONENT_TYPE
     attributes=
         [
             {
@@ -102,12 +91,11 @@
                 "Description" : "Does the route table require Public IP internet access",
                 "Type" : BOOLEAN_TYPE,
                 "Default" : false
-            },
-            {
-                "Names" : "Profiles",
-                "Children" : profileChildConfiguration
             }
         ]
+    parent=NETWORK_COMPONENT_TYPE
+    childAttribute="RouteTables"
+    linkAttributes="RouteTable"
 /]
 
 [@addChildComponent
@@ -127,13 +115,6 @@
                 "Value" : "segment"
             }
         ]
-    parent=NETWORK_COMPONENT_TYPE
-    childAttribute="NetworkACLs"
-    linkAttributes="NetworkACL"
-/]
-
-[@addComponentResourceGroup
-    type=NETWORK_ACL_COMPONENT_TYPE
     attributes=
         [
             {
@@ -199,4 +180,7 @@
                 ]
             }
         ]
+    parent=NETWORK_COMPONENT_TYPE
+    childAttribute="NetworkACLs"
+    linkAttributes="NetworkACL"
 /]

--- a/providers/shared/component/rds.ftl
+++ b/providers/shared/component/rds.ftl
@@ -17,10 +17,6 @@
                 "Value" : "solution"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=RDS_COMPONENT_TYPE
     attributes=
         [
             {
@@ -119,14 +115,14 @@
             },
             {
                 "Names" : "Profiles",
-                "Children" : profileChildConfiguration +
-                                [
-                                    {
-                                        "Names" : "Processor",
-                                        "Type" : STRING_TYPE,
-                                        "Default" : "default"
-                                    }
-                                ]
+                "Children" :
+                    [
+                        {
+                            "Names" : "Processor",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        }
+                    ]
             },
             {
                 "Names" : "Hibernate",

--- a/providers/shared/component/s3.ftl
+++ b/providers/shared/component/s3.ftl
@@ -17,10 +17,6 @@
                 "Value" : "solution"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=S3_COMPONENT_TYPE
     attributes=
         [
             {
@@ -99,10 +95,6 @@
                 "Names" : "CORSBehaviours",
                 "Type" : ARRAY_OF_STRING_TYPE,
                 "Default" : []
-            },
-            {
-                "Names" : "Profiles",
-                "Children" : profileChildConfiguration
             },
             {
                 "Names" : "Replication",

--- a/providers/shared/component/serviceregistry.ftl
+++ b/providers/shared/component/serviceregistry.ftl
@@ -17,16 +17,8 @@
                 "Value" : "solution"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=SERVICE_REGISTRY_COMPONENT_TYPE
     attributes=
         [
-            {
-                "Names" : "Profiles",
-                "Children" : profileChildConfiguration
-            },
             {
                 "Names" : "Links",
                 "Subobjects" : true,
@@ -56,24 +48,8 @@
                 "Value" : "solution"
             }
         ]
-    parent=SERVICE_REGISTRY_COMPONENT_TYPE
-    childAttribute="RegistryServices"
-    linkAttributes="RegistryService"
-/]
-
-[@addComponentResourceGroup
-    type=SERVICE_REGISTRY_SERVICE_COMPONENT_TYPE
     attributes=
         [
-            {
-                "Names" : "Profiles",
-                "Children" : profileChildConfiguration
-            },
-            {
-                "Names" : "Links",
-                "Subobjects" : true,
-                "Children" : linkChildrenConfiguration
-            },
             {
                 "Names" : "ServiceName",
                 "Description" : "The hostname portion of the DNS record which will identify this service",
@@ -100,4 +76,7 @@
                 "Default" : "OnlyOne"
             }
         ]
+    parent=SERVICE_REGISTRY_COMPONENT_TYPE
+    childAttribute="RegistryServices"
+    linkAttributes="RegistryService"
 /]

--- a/providers/shared/component/spa.ftl
+++ b/providers/shared/component/spa.ftl
@@ -17,10 +17,6 @@
                 "Value" : "application"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=SPA_COMPONENT_TYPE
     attributes=
         [
             {
@@ -192,7 +188,7 @@
             },
             {
                 "Names" : "Profiles",
-                "Children" : profileChildConfiguration + [
+                "Children" : [
                     {
                         "Names" : "Security",
                         "Type" : STRING_TYPE,

--- a/providers/shared/component/sqs.ftl
+++ b/providers/shared/component/sqs.ftl
@@ -17,10 +17,6 @@
                 "Value" : "solution"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=SQS_COMPONENT_TYPE
     attributes=
         [
             {
@@ -52,10 +48,6 @@
             {
                 "Names" : "VisibilityTimeout",
                 "Type" : NUMBER_TYPE
-            },
-            {
-                "Names" : "Profiles",
-                "Children" : profileChildConfiguration
             },
             {
                 "Names" : "Alerts",

--- a/providers/shared/component/user.ftl
+++ b/providers/shared/component/user.ftl
@@ -17,11 +17,6 @@
                 "Value" : "application"
             }
         ]
-    dependencies=[APIGATEWAY_COMPONENT_TYPE, APIGATEWAY_USAGEPLAN_COMPONENT_TYPE]
-/]
-
-[@addComponentResourceGroup
-    type=USER_COMPONENT_TYPE
     attributes=
         [
             {
@@ -33,10 +28,6 @@
                 "Names" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration
-            },
-            {
-                "Names" : "Profiles",
-                "Children" : profileChildConfiguration
             },
             {
                 "Names" : "GenerateCredentials",
@@ -86,4 +77,5 @@
                 ]
             }
         ]
+    dependencies=[APIGATEWAY_COMPONENT_TYPE]
 /]

--- a/providers/shared/component/userpool.ftl
+++ b/providers/shared/component/userpool.ftl
@@ -30,10 +30,6 @@
                 "Severity" : "warning"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=USERPOOL_COMPONENT_TYPE
     attributes=
         [
             {
@@ -112,10 +108,6 @@
                 "Children" : linkChildrenConfiguration
             },
             {
-                "Names" : "Profiles",
-                "Children" : profileChildConfiguration
-            },
-            {
                 "Names" : "DefaultClient",
                 "Type" : BOOLEAN_TYPE,
                 "Description" : "Enable default client mode which creates app client for the user pool and aligns with legacy config",
@@ -173,13 +165,6 @@
                 "Value" : "solution"
             }
         ]
-    parent=USERPOOL_COMPONENT_TYPE
-    childAttribute="Clients"
-    linkAttributes="Client"
-/]
-
-[@addComponentResourceGroup
-    type=USERPOOL_CLIENT_COMPONENT_TYPE
     attributes=
         [
             {
@@ -229,6 +214,9 @@
                 "Children" : linkChildrenConfiguration
             }
         ]
+    parent=USERPOOL_COMPONENT_TYPE
+    childAttribute="Clients"
+    linkAttributes="Client"
 /]
 
 [@addChildComponent
@@ -248,13 +236,6 @@
                 "Value" : "solution"
             }
         ]
-    parent=USERPOOL_COMPONENT_TYPE
-    childAttribute="AuthProviders"
-    linkAttributes="AuthProvider"
-/]
-
-[@addComponentResourceGroup
-    type=USERPOOL_AUTHPROVIDER_COMPONENT_TYPE
     attributes=
         [
             {
@@ -305,4 +286,7 @@
                 ]
             }
         ]
+    parent=USERPOOL_COMPONENT_TYPE
+    childAttribute="AuthProviders"
+    linkAttributes="AuthProvider"
 /]


### PR DESCRIPTION
Allow different subsets of a component's resources to be deployed
to different accounts/regions.

The subsets are called Resource Groups. The deployment details is called a placement.

For now, placements are assumed to provide provider and deployment
framework information. A subsequent change will look up the provider
based on the account. A default provider of AWS and deployment framework
of cloud formation are used for backwards compatibility.

The component designer decides which resources can be deployed to different
placements, thus deciding how many resource groups are needed.

Each group is then given a name in the component configuration, independent
of the provider. Each group is also assigned a name for the
placement to be used.

Every component has a "default" resource group where the bulk of its
resources are typically created. It uses "PRODUCT_PLACEMENT" as its
placement name.

Each resource group can have "shared" attributes which are expected for
all implementations. It can also have provider specific attributes which
will be expected depending on the placement of the resource group.

Placement names are mapped to actual placement details via a placement
profile. Placement profiles can be configured at the product and tenant
level, and support qualification.

When a component needs to be processed, the logic first needs to
determine the placement details to determine the provider to be used.
This in turn defines the set of attributes required, and the processing
needed to create the component and manage its state.

To implement the above, the macros for creating the component
configuration have been adjusted to create the default resource group
for each component.

The template loading logic was extended to work off the resource group
placement information, along with the process of determining the
processing macros to be used.

The handling of special attributes used for profile and placement
handling, along with the standard attributes all component have, was
modified such that they are added to the configuration provided by the
component configuration files. This permits documentation generated from
the component configuration to show the full range of configuration
options. Attributes are ordered so these framework injected attributes
appear last in the list of attributes, so that documentation can focus
the reader's attention on the unique attributes of the component.

A hook has also been added to permit each provider specific
implementation of a component to specify the provider specific services
it uses, and for these to then be loaded whenever that implementation is
required. A subsequent change will use this mechanism to move all of the
remaining service configuration in the original template tree across to
the new provider based tree.