### PR TITLE
<refactor> use baselineprofile for all components

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -982,9 +982,7 @@ behaviour.
                 "COMPONENT_VERSION" : core.Version.Name,
                 "REQUEST_REFERENCE" : requestReference,
                 "CONFIGURATION_REFERENCE" : configurationReference,
-                "APPDATA_BUCKET" : dataBucket,
                 "APPDATA_PREFIX" : getAppDataFilePrefix(occurrence),
-                "OPSDATA_BUCKET" : operationsBucket,
                 "APPSETTINGS_PREFIX" : getSettingsFilePrefix(occurrence),
                 "CREDENTIALS_PREFIX" : getSettingsFilePrefix(occurrence),
                 "SETTINGS_PREFIX" : getSettingsFilePrefix(occurrence)

--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -447,13 +447,22 @@
     ]
 [/#function]
 
-[#function getFinalEnvironment occurrence context operationsBucket dataBucket environmentSettings={}]
+[#function getFinalEnvironment occurrence context operationsBucket dataBucket="" environmentSettings={}]
     [#local asFile = environmentSettings.AsFile!false]
     [#local serialisationConfig = environmentSettings.Json!{}]
 
     [#return
         {
             "Environment" :
+                {
+                    "OPSDATA_BUCKET" : operationsBucket
+                } +
+                valueIfContent(
+                    {
+                        "APPDATA_BUCKET" : dataBucket
+                    },
+                    dataBucket
+                ) + 
                 valueIfTrue(
                     getSettingsAsEnvironment(
                         occurrence.Configuration.Settings.Core,

--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -456,11 +456,7 @@
             "Environment" :
                 valueIfTrue(
                     getSettingsAsEnvironment(
-                        occurrence.Configuration.Settings.Core + 
-                        {
-                            "APPDATA_BUCKET" : dataBucket,
-                            "OPSDATA_BUCKET" : operationsBucket
-                        },
+                        occurrence.Configuration.Settings.Core,
                         serialisationConfig
                     ),
                     context.DefaultCoreVariables || asFile
@@ -498,9 +494,11 @@
     [#local solution = task.Configuration.Solution ]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(task.Profiles.Baseline, [ "OpsData", "AppData", "Encryption" ] )]
+    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption" ] )]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
+
+    [@cfDebug listMode operationsBucket true /]
 
     [#local tier = core.Tier ]
     [#local component = core.Component ]

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -247,6 +247,7 @@
 
     [#assign consoleOnly = (segmentObject.ConsoleOnly)!false]
 
+    [#-- 
     [#assign operationsBucket =
         firstContent(
             getExistingReference(formatS3OperationsId()),
@@ -256,6 +257,7 @@
         firstContent(
             getExistingReference(formatS3DataId()),
             formatSegmentBucketName(segmentSeed, "data"))]
+    --]
 
     [#assign operationsExpiration =
         (segmentObject.Operations.Expiration)!

--- a/providers/aws/components/apigateway/setup.ftl
+++ b/providers/aws/components/apigateway/setup.ftl
@@ -36,6 +36,11 @@
                                                 "config",
                                                 swaggerFileName)]
 
+    [#-- Baseline component lookup --]
+    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData" ] )]
+    [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
+    [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
+
     [#local contextLinks = getLinkTargets(occurrence) ]
     [#assign _context =
         {
@@ -60,7 +65,7 @@
             [#include fragmentList?ensure_starts_with("/")]
     [/#if]
 
-    [#local stageVariables += getFinalEnvironment(occurrence, _context).Environment ]
+    [#local stageVariables += getFinalEnvironment(occurrence, _context, operationsBucket, dataBucket).Environment ]
 
     [#local cognitoPools = {} ]
 

--- a/providers/aws/components/baseline/setup.ftl
+++ b/providers/aws/components/baseline/setup.ftl
@@ -339,7 +339,14 @@
                                 "  fi",
                                 "  #"
                             ] +
-                            pseudoStackOutputScript("SSH Key Pair", { formatId(ec2KeyPairId, "name") : "$\{key_pair_name}"}, "keypair") +
+                            pseudoStackOutputScript(
+                                "SSH Key Pair", 
+                                { 
+                                    ec2KeyPairId : "$\{key_pair_name}", 
+                                    formatId(ec2KeyPairId, "name") : "$\{key_pair_name}"
+                                }, 
+                                "keypair"
+                            ) +
                             valueIfTrue(
                                 [
                                     "   info \"Removing old ssh pseduo stack output\"",

--- a/providers/aws/components/bastion/setup.ftl
+++ b/providers/aws/components/bastion/setup.ftl
@@ -37,6 +37,7 @@
     [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
+    [#local sshKeyPairId = baselineComponentIds["SSHKey"]]
 
     [#switch bastionOS ]
         [#case "linux" ]
@@ -270,7 +271,7 @@
                 enableCfnSignal=true
                 environmentId=environmentId
                 sshFromProxy=[]
-                keyPairId=baselineComponentIds["SSHKey"]
+                keyPairId=sshKeyPairId
             /]
         [/#if]
     [/#if]

--- a/providers/aws/components/computecluster/setup.ftl
+++ b/providers/aws/components/computecluster/setup.ftl
@@ -33,6 +33,11 @@
     [#local logFileProfile   = getLogFileProfile(occurrence, "ComputeCluster")]
     [#local bootstrapProfile = getBootstrapProfile(occurrence, "ComputeCluster")]
 
+    [#-- Baseline component lookup --]
+    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
+    [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
+
     [#local occurrenceNetwork = getOccurrenceNetwork(occurrence) ]
     [#local networkLink = occurrenceNetwork.Link!{} ]
 
@@ -139,7 +144,7 @@
     [#local fragmentId = formatFragmentId(_context)]
     [#include fragmentList?ensure_starts_with("/")]
 
-    [#local environmentVariables += getFinalEnvironment(occurrence, _context).Environment ]
+    [#local environmentVariables += getFinalEnvironment(occurrence, _context, operationsBucket, dataBucket ).Environment ]
 
     [#local configSets +=
         getInitConfigEnvFacts(environmentVariables, false) +
@@ -369,6 +374,7 @@
             configSet=configSetName
             enableCfnSignal=(solution.UseInitAsService != true)
             environmentId=environmentId
+            keyPairId=baselineComponentIds["SSHKey"]
         /]
     [/#if]
 [/#macro]

--- a/providers/aws/components/computecluster/setup.ftl
+++ b/providers/aws/components/computecluster/setup.ftl
@@ -99,7 +99,7 @@
 
     [#local configSets =
             getInitConfigDirectories() +
-            getInitConfigBootstrap(occurrence) ]
+            getInitConfigBootstrap(occurrence, operationsBucket, dataBucket) ]
 
     [#local scriptsPath =
             formatRelativePath(

--- a/providers/aws/components/configstore/setup.ftl
+++ b/providers/aws/components/configstore/setup.ftl
@@ -19,6 +19,11 @@
     [#local tableKey = parentResources["table"].Key ]
     [#local tableSortKey = parentResources["table"].SortKey!"" ]
 
+    [#-- Baseline component lookup --]
+    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData" ] )]
+    [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
+    [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
+
     [#local itemInitCommand = "initItem"]
     [#local itemUpdateCommand = "updateItem" ]
     [#local tableCleanupCommand = "cleanupTable" ]
@@ -103,7 +108,7 @@
         [#assign fragmentListMode = "model"]
         [#include fragmentList?ensure_starts_with("/")]
 
-        [#local finalEnvironment = getFinalEnvironment(subOccurrence, _context ) ]
+        [#local finalEnvironment = getFinalEnvironment(subOccurrence, _context, operationsBucket, dataBucket ) ]
         [#assign _context += finalEnvironment ]
 
         [#assign _context +=

--- a/providers/aws/components/datavolume/setup.ftl
+++ b/providers/aws/components/datavolume/setup.ftl
@@ -18,6 +18,12 @@
     [#local manualSnapshotId = resources["manualSnapshot"].Id]
     [#local manualSnapshotName = getExistingReference(manualSnapshotId, NAME_ATTRIBUTE_TYPE)]
 
+
+    [#-- Baseline component lookup --]
+    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "Encryption"] )]
+
+    [#local cmkKeyId = baselineComponentIds["Encryption" ]]
+
     [#local backupEnabled = solution.Backup.Enabled ]
     [#if backupEnabled ]
         [#local maintenanceWindowId = resources["maintenanceWindow"].Id ]
@@ -56,6 +62,7 @@
                 size=solution.Size
                 volumeType=solution.VolumeType
                 encrypted=solution.Encrypted
+                kmsKeyId=cmkKeyId
                 provisionedIops=solution.ProvisionedIops
                 zone=resourceZone
                 snapshotId=manualSnapshotName

--- a/providers/aws/components/ec2/setup.ftl
+++ b/providers/aws/components/ec2/setup.ftl
@@ -65,7 +65,7 @@
     [#local configSetName = occurrence.Core.Type]
     [#local configSets =
             getInitConfigDirectories() +
-            getInitConfigBootstrap(occurrence) +
+            getInitConfigBootstrap(occurrence, operationsBucket, dataBucket) +
             getInitConfigPuppet() ]
 
     [#local efsMountPoints = {}]

--- a/providers/aws/components/ec2/setup.ftl
+++ b/providers/aws/components/ec2/setup.ftl
@@ -32,6 +32,12 @@
     [#local logFileProfile         = getLogFileProfile(occurrence, "EC2")]
     [#local bootstrapProfile       = getBootstrapProfile(occurrence, "EC2")]
 
+    [#-- Baseline component lookup --]
+    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
+    [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
+    [#local sshKeyPairId = baselineComponentIds["SSHKey"] ]
+
     [#local occurrenceNetwork = getOccurrenceNetwork(occurrence) ]
     [#local networkLink = occurrenceNetwork.Link!{} ]
 
@@ -119,7 +125,7 @@
     [#local fragmentId = formatFragmentId(_context)]
     [#include fragmentList?ensure_starts_with("/")]
 
-    [#local environmentVariables += getFinalEnvironment(occurrence, _context).Environment ]
+    [#local environmentVariables += getFinalEnvironment(occurrence, _context, operationsBucket, dataBucket ).Environment ]
 
     [#local configSets +=
         getInitConfigEnvFacts(environmentVariables, false) +
@@ -371,7 +377,7 @@
                             "IamInstanceProfile" : { "Ref" : ec2InstanceProfileId },
                             "InstanceInitiatedShutdownBehavior" : "stop",
                             "InstanceType": processorProfile.Processor,
-                            "KeyName": getExistingReference(formatEC2KeyPairId(), NAME_ATTRIBUTE_TYPE),
+                            "KeyName": getExistingReference(sshKeyPairId, NAME_ATTRIBUTE_TYPE),
                             "Monitoring" : false,
                             "NetworkInterfaces" : [
                                 {

--- a/providers/aws/components/ecs/setup.ftl
+++ b/providers/aws/components/ecs/setup.ftl
@@ -361,7 +361,7 @@
     [#local ecsServiceRoleId = parentResources["serviceRole"].Id ]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption" ] )]
+    [#local baselineComponentIds = getBaselineLinks(parentSolution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption" ] )]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
 
     [#local occurrenceNetwork = getOccurrenceNetwork(occurrence) ]

--- a/providers/aws/components/ecs/setup.ftl
+++ b/providers/aws/components/ecs/setup.ftl
@@ -38,6 +38,12 @@
     [#local logFileProfile = getLogFileProfile(occurrence, "ECS")]
     [#local bootstrapProfile = getBootstrapProfile(occurrence, "ECS")]
 
+    [#-- Baseline component lookup --]
+    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
+    [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
+    [#local sshKeyPairId = baselineComponentIds["SSHKey"] ]
+
     [#local occurrenceNetwork = getOccurrenceNetwork(occurrence) ]
     [#local networkLink = occurrenceNetwork.Link!{} ]
 
@@ -96,7 +102,7 @@
     [#local fragmentId = formatFragmentId(_context)]
     [#include fragmentList?ensure_starts_with("/")]
 
-    [#local environmentVariables += getFinalEnvironment(occurrence, _context).Environment ]
+    [#local environmentVariables += getFinalEnvironment(occurrence, _context, operationsBucket, dataBucket ).Environment ]
 
     [#local configSets +=
         getInitConfigEnvFacts(environmentVariables, false) +
@@ -330,6 +336,7 @@
             configSet=configSetName
             environmentId=environmentId
             enableCfnSignal=solution.AutoScaling.WaitForSignal
+            keyPairId=sshKeyPairId
         /]
     [/#if]
 [/#macro]
@@ -352,6 +359,10 @@
     [#local ecsId = parentResources["cluster"].Id ]
     [#local ecsSecurityGroupId = parentResources["securityGroup"].Id ]
     [#local ecsServiceRoleId = parentResources["serviceRole"].Id ]
+
+    [#-- Baseline component lookup --]
+    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption" ] )]
+    [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
 
     [#local occurrenceNetwork = getOccurrenceNetwork(occurrence) ]
     [#local networkLink = occurrenceNetwork.Link!{} ]

--- a/providers/aws/components/ecs/setup.ftl
+++ b/providers/aws/components/ecs/setup.ftl
@@ -40,6 +40,7 @@
 
     [#-- Baseline component lookup --]
     [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
     [#local sshKeyPairId = baselineComponentIds["SSHKey"] ]
@@ -70,7 +71,7 @@
     [#local configSetName = occurrence.Core.Type]
     [#local configSets =
             getInitConfigDirectories() +
-            getInitConfigBootstrap(occurrence) +
+            getInitConfigBootstrap(occurrence, operationsBucket, dataBucket) +
             getInitConfigECSAgent(ecsId, defaultLogDriver, solution.DockerUsers, solution.VolumeDrivers ) ]
 
     [#local efsMountPoints = {}]

--- a/providers/aws/components/efs/setup.ftl
+++ b/providers/aws/components/efs/setup.ftl
@@ -41,6 +41,10 @@
                                             efsSecurityGroupId,
                                             efsPort)]
 
+    [#-- Baseline component lookup --]
+    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "Encryption"] )]
+    [#local cmkKeyId = baselineComponentIds["Encryption" ]]
+
     [#if deploymentSubsetRequired("efs", true) ]
         [@createSecurityGroup
             mode=listMode
@@ -65,6 +69,7 @@
             name=efsFullName
             component=core.Component
             encrypted=solution.Encrypted
+            kmsKeyId=cmkKeyId
         /]
 
         [#list zones as zone ]

--- a/providers/aws/components/mobileapp/setup.ftl
+++ b/providers/aws/components/mobileapp/setup.ftl
@@ -19,6 +19,11 @@
     [#local configFilePath = resources["mobileapp"].ConfigFilePath ]
     [#local configFileName = resources["mobileapp"].ConfigFileName ]
 
+    [#-- Baseline component lookup --]
+    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData" ] )]
+    [#local dataBucket getExistingReference(baselineComponentIds["AppData"])]
+    [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
+
     [#local fragment = getOccurrenceFragmentBase(occurrence) ]
 
     [#local contextLinks = getLinkTargets(occurrence) ]
@@ -42,7 +47,7 @@
     [#local fragmentId = formatFragmentId(_context)]
     [#include fragmentList?ensure_starts_with("/")]
 
-    [#local finalAsFileEnvironment = getFinalEnvironment(occurrence, _context, { "Json" : { "Include" : { "Sensitive" : false }}}) ]
+    [#local finalAsFileEnvironment = getFinalEnvironment(occurrence, _context, operationsBucket, dataBucket, { "Json" : { "Include" : { "Sensitive" : false }}}) ]
 
     [#if deploymentSubsetRequired("config", false)]
         [@cfConfig

--- a/providers/aws/components/spa/setup.ftl
+++ b/providers/aws/components/spa/setup.ftl
@@ -145,10 +145,11 @@
     [/#if]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "CDNOriginKey", "OpsData" ] )]
+    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "CDNOriginKey", "OpsData", "AppData" ] )]
     
     [#local cfAccess         = getExistingReference(baselineComponentIds["CDNOriginKey"]) ]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
+    [#local dataBucket       = getExistingReference(baselineComponentIds["AppData"]) ]
     
     [#if !cfAccess?has_content]
         [@cfPreconditionFailed listMode "solution_spa" occurrence "No CF Access Id found" /]
@@ -384,7 +385,7 @@
     [#local fragmentId = formatFragmentId(_context)]
     [#include fragmentList?ensure_starts_with("/")]
 
-    [#assign _context += getFinalEnvironment(occurrence, _context) ]
+    [#assign _context += getFinalEnvironment(occurrence, _context, operationsBucket, dataBucket ) ]
 
     [#if deploymentSubsetRequired("config", false)]
         [@cfConfig

--- a/providers/aws/services/ec2/resource.ftl
+++ b/providers/aws/services/ec2/resource.ftl
@@ -38,7 +38,7 @@
     } ]
 [/#function]
 
-[#function getInitConfigBootstrap occurrence ignoreErrors=false priority=1 ]
+[#function getInitConfigBootstrap occurrence operationsBucket dataBucket ignoreErrors=false priority=1 ]
     [#local role = (occurrence.Configuration.Settings.Product["Role"].Value)!""]
     [#return
         {
@@ -634,6 +634,7 @@
     publicIP
     configSet
     environmentId
+    keyPairId
     sshFromProxy=sshFromProxySecurityGroup
     enableCfnSignal=false
     dependencies=""
@@ -655,7 +656,7 @@
         properties=
             getBlockDevices(storageProfile) +
             {
-                "KeyName" : getExistingReference(formatEC2KeyPairId(), NAME_ATTRIBUTE_TYPE),
+                "KeyName" : getExistingReference(keyPairId, NAME_ATTRIBUTE_TYPE),
                 "InstanceType": processorProfile.Processor,
                 "ImageId" : imageId,
                 "SecurityGroups" :
@@ -837,9 +838,10 @@
     size
     zone
     volumeType
+    encrypted
+    kmsKeyId
     provisionedIops=0
     snapshotId=""
-    encrypted=false
     dependencies=""
     outputId=""
 ]
@@ -856,7 +858,7 @@
         (!(snapshotId?has_content) && encrypted)?then(
             {
                 "Encrypted" : encrypted,
-                "KmsKeyId" : getReference(formatSegmentCMKId(), ARN_ATTRIBUTE_TYPE)
+                "KmsKeyId" : getReference(kmsKeyId, ARN_ATTRIBUTE_TYPE)
             },
             {}
         ) +

--- a/providers/aws/services/efs/resource.ftl
+++ b/providers/aws/services/efs/resource.ftl
@@ -29,7 +29,7 @@
     }
 ]
 
-[#macro createEFS mode id name tier component encrypted]
+[#macro createEFS mode id name tier component encrypted kmsKeyId]
     [@cfResource
         mode=mode
         id=id
@@ -42,7 +42,7 @@
             encrypted?then(
                 {
                     "Encrypted" : true,
-                    "KmsKeyId" : getReference(formatSegmentCMKId(), ARN_ATTRIBUTE_TYPE)
+                    "KmsKeyId" : getReference(fkmsKeyId, ARN_ATTRIBUTE_TYPE)
                 },
                 {}
             )

--- a/providers/aws/services/efs/resource.ftl
+++ b/providers/aws/services/efs/resource.ftl
@@ -42,7 +42,7 @@
             encrypted?then(
                 {
                     "Encrypted" : true,
-                    "KmsKeyId" : getReference(fkmsKeyId, ARN_ATTRIBUTE_TYPE)
+                    "KmsKeyId" : getReference(kmsKeyId, ARN_ATTRIBUTE_TYPE)
                 },
                 {}
             )

--- a/providers/aws/services/kinesis/resource.ftl
+++ b/providers/aws/services/kinesis/resource.ftl
@@ -94,6 +94,7 @@
         bufferSize
         roleId
         encrypted
+        kmsKeyId
         loggingConfiguration
     ]
 
@@ -114,7 +115,7 @@
             encrypted,
             {
                 "KMSEncryptionConfig" : {
-                    "AWSKMSKeyARN" : getReference(formatSegmentCMKId(), ARN_ATTRIBUTE_TYPE)
+                    "AWSKMSKeyARN" : getReference(kmsKeyId, ARN_ATTRIBUTE_TYPE)
                 }
             }
         )

--- a/providers/aws/services/kms/policy.ftl
+++ b/providers/aws/services/kms/policy.ftl
@@ -10,10 +10,6 @@
     ]
 [/#function]
 
-[#function credentialsDecryptPermission]
-    [#return cmkDecryptPermission(formatSegmentCMKId())]
-[/#function]
-
 [#function s3EncryptionPermission keyId bucketName bucketPrefix bucketRegion ]
     [#return
         [

--- a/providers/aws/services/lambda/resource.ftl
+++ b/providers/aws/services/lambda/resource.ftl
@@ -86,8 +86,8 @@
             attributeIfTrue("Timeout", settings.Timeout > 0, settings.Timeout) +
             attributeIfTrue(
                 "KmsKeyArn",
-                settings.UseSegmentKey!false,
-                getReference(formatSegmentCMKId(), ARN_ATTRIBUTE_TYPE)) +
+                settings.Encrypted!false,
+                getReference(settings.KMSKeyId, ARN_ATTRIBUTE_TYPE)) +
             attributeIfContent(
                 "VpcConfig",
                 securityGroupIds,

--- a/providers/aws/services/rds/resource.ftl
+++ b/providers/aws/services/rds/resource.ftl
@@ -43,6 +43,7 @@
     port
     multiAZ
     encrypted
+    kmsKeyId
     masterUsername
     masterPassword
     databaseName
@@ -95,7 +96,7 @@
         (!(snapshotId?has_content) && encrypted)?then(
             {
                 "StorageEncrypted" : true,
-                "KmsKeyId" : getReference(formatSegmentCMKId(), ARN_ATTRIBUTE_TYPE)
+                "KmsKeyId" : getReference(kmsKeyId, ARN_ATTRIBUTE_TYPE)
             },
             {}
         ) +

--- a/providers/aws/services/s3/resource.ftl
+++ b/providers/aws/services/s3/resource.ftl
@@ -207,21 +207,12 @@
     destinationBucket
     enabled
     prefix
-    encryptReplica=false
 ]
     [#return
         {
             "Destination" : {
                 "Bucket" : getArn(destinationBucket)
-            } +
-            encryptReplica?then(
-                    {
-                        "EncryptionConfiguration" : {
-                        "ReplicaKmsKeyID" : getReference(formatSegmentCMKId(), ARN_ATTRIBUTE_TYPE)
-                        }
-                    },
-                    {}
-            ),
+            },
             "Prefix" : prefix,
             "Status" : enabled?then(
                 "Enabled",

--- a/providers/shared/components/baseline/id.ftl
+++ b/providers/shared/components/baseline/id.ftl
@@ -56,7 +56,7 @@
             [#else]
                 [@cfException
                     mode=listMode
-                    description="Missing component Id or component not found "
+                    description="Baseline component not found or not deployed"
                     detail=baselineProfile
                     context=baselineLink
                 /]

--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -120,7 +120,7 @@
                 "Default" : true
             },
             {
-                "Names" : "UseSegmentKey",
+                "Names" : ["Encrypted", "UseSegmentKey"],
                 "Type" : BOOLEAN_TYPE,
                 "Default" : false
             },


### PR DESCRIPTION
This PR moves to using the baseline profile introduced in #834 for all components. 

I've commented out the setContext for the operations and data buckets to make sure that they aren't in use 

Also has some fixes for ES based on the split of the AWS identity pool from our userpool component