### PR TITLE
<refactor> baseline: Migrate OAI to cf for all deployments

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -1588,7 +1588,7 @@ behaviour.
 
 [/#function]
 
-[#function getLinkTarget occurrence link activeOnly=true]
+[#function getLinkTarget occurrence link activeOnly=true activeRequired=false]
 
     [#local instanceToMatch = link.Instance!occurrence.Core.Instance.Id ]
     [#local versionToMatch = link.Version!occurrence.Core.Version.Id ]
@@ -1717,7 +1717,21 @@ behaviour.
             [@debug message="Link matched target" enabled=false /]
 
             [#-- Determine if deployed --]
-            [#if activeOnly && !isOccurrenceDeployed(targetSubOccurrence) ]
+            [#if ( activeOnly || activeRequired ) && !isOccurrenceDeployed(targetSubOccurrence) ]
+                [#if activeRequired ]
+                    [@postcondition
+                        function="getLinkTarget"
+                        context=
+                            {
+                                "Occurrence" : occurrence,
+                                "Link" : link,
+                                "EffectiveInstance" : instanceToMatch,
+                                "EffectiveVersion" : versionToMatch
+                            }
+                        detail="COTFatal:Link target not active/deployed"
+                        enabled=true
+                    /]
+                [/#if]
                 [#return {} ]
             [/#if]
 

--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -1765,11 +1765,11 @@ behaviour.
     [#return {} ]
 [/#function]
 
-[#function getLinkTargets occurrence links={} activeOnly=true]
+[#function getLinkTargets occurrence links={} activeOnly=true activeRequired=false ]
     [#local result={} ]
     [#list (valueIfContent(links, links, occurrence.Configuration.Solution.Links!{}))?values as link]
         [#if link?is_hash]
-            [#local linkTarget = getLinkTarget(occurrence, link, activeOnly) ]
+            [#local linkTarget = getLinkTarget(occurrence, link, activeOnly, activeRequired) ]
             [#local result +=
                 valueIfContent(
                     {

--- a/providers/aws/services/iam/resource.ftl
+++ b/providers/aws/services/iam/resource.ftl
@@ -32,34 +32,6 @@
     /]
 [/#macro]
 
-[#macro createSQSPolicy id queues statements dependencies=[] ]
-    [@cfResource
-        id=id
-        type="AWS::SQS::QueuePolicy"
-        properties=
-            {
-                "Queues" : getReferences(queues, URL_ATTRIBUTE_TYPE)
-            } +
-            getPolicyDocument(statements)
-        outputs={}
-        dependencies=dependencies
-    /]
-[/#macro]
-
-[#macro createBucketPolicy id bucket statements dependencies=[] ]
-    [@cfResource
-        id=id
-        type="AWS::S3::BucketPolicy"
-        properties=
-            {
-                "Bucket" : (getExistingReference(bucket)?has_content)?then(getExistingReference(bucket),bucket)
-            } +
-            getPolicyDocument(statements)
-        outputs={}
-        dependencies=dependencies
-    /]
-[/#macro]
-
 [#assign ROLE_OUTPUT_MAPPINGS =
     {
         REFERENCE_ATTRIBUTE_TYPE : {

--- a/providers/aws/services/s3/resource.ftl
+++ b/providers/aws/services/s3/resource.ftl
@@ -356,4 +356,16 @@
     /]
 [/#macro]
 
-
+[#macro createBucketPolicy id bucket statements dependencies=[] ]
+    [@cfResource
+        id=id
+        type="AWS::S3::BucketPolicy"
+        properties=
+            {
+                "Bucket" : (getExistingReference(bucket)?has_content)?then(getExistingReference(bucket),bucket)
+            } +
+            getPolicyDocument(statements)
+        outputs={}
+        dependencies=dependencies
+    /]
+[/#macro]

--- a/providers/aws/services/sqs/resource.ftl
+++ b/providers/aws/services/sqs/resource.ftl
@@ -60,4 +60,16 @@
     /]
 [/#macro]
 
-
+[#macro createSQSPolicy id queues statements dependencies=[] ]
+    [@cfResource
+        id=id
+        type="AWS::SQS::QueuePolicy"
+        properties=
+            {
+                "Queues" : getReferences(queues, URL_ATTRIBUTE_TYPE)
+            } +
+            getPolicyDocument(statements)
+        outputs={}
+        dependencies=dependencies
+    /]
+[/#macro]

--- a/providers/shared/components/baseline/id.ftl
+++ b/providers/shared/components/baseline/id.ftl
@@ -44,21 +44,25 @@
                     subComponentType : value
                 }
             ]
-            [#local baselineLinkTarget = getLinkTarget( {}, baselineLink )]
-            [#if baselineLinkTarget?has_content && (baselineLinkTarget.State.Attributes["ID"])?has_content  ]
-                [#local baselineComponentIds += {
-                    key : baselineLinkTarget.State.Attributes["ID"]!"COTFatal: ResourceID not found"
-                }]
-                [#local baselineLinkTargets += {
-                        key : baselineLinkTargets
-                }]
-            [#else]
-                [@fatal
+            [#local baselineLinkTarget = getLinkTarget( {}, baselineLink, true, true )]
+            [#local baselineComponentId = (baselineLinkTarget.State.Attributes["ID"])!"" ]
+            
+            [#if ! baselineComponentId?has_content ]
+                [@fatal 
                     message="Baseline component not found or not deployed"
-                    detail=baselineProfile
-                    context=baselineLink
+                    detail={
+                        key: value
+                    }
+                    enabled=true
                 /]
             [/#if]
+
+            [#local baselineComponentIds += {
+                key : baselineComponentId
+            }]
+            [#local baselineLinkTargets += {
+                    key : baselineLinkTarget
+            }]
         [/#if]
     [/#list]
 


### PR DESCRIPTION
A couple of commits which are mostly related to baseline components

- Instead of using the legacy OAI key created using the cli, migrate all deployments over to use a cloudformation generated OAI
  - The legacy key will still be retained and added to all segment databucket bucket policies if its found
- Adds the activeRequired option to getLinkTarget(s) which will throw a fatal error if a link is not active 
- Fix up the baseline component lookup to include the activeRequired option and an extra exception to highlight why a baseline link has failed 
- Move the resource based policies into the resource files for a service