### PR TITLE
<refactor> Template processing

### DIFF
--- a/aws/templates/createAccountTemplate.ftl
+++ b/aws/templates/createAccountTemplate.ftl
@@ -15,4 +15,4 @@
         [#break]
 [/#switch]
 
-[@cfTemplate include=accountList /]
+[@cf_template include=accountList /]

--- a/aws/templates/createApplicationTemplate.ftl
+++ b/aws/templates/createApplicationTemplate.ftl
@@ -25,4 +25,4 @@
 
 [/#switch]
 
-[@cfTemplate level="application" /]
+[@cf_template level="application" /]

--- a/aws/templates/createMultipleTemplate.ftl
+++ b/aws/templates/createMultipleTemplate.ftl
@@ -13,6 +13,6 @@
         [#break]
 [/#switch]
 
-[@cfTemplate level="segment" /]
-[@cfTemplate level="solution" /]
-[@cfTemplate level="application" /]
+[@cf_template level="segment" /]
+[@cf_template level="solution" /]
+[@cf_template level="application" /]

--- a/aws/templates/createProductTemplate.ftl
+++ b/aws/templates/createProductTemplate.ftl
@@ -36,4 +36,4 @@
 [#-- Product --]
 [#assign rotateKeys = (productObject.RotateKeys)!true]
 
-[@cfTemplate include=productList /]
+[@cf_template include=productList /]

--- a/aws/templates/createSegmentTemplate.ftl
+++ b/aws/templates/createSegmentTemplate.ftl
@@ -20,4 +20,4 @@
         [#break]
 [/#switch]
 
-[@cfTemplate level="segment" /]
+[@cf_template level="segment" /]

--- a/aws/templates/createSolutionTemplate.ftl
+++ b/aws/templates/createSolutionTemplate.ftl
@@ -18,4 +18,4 @@
         [#break]
 [/#switch]
 
-[@cfTemplate level="solution" /]
+[@cf_template level="solution" /]

--- a/engine/bootstrap.ftl
+++ b/engine/bootstrap.ftl
@@ -7,5 +7,8 @@
 [#include "component.ftl" ]
 [#include "provider.ftl" ]
 
+[#-- Template hanlding --]
+[#include "template.ftl"]
+
 [#-- Set the context for templates processing --]
 [#include "setContext.ftl" ]

--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -219,8 +219,6 @@
     [#list tiers as tier]
         [#list (tier.Components!{})?values as component]
             [#if deploymentRequired(component, deploymentUnit)]
-                [#assign componentTemplates = {} ]
-                [#assign dashboardRows = []]
                 [#assign multiAZ = component.MultiAZ!solnMultiAZ]
                 [#list requiredOccurrences(
                     getOccurrences(tier, component),

--- a/engine/template.ftl
+++ b/engine/template.ftl
@@ -1,0 +1,48 @@
+[#ftl]
+
+[#-- Support routines for template generation --]
+
+[#-- Text based template --]
+
+[#assign textTemplate = [] ]
+
+[#macro initialiseTextTemplate]
+    [#assign textTemplate = [] ]
+[/#macro]
+
+[#function getTextTemplate]
+    [#return textTemplate]
+[/#function]
+
+[#macro addToTextTemplate lines=[] ]
+    [#assign textTemplate += asFlattenedArray(lines)]
+[/#macro]
+
+[#macro serialiseTextTemplate]
+    [#list textTemplate as line]
+        ${line}
+    [/#list]
+[/#macro]
+
+[#-- JSON object based template --]
+[#assign jsonTemplate = {} ]
+
+[#macro initialiseJsonTemplate]
+    [#assign jsonTemplate = {} ]
+[/#macro]
+
+[#function getJsonTemplate]
+    [#return jsonTemplate]
+[/#function]
+
+[#macro mergeWithJsonTemplate object={} ]
+    [#assign jsonTemplate = mergeObjects(jsonTemplate, object)]
+[/#macro]
+
+[#macro addToJsonTemplate object={} ]
+    [#assign jsonTemplate = jsonTemplate + object]
+[/#macro]
+
+[#macro serialiseJsonTemplate]
+    [@toJSON jsonTemplate /]
+[/#macro]


### PR DESCRIPTION
This is the first of several PRs to rework the processing of templates
to add multi-provider support.

The first step is to factor out some generic processing for standard
output formats (text, json), which is what this change does.

Next step will be to make the top level macro for a template
dynamically.

This PR should be reviewed/merged after https://github.com/codeontap/gen3/pull/833.