### PR TITLE
<feature> Processing timing and component cache

### DIFF
--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -524,14 +524,34 @@
     [#return ""]
 [/#function]
 
+[#--------------------------
+-- Date/time manipulation --
+----------------------------]
+
+[#function datetimeAsString datetime ms=true utc=false]
+    [#local format = "iso"]
+    [#if utc]
+        [#local format += "_utc"]
+    [/#if]
+    [#if ms]
+        [#local format += "_ms"]
+    [/#if]
+    [#return datetime?string[format]]
+[/#function]
+
+[#function duration end start ]
+    [#return (end?long - start?long)]
+[/#function]
+
 [#-----------
 -- Logging --
 -------------]
 
 [#assign DEBUG_LOG_LEVEL = 0]
 [#assign TRACE_LOG_LEVEL = 1]
-[#assign INFORMATION_LOG_LEVEL=3]
-[#assign WARNING_LOG_LEVEL= 5]
+[#assign INFORMATION_LOG_LEVEL = 3]
+[#assign TIMING_LOG_LEVEL = 4]
+[#assign WARNING_LOG_LEVEL = 5]
 [#assign ERROR_LOG_LEVEL = 7]
 [#assign FATAL_LOG_LEVEL = 9]
 
@@ -540,7 +560,7 @@
     "trace",
     "",
     "info",
-    "",
+    "timing",
     "warn",
     "",
     "error",
@@ -585,7 +605,7 @@
         [#assign logMessages +=
             [
                 {
-                    "Timestamp" : .now?string["iso_ms"],
+                    "Timestamp" : datetimeAsString(.now),
                     "Severity" : logLevelDescriptions[severity]!"unknown",
                     "Message" : message
                 } +
@@ -595,7 +615,7 @@
     [/#if]
 [/#macro]
 
-[#macro debug message context={} detail={} enabled=false]
+[#macro debug message context={} detail={} enabled=true]
     [@logMessage
         severity=DEBUG_LOG_LEVEL
         message=message
@@ -605,7 +625,7 @@
     /]
 [/#macro]
 
-[#macro trace message context={} detail={} enabled=false]
+[#macro trace message context={} detail={} enabled=true]
     [@logMessage
         severity=TRACE_LOG_LEVEL
         message=message
@@ -615,7 +635,7 @@
     /]
 [/#macro]
 
-[#macro info message context={} detail={} enabled=false]
+[#macro info message context={} detail={} enabled=true]
     [@logMessage
         severity=INFORMATION_LOG_LEVEL
         message=message
@@ -625,7 +645,17 @@
     /]
 [/#macro]
 
-[#macro warn message context={} detail={} enabled=false]
+[#macro timing message context={} detail={} enabled=true]
+    [@logMessage
+        severity=TIMING_LOG_LEVEL
+        message=message
+        context=context
+        detail=detail
+        enabled=enabled
+    /]
+[/#macro]
+
+[#macro warn message context={} detail={} enabled=true]
     [@logMessage
         severity=WARNING_LOG_LEVEL
         message=message
@@ -635,7 +665,7 @@
     /]
 [/#macro]
 
-[#macro error message context={} detail={} enabled=false]
+[#macro error message context={} detail={} enabled=true]
     [@logMessage
         severity=ERROR_LOG_LEVEL
         message=message
@@ -645,7 +675,7 @@
     /]
 [/#macro]
 
-[#macro fatal message context={} detail={} enabled=false]
+[#macro fatal message context={} detail={} enabled=true]
     [@logMessage
         severity=FATAL_LOG_LEVEL
         message=message
@@ -655,7 +685,7 @@
     /]
 [/#macro]
 
-[#macro precondition function context={} detail={} enabled=false]
+[#macro precondition function context={} detail={} enabled=true]
     [@fatal
         message="Precondition failed for " + function
         context=context
@@ -664,7 +694,7 @@
     /]
 [/#macro]
 
-[#macro postcondition function context={} detail={} enabled=false]
+[#macro postcondition function context={} detail={} enabled=true]
     [@fatal
         message="Postcondition failed for " + function
         context=context

--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -1279,6 +1279,8 @@ behaviour.
     ]
 [/#function]
 
+[#assign occurrencesCache = {}]
+
 [#-- Get the occurrences of versions/instances of a component           --]
 [#-- This function should NOT be called directly - it is for the use of --]
 [#-- other functions in this file                                       --]
@@ -1317,6 +1319,12 @@ behaviour.
         [#local subComponentId = typeObject.Id?split("-") ]
         [#local subComponentName = typeObject.Name?split("-") ]
         [#local componentContexts += [typeObject] ]
+    [/#if]
+
+    [#-- Have we already seen this occurrence --]
+    [#local cacheIndex = formatId(tierId, componentId, subComponentId)]
+    [#if occurrencesCache[cacheIndex]?has_content]
+        [#return occurrencesCache[cacheIndex]]
     [/#if]
 
     [#local occurrences=[] ]
@@ -1572,6 +1580,7 @@ behaviour.
         [/#if]
     [/#list]
 
+    [#assign occurrencesCache += {cacheIndex : occurrences}]
     [#return occurrences ]
 [/#function]
 

--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -215,28 +215,55 @@
 [/#function]
 
 [#macro processComponents level=""]
+    [#local start = .now]
+    [@timing message="Starting component processing ..." /]
     [#list tiers as tier]
         [#list (tier.Components!{})?values as component]
             [#if deploymentRequired(component, deploymentUnit)]
                 [#assign multiAZ = component.MultiAZ!solnMultiAZ]
+                [#local occurrenceStart = .now]
                 [#list requiredOccurrences(
                     getOccurrences(tier, component),
                     deploymentUnit,
                     true) as occurrence]
-                    [@debug
-                        message=occurrence
-                        enabled=false
+                    [#local occurrenceEnd = .now]
+                    [@timing
+                        message= "Got " + tier.Id + "/" + component.Id + " occurrences ..."
+                        context=
+                            {
+                                "Elapsed" : (duration(occurrenceEnd, start)/1000)?string["0.000"],
+                                "Duration" : (duration(occurrenceEnd, occurrenceStart)/1000)?string["0.000"]
+                            }
                     /]
+
+                    [@debug message=occurrence enabled=false /]
+
                     [#list occurrence.State.ResourceGroups as key,value]
                         [#if invokeSetupMacro(occurrence, key, ["setup", level]) ]
                             [@debug
-                                message="Processing " + tier.Id + "/" + component.Id + "/" + key + " ..."
+                                message="Processing " + key + " ..."
                                 enabled=false
                             /]
                         [/#if]
                     [/#list]
+                    [#local processingEnd = .now]
+                    [@timing
+                        message="Processed " + tier.Id + "/" + component.Id + "."
+                        context=
+                            {
+                                "Elapsed"  : (duration(processingEnd, start)/1000)?string["0.000"],
+                                "Duration" : (duration(processingEnd, occurrenceEnd)/1000)?string["0.000"]
+                            }
+                    /]
                 [/#list]
             [/#if]
         [/#list]
     [/#list]
+    [@timing
+        message="Finished component processing."
+        context=
+            {
+                "Elapsed"  : (duration(.now, start)/1000)?string["0.000"]
+            }
+        /]
 [/#macro]

--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -66,7 +66,7 @@
             ] ]
         [#list messages as message]
             [#local timestamp = message.Timestamp?right_pad(30) ]
-            [#local severity = "[" + message.Severity?right_pad(5) + "]" ]
+            [#local severity = "[" + message.Severity?right_pad(6) + "]" ]
             [#local comments += [[timestamp, severity, getJSON(message.Message)]?join(" ")] ]
             [#if message.Context?has_content]
                 [#local comments += [" ...." + getJSON(message.Context)] ]

--- a/providers/shared/components/baseline/id.ftl
+++ b/providers/shared/components/baseline/id.ftl
@@ -46,14 +46,13 @@
             ]
             [#local baselineLinkTarget = getLinkTarget( {}, baselineLink, true, true )]
             [#local baselineComponentId = (baselineLinkTarget.State.Attributes["ID"])!"" ]
-            
+
             [#if ! baselineComponentId?has_content ]
-                [@fatal 
+                [@fatal
                     message="Baseline component not found or not deployed"
                     detail={
                         key: value
                     }
-                    enabled=true
                 /]
             [/#if]
 


### PR DESCRIPTION
Added an additional log level to allow timing information to be displayed
and added duration calculations in the core component processing routine.

Changed the default value for enabled to true for all logging macros, as
output now controlled vi the log level selected.

Added a component cache which speeds up all component processing
significantly particularly for units which process all components.