### PR TITLE
<feat> Federated Roles

### DIFF
--- a/aws/templates/common.ftl
+++ b/aws/templates/common.ftl
@@ -1359,7 +1359,9 @@ behaviour.
                                 },
                                 "Component" : {
                                     "Id" : componentId,
+                                    "RawId" : component.Id,
                                     "Name" : componentName,
+                                    "RawName" : component.Name,
                                     "Type" : type
                                 },
                                 "Instance" : {

--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -970,14 +970,14 @@ function update_cognito_userpool_authprovider() {
   local authprovidertype="$1"; shift
   local configfile="$1"; shift
 
-  current_provider_type="$(aws --region "${region}" cognito-idp decribe-identity-provider --user-pool-id "${userpoolid}" --provider-name "${authprovidername}" --query "IdentityProvider.ProviderType" --output text 2>/dev/null || true )" 
+  current_provider_type="$(aws --region "${region}" cognito-idp describe-identity-provider --user-pool-id "${userpoolid}" --provider-name "${authprovidername}" --query "IdentityProvider.ProviderType" --output text 2>/dev/null || true )" 
 
-  if [[ ( "${current_provider_type}" != "${authprovidertype}" ) && -n "${current_provider_type}" ]]; then
+  if [[ -n "${current_provider_type}" && ( "${current_provider_type}" != "${authprovidertype}" ) ]]; then
     # delete the provider if the type is different
     aws --region "${region}" cognito-idp delete-identity-provider --user-pool-id "${userpoolid}" --provider-name "${authprovidername}" || return $?
   fi 
 
-  if [[ -n "${current_provider_type}" || "${current_provider_type}" != "${authprovidertype}" ]]; then
+  if [[ -z "${current_provider_type}" || ( "${current_provider_type}" != "${authprovidertype}" ) ]]; then
     # create the provider 
     aws --region "${region}" cognito-idp create-identity-provider --user-pool-id "${userpoolid}" --provider-name "${authprovidername}" --provider-type "${authprovidertype}" --cli-input-json "file://${configfile}" || return $?
   fi
@@ -995,14 +995,14 @@ function cleanup_cognito_userpool_authproviders() {
   local expectedproviders="$1"; shift
   local removeall="$1"; shift
 
-  current_providers="$(aws --region "${region}" cognito_idp list-identity-providers --user-pool-id "${userpoolid}" --query "Providers[*].ProviderName" --output text || true)"
+  current_providers="$(aws --region "${region}" cognito-idp list-identity-providers --user-pool-id "${userpoolid}" --query "Providers[*].ProviderName" --output text)"
 
   if [[ "${current_providers}" != "None" && -n "${current_providers}" ]]; then
     arrayFromList expected_provider_list "${expectedproviders}"
-    arrayFromCommand current_provider_list "${current_providers}"
+    arrayFromList current_provider_list "${current_providers}"
 
-    for provider in "${current_provider_list[@]}"; do
-      if [[ ! $(inArray "expected_provider_list" "${provider}") || "${removeall}" == "true" ]]; then
+    for provider in "${current_provider_list[@]}"; do 
+      if [[ $( ! inArray "expected_provider_list" "${provider}" ) || "${removeall}" == "true" ]]; then
         info "Removing auth provider ${provider} from ${userpoolid}"
         aws --region "${region}" cognito-idp delete-identity-provider --user-pool-id "${userpoolid}" --provider-name "${provider}" || return $?
       fi

--- a/providers/aws/component/federatedrole/setup.ftl
+++ b/providers/aws/component/federatedrole/setup.ftl
@@ -74,13 +74,15 @@
         [/#if]
     [/#list]
 
-    [@createIdentityPool
-        mode=listMode
-        id=identityPoolId
-        name=identityPoolName
-        cognitoIdProviders=federationCognitoProviders
-        allowUnauthenticatedIdentities=solution.AllowUnauthenticatedUsers
-    /]
+    [#if deploymentSubsetRequired(USERPOOL_COMPONENT_TYPE, true) ]
+        [@createIdentityPool
+            mode=listMode
+            id=identityPoolId
+            name=identityPoolName
+            cognitoIdProviders=federationCognitoProviders
+            allowUnauthenticatedIdentities=solution.AllowUnauthenticatedUsers
+        /]
+    [/#if]
 
     [#-- Assignment Management --]
     [#local authenticatedRole= ""]

--- a/providers/aws/component/federatedrole/setup.ftl
+++ b/providers/aws/component/federatedrole/setup.ftl
@@ -1,0 +1,282 @@
+[#ftl]
+[#macro aws_federatedrole_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@cfScript
+            mode=listMode
+            content=
+                getGenerationPlan(["template"])
+        /]
+        [#return]
+    [/#if]
+
+    [@cfDebug listMode occurrence false /]
+
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+    [#local resources = occurrence.State.Resources]
+
+    [#local identityPoolId = resources["identitypool"].Id ]
+    [#local identityPoolName = resources["identitypool"].Name ]
+    
+    [#local roleMappingId = resources["rolemapping"].Id ]
+    
+    [#local fragment = getOccurrenceFragmentBase(occurrence) ]
+    [#local _parentContext =
+        {
+            "Id" : fragment,
+            "Name" : fragment,
+            "Instance" : core.Instance.Id,
+            "Version" : core.Version.Id
+        }
+    ]
+    [#local fragmentId = formatFragmentId(_parentContext)]
+
+    [#local federationProviders = {}]
+    [#local federationCognitoProviders = [] ]
+
+    [#list solution.Links as id,link]
+        [#if link?is_hash]
+            [#local linkTarget = getLinkTarget( occurrence, link ) ]
+
+            [@cfDebug listMode linkTarget false /]
+
+            [#if !linkTarget?has_content]
+                [#continue]
+            [/#if]
+
+            [#local linkTargetCore = linkTarget.Core ]
+            [#local linkTargetConfiguration = linkTarget.Configuration ]
+            [#local linkTargetResources = linkTarget.State.Resources ]
+            [#local linkTargetAttributes = linkTarget.State.Attributes ]
+
+            [#switch linkTargetCore.Type]
+                [#case USERPOOL_CLIENT_COMPONENT_TYPE ]
+                [#case USERPOOL_COMPONENT_TYPE ]
+
+                    [#local userPoolName = linkTargetAttributes["USER_POOL_NAME"] ]
+                    [#local userPoolClient = linkTargetAttributes["CLIENT"] ]
+
+                    [#local federationProviders +=  
+                                {
+                                    id : { 
+                                        "Provider" : concatenate( [ userPoolName, userPoolClient], ":" ),
+                                        "Rules" : []
+                                    }
+                                }]
+
+                    [#local federationCognitoProviders += 
+                                getIdentityPoolCognitoProvider( 
+                                    userPoolName,
+                                    userPoolClient
+                                )]  
+                    [#break]
+            [/#switch]
+        [/#if]
+    [/#list]
+
+    [@createIdentityPool
+        mode=listMode
+        id=identityPoolId
+        name=identityPoolName
+        cognitoIdProviders=federationCognitoProviders
+        allowUnauthenticatedIdentities=solution.AllowUnauthenticatedUsers
+    /]
+
+    [#-- Assignment Management --]
+    [#local authenticatedRole= ""]
+    [#local unauthenticatedRole = ""]
+    [#local ruleAssignments = {} ]
+
+    [#list occurrence.Occurrences![] as subOccurrence]
+
+        [#local subCore = subOccurrence.Core ]
+        [#local subSolution = subOccurrence.Configuration.Solution ]
+        [#local subResources = subOccurrence.State.Resources ]
+
+        [#if !subSolution.Enabled]
+            [#continue]
+        [/#if]
+
+        [#local roleId = subResources["role"].Id ]
+
+        [#local contextLinks = getLinkTargets(subOccurrence)]
+
+        [#assign _context =
+            {
+                "Id" : fragment,
+                "Name" : fragment,
+                "Instance" : core.Instance.Id,
+                "Version" : core.Version.Id,
+                "Links" : contextLinks,
+                "Policy" : standardPolicies(subOccurrence),
+                "ManagedPolicy" : [],
+                "Assignment" : subCore.SubComponent.Id
+            }
+        ]
+
+        [#switch subSolution.Type ]
+            [#case "Authenticated" ]
+                [#if ! authenticatedRole?has_content ]
+                    [#local authenticatedRole = roleId ]
+                [#else]
+                    [@cfException
+                        mode=listMode
+                        description="Only one assignment of this type is possible"
+                        context=
+                            {
+                                "Type" : subSolution.Type,
+                                "Asignment" : subOccurrence
+                            }
+                    /]
+                [/#if]
+                [#break]
+
+            [#case "Unauthenticated" ]
+                [#if ! unauthenticatedRole?has_content ]
+                    [#local unauthenticatedRole = roleId ]
+                [#else]
+                    [@cfException
+                        mode=listMode
+                        description="Only one assignment of this type is possible"
+                        context=
+                            {
+                                "Type" : subSolution.Type,
+                                "Asignment" : subOccurrence
+                            }
+                    /]
+                [/#if]
+                [#break]
+
+            [#case "Rule" ]
+
+                [#local mappingRule = getIdentityPoolMappingRule( 
+                                            (subSolution.Rule.Priority + subOccurrence?counter),
+                                            subSolution.Rule.Claim,
+                                            subSolution.Rule.MatchType,
+                                            subSolution.Rule.Value,
+                                            roleId
+                                    )]
+
+                [#list subSolution.Rule.Providers as provider ]
+                    [#local federationProvider = federationProviders[ provider ]]
+                    [#if federationProvider?has_content]  
+                    
+                        [#local federationProviderRules = federationProvider["Rules"] + mappingRule ]
+
+                        
+                        [#local federationProviders = mergeObjects( federationProviders, 
+                                                            {
+                                                                provider : {
+                                                                    "Rules" : federationProviderRules 
+                                                                }
+                                                            }
+                        
+                        )]
+                    [/#if]
+                [/#list]
+                    
+                [#break]
+        [/#switch]
+
+        [#-- Add in fragment specifics including override of defaults --]
+        [#assign fragmentListMode = "model"]
+        [#include fragmentList?ensure_starts_with("/")]
+
+        [#local managedPolicies = _context.ManagedPolicy ]
+        [#local linkPolicies = getLinkTargetsOutboundRoles(_context.Links) ]
+
+        [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(roleId)]
+
+            [@createRole
+                mode=listMode
+                id=roleId
+                federatedServices="cognito-identity.amazonaws.com"
+                condition={
+                    "StringEquals": {
+                        "cognito-identity.amazonaws.com:aud": getReference(identityPoolId)
+                    },
+                    "ForAnyValue:StringLike": {
+                        "cognito-identity.amazonaws.com:amr": valueIfTrue(
+                                                                "unauthenticated",
+                                                                subCore.Type == "Unauthenticated",
+                                                                "authenticated"
+                        )
+                    }
+                }
+                managedArns=managedPolicies
+            /]
+
+            [#if _context.Policy?has_content]
+                [#local policyId = formatDependentPolicyId(subCore.Id)]
+                [@createPolicy
+                    mode=listMode
+                    id=policyId
+                    name=_context.Name
+                    statements=_context.Policy
+                    roles=roleId
+                /]
+            [/#if]
+
+            [#if linkPolicies?has_content]
+                [#local policyId = formatDependentPolicyId(subCore.Id, "links")]
+                [@createPolicy
+                    mode=listMode
+                    id=policyId
+                    name="links"
+                    statements=linkPolicies
+                    roles=roleId
+                /]
+            [/#if]
+        [/#if]
+    [/#list]
+
+    [#if deploymentSubsetRequired(USERPOOL_COMPONENT_TYPE, true) ]
+
+        [#if solution.AllowUnauthenticatedUsers && ! unauthenticatedRole?has_content ]
+            [@cfException
+                mode=listMode
+                description="No unauthenicated assignments found"
+                context=solution
+            /]
+        [/#if]
+
+        [#if ! authenticatedRole?has_content && ! ruleAssignments ]
+            [@cfException
+                mode=listMode
+                description="No authenticated assignments found"
+                context=solution
+            /]
+        [/#if]
+
+        [#list federationProviders as id,federationProvider ]
+            [#if federationProvider?is_hash ]
+                [#if (federationProvider["Rules"]![])?has_content ]
+
+                    [#local providerRules = [] ]
+                    [#list federationProvider["Rules"]?sort_by("Priority") as rule  ]
+                        [#local providerRules += [ rule.Rule ]]
+                    [/#list]
+
+                    [#local ruleAssignments += 
+                            getIdentityPoolRoleMapping( 
+                                federationProvider["Provider"],
+                                subSolution.Type,
+                                providerRules,
+                                solution.NoMatchBehaviour
+                            )]
+                [/#if]
+            [/#if]
+        [/#list]
+
+        [@createIdentityPoolRoleMapping
+            mode=listMode
+            id=roleMappingId
+            identityPoolId=identityPoolId
+            roleMappings=ruleAssignments
+            authenticatedRoleId=authenticatedRole
+            unauthenticatedRoleId=unauthenticatedRole
+        /]
+    [/#if]
+[/#macro]
+
+

--- a/providers/aws/component/federatedrole/state.ftl
+++ b/providers/aws/component/federatedrole/state.ftl
@@ -1,0 +1,49 @@
+[#ftl]
+
+[#macro aws_federatedrole_cf_state occurrence parent={} baseState={}  ]
+    [#local core = occurrence.Core]
+
+    [#assign componentState = 
+        {
+            "Resources" : {
+                "identitypool" : {
+                    "Id" : formatResourceId(AWS_COGNITO_IDENTITYPOOL_RESOURCE_TYPE, core.Id),
+                    "Name" : core.FullName,
+                    "Type" : AWS_COGNITO_IDENTITYPOOL_RESOURCE_TYPE
+                },
+                "rolemapping" : {
+                    "Id" : formatResourceId(AWS_COGNITO_IDENTITYPOOL_ROLEMAPPING_RESOURCE_TYPE, core.Id ),
+                    "Type" : AWS_COGNITO_IDENTITYPOOL_ROLEMAPPING_RESOURCE_TYPE
+                }
+            },
+            "Attributes" : {
+            },
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+
+[/#macro]
+
+[#macro aws_federatedroleassignment_cf_state occurrence parent={} baseState={}  ]
+    [#local core = occurrence.Core]
+
+    [#assign componentState = 
+        {
+            "Resources" : {
+                "role" : {
+                    "Id" : formatResourceId(AWS_IAM_ROLE_RESOURCE_TYPE, core.Id),
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                }
+            },
+            "Attributes" : {
+            },
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#macro]

--- a/providers/aws/component/federatedrole/state.ftl
+++ b/providers/aws/component/federatedrole/state.ftl
@@ -8,7 +8,7 @@
             "Resources" : {
                 "identitypool" : {
                     "Id" : formatResourceId(AWS_COGNITO_IDENTITYPOOL_RESOURCE_TYPE, core.Id),
-                    "Name" : core.FullName,
+                    "Name" : replaceAlphaNumericOnly(core.FullName, "X"),
                     "Type" : AWS_COGNITO_IDENTITYPOOL_RESOURCE_TYPE
                 },
                 "rolemapping" : {

--- a/providers/aws/component/userpool/setup.ftl
+++ b/providers/aws/component/userpool/setup.ftl
@@ -27,11 +27,6 @@
         [#local userPoolCustomDomainCertArn = resources["customdomain"].CertificateArn]
     [/#if]
 
-    [#local userPoolRoleId             = resources["userpoolrole"].Id]
-
-    [#local identityPoolId             = resources["identitypool"].Id]
-    [#local identityPoolName           = resources["identitypool"].Name]
-
     [#local smsVerification = false]
     [#local userPoolTriggerConfig = {}]
     [#local userPoolManualTriggerConfig = {}]
@@ -316,7 +311,6 @@
                 [/#switch]
 
                 [#local updateUserPoolAuthProvider =  {
-                        "ProviderType" : authProviderEngine,
                         "AttributeMapping" : attributeMappings,
                         "ProviderDetails" : providerDetails
                     } +
@@ -383,7 +377,7 @@
                     [#local linkTarget = getLinkTarget(occurrence,
                                             {
                                                 "Tier" : core.Tier.Id,
-                                                "Component" : core.Component.Id,
+                                                "Component" : core.Component.RawId,
                                                 "AuthProvider" : authProvider
                                             })]
                     [#if linkTarget?has_content ]

--- a/providers/aws/component/userpool/setup.ftl
+++ b/providers/aws/component/userpool/setup.ftl
@@ -374,12 +374,15 @@
                 [#if authProvider?upper_case == "COGNITO" ]
                     [#local identityProviders += [ "COGNITO" ] ]
                 [#else]
-                    [#local linkTarget = getLinkTarget(occurrence,
-                                            {
-                                                "Tier" : core.Tier.Id,
-                                                "Component" : core.Component.RawId,
-                                                "AuthProvider" : authProvider
-                                            })]
+                    [#local linkTarget = getLinkTarget(
+                                                occurrence,
+                                                {
+                                                    "Tier" : core.Tier.Id,
+                                                    "Component" : core.Component.RawId,
+                                                    "AuthProvider" : authProvider
+                                                }, 
+                                                false
+                                            )]
                     [#if linkTarget?has_content ]
                         [#local identityProviders += [ linkTarget.State.Attributes["PROVIDER_NAME"] ]]
                     [/#if]

--- a/providers/aws/component/userpool/setup.ftl
+++ b/providers/aws/component/userpool/setup.ftl
@@ -31,7 +31,6 @@
     [#local userPoolTriggerConfig = {}]
     [#local userPoolManualTriggerConfig = {}]
     [#local smsConfig = {}]
-    [#local identityPoolProviders = []]
     [#local authProviders = []]
 
     [#local defaultUserPoolClientRequired = false ]
@@ -361,10 +360,6 @@
 
             [#local userPoolClientId           = subResources["client"].Id]
             [#local userPoolClientName         = subResources["client"].Name]
-            [#local identityPoolProviders      += subSolution.IdentityPoolAccess?then(
-                                                    [getIdentityPoolCognitoProvider( userPoolId, userPoolClientId )],
-                                                    []
-                                                )]
 
             [#local callbackUrls = []]
             [#local logoutUrls = []]

--- a/providers/aws/component/userpool/setup.ftl
+++ b/providers/aws/component/userpool/setup.ftl
@@ -31,9 +31,6 @@
 
     [#local identityPoolId             = resources["identitypool"].Id]
     [#local identityPoolName           = resources["identitypool"].Name]
-    [#local identityPoolUnAuthRoleId   = resources["unauthrole"].Id]
-    [#local identityPoolAuthRoleId     = resources["authrole"].Id]
-    [#local identityPoolRoleMappingId  = resources["rolemapping"].Id]
 
     [#local smsVerification = false]
     [#local userPoolTriggerConfig = {}]
@@ -550,65 +547,6 @@
             smsConfiguration=smsConfig
         /]
 
-        [@createIdentityPool
-            mode=listMode
-            component=core.Component
-            tier=core.Tier
-            id=identityPoolId
-            name=identityPoolName
-            cognitoIdProviders=identityPoolProviders
-            allowUnauthenticatedIdentities=solution.AllowUnauthenticatedIds
-        /]
-
-        [@createRole
-            mode=listMode
-            id=identityPoolUnAuthRoleId
-            policies=[
-                getPolicyDocument(
-                    getUserPoolUnAuthPolicy(),
-                    "DefaultUnAuthIdentityRole"
-                )
-            ]
-            federatedServices="cognito-identity.amazonaws.com"
-            condition={
-                "StringEquals": {
-                    "cognito-identity.amazonaws.com:aud": getReference(identityPoolId)
-                },
-                "ForAnyValue:StringLike": {
-                    "cognito-identity.amazonaws.com:amr": "unauthenticated"
-                }
-            }
-        /]
-
-        [@createRole
-            mode=listMode
-            id=identityPoolAuthRoleId
-            policies=[
-                getPolicyDocument(
-                    getUserPoolAuthPolicy(),
-                    "DefaultAuthIdentityRole"
-                )
-            ]
-            federatedServices="cognito-identity.amazonaws.com"
-            condition={
-                "StringEquals": {
-                    "cognito-identity.amazonaws.com:aud": getReference(identityPoolId)
-                },
-                "ForAnyValue:StringLike": {
-                    "cognito-identity.amazonaws.com:amr": "authenticated"
-                }
-            }
-        /]
-
-        [@createIdentityPoolRoleMapping
-            mode=listMode
-            component=core.Component
-            tier=core.Tier
-            id=identityPoolRoleMappingId
-            identityPoolId=getReference(identityPoolId)
-            authenticatedRoleArn=getReference(identityPoolAuthRoleId, ARN_ATTRIBUTE_TYPE)
-            unauthenticatedRoleArn=getReference(identityPoolUnAuthRoleId, ARN_ATTRIBUTE_TYPE)
-        /]
     [/#if]
     [#-- When using the cli to update a user pool, any properties that are not set in the update are reset to their default value --]
     [#-- So to use the CLI to update the lambda triggers we need to generate all of the custom configuration we use in the CF template and use this as the update --]

--- a/providers/aws/component/userpool/state.ftl
+++ b/providers/aws/component/userpool/state.ftl
@@ -21,6 +21,7 @@
                 },
                 "Attributes" : {
                     "USER_POOL_ARN" : baseState.Attributes["USERPOOL_ARN"],
+                    "USER_POOL_NAME" : baseState.Attributes["USERPOOL_NAME"],
                     "CLIENT" : baseState.Attributes["USERPOOL_CLIENTID" ]!"",
                     "USER_POOL" : baseState.Attributes["USERPOOL_ID"]!"",
                     "IDENTITY_POOL" : baseState.Attributes["USERPOOL_IDENTITYPOOL_ID"]!"",
@@ -45,15 +46,7 @@
         [#local defaultUserPoolClientName = formatSegmentFullName(core.Name)]
         [#local defaultUserPoolClientRequired = solution.DefaultClient ]
 
-        [#local identityPoolId = formatResourceId(AWS_COGNITO_IDENTITYPOOL_RESOURCE_TYPE, core.Id)]
-        [#local identityPoolName = formatSegmentFullName(core.Name)?replace("-","X")]
-
-        [#local identityPoolRoleMappingId = formatDependentResourceId(AWS_COGNITO_IDENTITYPOOL_ROLEMAPPING_RESOURCE_TYPE, identityPoolId)]
-
         [#local userPoolRoleId = formatComponentRoleId(core.Tier, core.Component)]
-
-        [#local identityPoolUnAuthRoleId = formatDependentRoleId(identityPoolId,USERPOOL_COMPONENT_ROLE_UNAUTH_EXTENSTION )]
-        [#local identityPoolAuthRoleId = formatDependentRoleId(identityPoolId,USERPOOL_COMPONENT_ROLE_AUTH_EXTENSTION )]
 
         [#local userPoolDomainId = formatResourceId(AWS_COGNITO_USERPOOL_DOMAIN_RESOURCE_TYPE, core.Id)]
         [#local certificatePresent = isPresent(solution.HostedUI.Certificate) ]
@@ -91,27 +84,6 @@
                         "Id" : userPoolDomainId,
                         "Name" : userPoolDomainName,
                         "Type" : AWS_COGNITO_USERPOOL_DOMAIN_RESOURCE_TYPE
-                    },
-                    "identitypool" : {
-                        "Id" : identityPoolId,
-                        "Name" : identityPoolName,
-                        "Type" : AWS_COGNITO_IDENTITYPOOL_RESOURCE_TYPE
-                    },
-                    "userpoolrole" : {
-                        "Id" : userPoolRoleId,
-                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
-                    },
-                    "unauthrole" : {
-                        "Id" : identityPoolUnAuthRoleId,
-                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
-                    },
-                    "authrole" : {
-                        "Id" : identityPoolAuthRoleId,
-                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
-                    },
-                    "rolemapping" : {
-                        "Id" : identityPoolRoleMappingId,
-                        "Type" : AWS_COGNITO_IDENTITYPOOL_ROLEMAPPING_RESOURCE_TYPE
                     }
                 } +
                 defaultUserPoolClientRequired?then(
@@ -138,8 +110,8 @@
                 "Attributes" : {
                     "API_AUTHORIZATION_HEADER" : occurrence.Configuration.Solution.AuthorizationHeader,
                     "USER_POOL" : getExistingReference(userPoolId),
+                    "USER_POOL_NAME" : getExistingReference(userPoolId, NAME_ATTRIBUTE_TYPE),
                     "USER_POOL_ARN" : getExistingReference(userPoolId, ARN_ATTRIBUTE_TYPE),
-                    "IDENTITY_POOL" : getExistingReference(identityPoolId),
                     "REGION" : region,
                     "UI_INTERNAL_BASE_URL" : userPoolBaseUrl,
                     "UI_INTERNAL_FQDN" : userPoolFQDN,

--- a/providers/shared/component/component.ftl
+++ b/providers/shared/component/component.ftl
@@ -575,6 +575,10 @@
             "Type" : STRING_TYPE
         },
         {
+            "Names" : [ "Assignment" ],
+            "Type" : STRING_TYPE
+        }
+        {
             "Names" : "Instance",
             "Type" : STRING_TYPE
         },

--- a/providers/shared/component/component.ftl
+++ b/providers/shared/component/component.ftl
@@ -78,6 +78,9 @@
 [#assign USERPOOL_CLIENT_COMPONENT_TYPE = "userpoolclient" ]
 [#assign USERPOOL_AUTHPROVIDER_COMPONENT_TYPE = "userpoolauthprovider" ]
 
+[#assign FEDERATEDROLE_COMPONENT_TYPE = "federatedrole" ]
+[#assign FEDERATEDROLE_ASSIGNMENT_COMPONENT_TYPE = "federatedroleassignment" ]
+
 [#-- Component configuration is extended dynamically by each component type --]
 [#assign componentConfiguration = {} ]
 

--- a/providers/shared/component/federatedrole.ftl
+++ b/providers/shared/component/federatedrole.ftl
@@ -113,10 +113,6 @@
                 "Children" : linkChildrenConfiguration
             },
             {
-                "Names" : "Profiles",
-                "Children" : profileChildConfiguration
-            },
-                        {
                 "Names" : "Permissions",
                 "Children" : [
                     {

--- a/providers/shared/component/federatedrole.ftl
+++ b/providers/shared/component/federatedrole.ftl
@@ -1,0 +1,157 @@
+[#ftl]
+
+[@addComponent
+    type=FEDERATEDROLE_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "Provides access to resources using an external identity source "
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+/]
+
+[@addComponentResourceGroup
+    type=FEDERATEDROLE_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : ["Fragment", "Container"],
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration
+            },
+            {
+                "Names" : "NoMatchBehaviour",
+                "Description" : "When using rule assignements how to behave on no match",
+                "Values" : [ "UseAuthenticated", "Deny" ],
+                "Default" : "Deny",
+                "Type" : STRING_TYPE
+            },
+            {
+                "Names" : "AllowUnauthenticatedUsers",
+                "Description" : "Allow unautheniated users to use a federated role",
+                "Default" : false,
+                "Type" : BOOLEAN_TYPE
+            }
+        ]
+/]
+
+
+[@addChildComponent
+    type=FEDERATEDROLE_ASSIGNMENT_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "A rule based role assignment of permissions"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+    parent=FEDERATEDROLE_COMPONENT_TYPE
+    childAttribute="Assignments"
+    linkAttributes="Assignment"
+/]
+
+[@addComponentResourceGroup
+    type=FEDERATEDROLE_ASSIGNMENT_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "Type",
+                "Description" : "How the assignment should be applied",
+                "Values" : [ "Authenticated", "Unauthenticated", "Rule" ],
+                "Mandatory" : true,
+                "Type" : STRING_TYPE
+            },
+            {
+                "Names" : "Rule",
+                "Children" : [
+                    {
+                        "Names" : "Priority",
+                        "Description" : "The order the rule should be evalutated in. lowest wins",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : 100
+                    },
+                    {
+                        "Names" : "Claim",
+                        "Description" : "The user claim to evalutate",
+                        "Type" : STRING_TYPE
+                    },
+                    {
+                        "Names" : "MatchType",
+                        "Description" : "How to match the claim value",
+                        "Values" : [ "Equals", "Contains", "StartsWith", "NotEqual" ],
+                        "Type" : STRING_TYPE
+                    },
+                    {
+                        "Names" : "Value",
+                        "Description" : "The value of the claim to match on",
+                        "Type" : STRING_TYPE
+                    },
+                    {
+                        "Names" : "Providers",
+                        "Description" : "The link ids of the providers the assignment applies to",
+                        "Type" : ARRAY_OF_STRING_TYPE
+                    }
+                ]
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : profileChildConfiguration
+            },
+                        {
+                "Names" : "Permissions",
+                "Children" : [
+                    {
+                        "Names" : "Decrypt",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "AsFile",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "AppData",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "AppPublic",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    }
+                ]
+            }
+        ]
+/]

--- a/providers/shared/component/federatedrole.ftl
+++ b/providers/shared/component/federatedrole.ftl
@@ -17,10 +17,6 @@
                 "Value" : "solution"
             }
         ]
-/]
-
-[@addComponentResourceGroup
-    type=FEDERATEDROLE_COMPONENT_TYPE
     attributes=
         [
             {
@@ -74,10 +70,6 @@
     parent=FEDERATEDROLE_COMPONENT_TYPE
     childAttribute="Assignments"
     linkAttributes="Assignment"
-/]
-
-[@addComponentResourceGroup
-    type=FEDERATEDROLE_ASSIGNMENT_COMPONENT_TYPE
     attributes=
         [
             {

--- a/providers/shared/component/federatedrole.ftl
+++ b/providers/shared/component/federatedrole.ftl
@@ -30,10 +30,6 @@
                 "Children" : linkChildrenConfiguration
             },
             {
-                "Names" : "Profiles",
-                "Children" : profileChildConfiguration
-            },
-            {
                 "Names" : "NoMatchBehaviour",
                 "Description" : "When using rule assignements how to behave on no match",
                 "Values" : [ "UseAuthenticated", "Deny" ],

--- a/providers/shared/component/userpool.ftl
+++ b/providers/shared/component/userpool.ftl
@@ -1,8 +1,5 @@
 [#ftl]
 
-[#assign USERPOOL_COMPONENT_ROLE_UNAUTH_EXTENSTION = "unauth" ]
-[#assign USERPOOL_COMPONENT_ROLE_AUTH_EXTENSTION = "auth" ]
-
 [@addComponent
     type=USERPOOL_COMPONENT_TYPE
     properties=
@@ -61,11 +58,6 @@
                 "Names" : "LoginAliases",
                 "Type" : ARRAY_OF_STRING_TYPE,
                 "Default" : ["email"]
-            },
-            {
-                "Names" : "AllowUnauthenticatedIds",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
             },
             {
                 "Names" : "AuthorizationHeader",
@@ -195,12 +187,6 @@
                 "Description" : "Time in days that the refresh token is valid for",
                 "Type" : NUMBER_TYPE,
                 "Default" : 30
-            },
-            {
-                "Names" : "IdentityPoolAccess",
-                "Description" : "Enable the use of the identity pool for this client",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : true
             },
             {
                 "Names" : "AuthProviders",


### PR DESCRIPTION
Federated roles provide cloud provider resource credentials to users based on external identity sources. This allows for users to use the same credentials to access an application and cloud provider resources directly 


Example: 
```
                "cloudrole" : {
                    "federatedrole" : { 
                        "Instances" : {
                            "default" : {
                                "DeploymentUnits" : [ "cloudrole" ]
                            }
                        },
                        "Fragment" : "_cloudrole",
                        "Links" : {
                            "userpool" : {
                                "Tier" : "dir",
                                "Component" : "app-userpool"
                            }
                        },
                        "Assignments" : {
                            "authenticated" : {
                                "Type" : "Authenticated",
                                "Links" : {
                                    "datastore" : {
                                        "Tier" : "db",
                                        "Component" : "data-s3",
                                        "Role" : "none"
                                    }
                                }
                            }
                        }
                    }
                }
```

Fragment
```
[#case "_cloudrole" ]

    [#if _context.Assignment == "authenticated" ]
        [#if (_context.Links["datastore"]!{})?has_content ]
            [@Policy  
                [
                    getS3Statement( 
                        [
                            "s3:GetObject",
                            "s3:PutObject"
                        ],
                        _context.Links["datastore"].State.Attributes["NAME"],
                        "submissions/$\{cognito-identity.amazonaws.com:sub}",
                        "*"
                    ) + 
                    getS3BucketStatement(
                        [
                            "s3:ListBucket",
                            "s3:ListBucketVersions"
                        ],
                        _context.Links["datastore"].State.Attributes["NAME"],
                        "submissions/$\{cognito-identity.amazonaws.com:sub}"
                    )
                ]
            /]
        [/#if]
    [/#if]

    [#break]
```
In the example all authenticated users can put objects into an S3 bucket if the prefix of the file matches the pattern `submissions/<the users cognito id>` which essentially provides permission control home drives for users

The authenticated type here will apply to all authenticated users. Instead of this you can create Rule based assignments which check user claims and provided roles based on the values of the claims ( e.g. if a user has claim of `isAdmin` you can apply a role based on this being true or not. Rules have priorities and apply the role from the first match.

In AWS federated roles are based on Cognito Federated Identity pools which map attributes from multiple authentication providers, ( Cognito Userpools, SAML, OIDC, Facebook, Google, Amazon ) into an IAM Role. 

The role in turn then can have policies which allow it to access AWS resources like  you normally would 

A `federatedrole` has a parent component which hosts the identity pool and the role mappings and then has `federatedroleassignments` which mange the roles, the permissions they have on AWS resources and the conditions users must meet to be assigned a given role. 

This PR also
 - removes the existing identity pool and role based resources from the `userpool` component. Since federatedroles are a separate concept from user pools and userpools aren't specifically required for a federated role
- Fixes up some bugs in the authprovider cli based config on the `userpool`
