### PR TITLE
<fix> Align blueprint generation with output framework

### DIFF
--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -238,9 +238,9 @@ function process_template_pass() {
         pass_region_prefix["${p}"]=""
       done
 
-      pass_level_prefix["template"]="blueprint"
-      pass_description["template"]="blueprint"
-      pass_suffix["template"]=".json"
+      pass_level_prefix["config"]="blueprint"
+      pass_description["config"]="blueprint"
+      pass_suffix["config"]=".json"
       ;;
 
     buildblueprint)
@@ -252,9 +252,9 @@ function process_template_pass() {
         pass_region_prefix["${p}"]=""
       done
 
-      pass_level_prefix["template"]="build_blueprint-"
-      pass_description["template"]="buildblueprint"
-      pass_suffix["template"]=".json"
+      pass_level_prefix["config"]="build_blueprint-"
+      pass_description["config"]="buildblueprint"
+      pass_suffix["config"]=".json"
       ;;
 
     account)

--- a/aws/templates/createBlueprint.ftl
+++ b/aws/templates/createBlueprint.ftl
@@ -1,9 +1,6 @@
 [#ftl]
 [#include "/bootstrap.ftl" ]
 
-[#assign allDeploymentUnits = true]
-[#assign deploymentUnit = ""]
-
 [#function getCleanedAttributes attributes ]
   [#local result={} ]
   [#list attributes as key, value]
@@ -124,9 +121,23 @@
   [#return  result ]
 [/#function]
 
-[#if deploymentSubsetRequired("blueprint", true)]
-  [@toJSON getTenantBlueprint() /]
+[#-- Redefine the core processing macro --]
+[#macro processComponents level]
+  [#if (deploymentUnitSubset!"") == "config" ]
+    [@addToDefaultJsonOutput content=getTenantBlueprint() /]
+  [/#if]
+[/#macro]
+
+[#if (deploymentUnitSubset!"") == "genplan" ]
+  [@initialiseDefaultScriptOutput format=outputFormat /]
+  [@addDefaultGenerationPlan subsets="config" /]
+[#else]
+  [#assign allDeploymentUnits = true]
+  [#assign deploymentUnit = ""]
 [/#if]
 
-
-
+[@generateOutput
+  deploymentFramework=deploymentFramework
+  type=outputType
+  format=outputFormat
+/]

--- a/aws/templates/createBlueprint.ftl
+++ b/aws/templates/createBlueprint.ftl
@@ -36,7 +36,7 @@
       }
     ]
   }]
-  [#return result ]
+[#return result]
 [/#function]
 
 [#function getProductBlueprint]

--- a/aws/templates/createBuildblueprint.ftl
+++ b/aws/templates/createBuildblueprint.ftl
@@ -1,9 +1,6 @@
 [#ftl]
 [#include "/bootstrap.ftl" ]
 
-[#assign exceptionResources = []]
-[#assign debugResources = []]
-
 [#function getComponentBuildBlueprint ]
   [#local result={} ]
 
@@ -30,27 +27,29 @@
                         } +
                         attributeIfContent("CostCentre", accountObject.CostCentre!""),
                     "Occurrence" : occurrence
-                    } +
-                    valueIfContent(
-                        {
-                            "Debug" : debugResources
-                        },
-                        debugResources
-                    ) +
-                    valueIfContent(
-                        {
-                            "Exceptions" : exceptionResources
-                        },
-                        exceptionResources
-                    )
+                    }
                 ]
             [/#list]
         [/#if]
     [/#list]
   [/#list]
-  [#return result ]
+  [#return result]
 [/#function]
 
-[#if deploymentSubsetRequired("buildblueprint", true)]
-    [@toJSON getComponentBuildBlueprint() /]
+[#-- Redefine the core processing macro --]
+[#macro processComponents level]
+  [#if (deploymentUnitSubset!"") == "config" ]
+    [@addToDefaultJsonOutput content=getComponentBuildBlueprint() /]
+  [/#if]
+[/#macro]
+
+[#if (deploymentUnitSubset!"") == "genplan" ]
+  [@initialiseDefaultScriptOutput format=outputFormat /]
+  [@addDefaultGenerationPlan subsets="config" /]
 [/#if]
+
+[@generateOutput
+  deploymentFramework=deploymentFramework
+  type=outputType
+  format=outputFormat
+/]


### PR DESCRIPTION
Use the output framework to generate the blueprint.

Because of the format required, redefine the key processing macro to
generate the output required.

Switch to using the config subset as it is a little simpler but that;s
hidden inside the genplan generation.