### PR TITLE
<fix> Application level templates processing

### DIFF
--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -440,7 +440,7 @@ function process_template_pass() {
   case "$(fileExtension "${template_result_file}")" in
     sh)
       # Detect any exceptions during generation
-      grep "\[fatal\]" < "${template_result_file}" > "${template_result_file}-exceptions"
+      grep "\[fatal \]" < "${template_result_file}" > "${template_result_file}-exceptions"
       if [[ -s "${template_result_file}-exceptions" ]]; then
         fatal "Exceptions occurred during script generation. Details follow...\n"
         cat "${template_result_file}-exceptions" >&2

--- a/aws/templates/createApplicationTemplate.ftl
+++ b/aws/templates/createApplicationTemplate.ftl
@@ -30,5 +30,5 @@
     deploymentFramework=deploymentFramework
     type=outputType
     format=outputFormat
-    level="segment"
+    level="application"
 /]

--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -186,10 +186,9 @@
             [/#if]
             [#return true]
         [#else]
-            [@debug
+            [@fatal
                 message="Unable to invoke any of the macro options"
                 context=macroOptions
-                enabled=false
             /]
         [/#if]
     [/#if]


### PR DESCRIPTION
Correct the application template to include the correct level.

Treat the absence of any suitable processing macro for a unit as a fatal
error.

Correct the detection of fatal errors in scripts - the length of the
severity indicator was increased to allow for "timing" but the check for
fata was not adjusted accordingly.