### PR TITLE
<fix> Update Expo config setup to support baseline

### DIFF
--- a/providers/aws/components/mobileapp/setup.ftl
+++ b/providers/aws/components/mobileapp/setup.ftl
@@ -41,9 +41,7 @@
         attributes +
         defaultEnvironment(occurrence, {})
     ]
-
-    [#local buildConfig += attributes ]
-
+    
     [#local fragment = getOccurrenceFragmentBase(occurrence) ]
 
     [#local contextLinks = getLinkTargets(occurrence) ]

--- a/providers/aws/components/mobileapp/state.ftl
+++ b/providers/aws/components/mobileapp/state.ftl
@@ -13,18 +13,17 @@
     [#local otaPrefix = ""]
     [#local otaURL = ""]
 
-    [#local releaseChannel = getOccurrenceSettingValue(occurrence, "RELEASE_CHANNEL", true)?has_content?then(
-            getOccurrenceSettingValue(occurrence, "RELEASE_CHANNEL", true),
-            environmentName
-    )]
+    [#local releaseChannel = 
+        getOccurrenceSettingValue(occurrence, "RELEASE_CHANNEL", true)?has_content?then(
+                getOccurrenceSettingValue(occurrence, "RELEASE_CHANNEL", true),
+                environmentName
+            )
+    ]
+    [#-- Baseline component lookup --]
+    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData" ] )]
 
-    [#local codeSrcBucket = getRegistryEndPoint("scripts", occurrence)]
-    [#local codeSrcPrefix = formatRelativePath(
-                                getRegistryPrefix("scripts", occurrence),
-                                    productName,
-                                    getOccurrenceBuildUnit(occurrence),
-                                    getOccurrenceBuildReference(occurrence))]
-
+    [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
+    
     [#local configFilePath = formatRelativePath(
                                 getOccurrenceSettingValue(occurrence, "SETTINGS_PREFIX"),
                                 "config" )]
@@ -71,16 +70,15 @@
             },
             "Attributes" : {
                 "ENGINE" : solution.Engine,
-                "APP_BUILD_FORMATS" : solution.BuildFormats?join(","),
                 "RELEASE_CHANNEL" : releaseChannel,
-                "CODE_SRC_BUCKET" : codeSrcBucket,
-                "CODE_SRC_PREFIX" : codeSrcPrefix,
                 "OTA_ARTEFACT_BUCKET" : otaBucket,
                 "OTA_ARTEFACT_PREFIX" : otaPrefix,
                 "OTA_ARTEFACT_URL" : otaURL,
+                "CONFIG_BUCKET" : operationsBucket,
                 "CONFIG_FILE" : formatRelativePath(
                                     configFilePath,
-                                    configFileName)
+                                    configFileName
+                                )
             }
         }
     ]


### PR DESCRIPTION
With the changes to using the baseline profile the APPDATA_BUCKET and OPSDATA_BUCKET variables aren't available until the setup stage instead of the state stage like the used to be 

This PR updates the expo build configuration to rely on a dedicated config file rather than using the build blue print. 

The build blueprint is still required to determine where the config file lives but the actual values required by the build are now baked into the config file provided for the build