### PR TITLE
<fix> userpool remove identifier option

### DIFF
--- a/providers/aws/components/userpool/id.ftl
+++ b/providers/aws/components/userpool/id.ftl
@@ -7,7 +7,9 @@
     services=
         [
             AWS_COGNITO_SERVICE,
-            AWS_CERTIFICATE_MANAGER_SERVICE
+            AWS_CERTIFICATE_MANAGER_SERVICE,
+            AWS_IDENTITY_SERVICE,
+            AWS_ROUTE53_SERVICE
         ]
 /]
 

--- a/providers/aws/components/userpool/setup.ftl
+++ b/providers/aws/components/userpool/setup.ftl
@@ -303,16 +303,9 @@
 
                 [#local updateUserPoolAuthProvider =  {
                         "AttributeMapping" : attributeMappings,
-                        "ProviderDetails" : providerDetails
-                    } +
-                    attributeIfContent(
-                        "AttributeMapping",
-                        attributeMappings
-                    ) +
-                    attributeIfContent(
-                        "IdpIdentifiers",
-                        subSolution.IDPIdentifiers
-                    )
+                        "ProviderDetails" : providerDetails,
+                        "IdpIdentifiers" : subSolution.IDPIdentifiers
+                    }
                 ]
 
                 [@addCliToDefaultJsonOutput

--- a/providers/shared/components/userpool/id.ftl
+++ b/providers/shared/components/userpool/id.ftl
@@ -252,7 +252,8 @@
             {
                 "Names" : "IDPIdentifiers",
                 "Type" : ARRAY_OF_STRING_TYPE,
-                "Description" : "A list of identifiers that can be used to automatically pick the IDP - E.g. email domain"
+                "Description" : "A list of identifiers that can be used to automatically pick the IDP - E.g. email domain",
+                "Default" : []
             },
             {
                 "Names" : "SAML",


### PR DESCRIPTION
- Allow for an empty IDP attribute to be provided in cli config so that IDP identifiers can be disabled 
- Add service dependencies for userpool