### PR TITLE
<fix>baseline bucketId Lookup

### DIFF
--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -249,18 +249,6 @@
 
     [#assign consoleOnly = (segmentObject.ConsoleOnly)!false]
 
-    [#-- 
-    [#assign operationsBucket =
-        firstContent(
-            getExistingReference(formatS3OperationsId()),
-            formatSegmentBucketName(segmentSeed, "ops"))]
-
-    [#assign dataBucket =
-        firstContent(
-            getExistingReference(formatS3DataId()),
-            formatSegmentBucketName(segmentSeed, "data"))]
-    --]
-
     [#assign operationsExpiration =
         (segmentObject.Operations.Expiration)!
         (environmentObject.Operations.Expiration)!""]

--- a/providers/aws/components/baseline/state.ftl
+++ b/providers/aws/components/baseline/state.ftl
@@ -52,7 +52,9 @@
 
     [#switch core.SubComponent.Id ]
         [#case "appdata" ]
+            [#local bucketId = formatSegmentResourceId(AWS_S3_RESOURCE_TYPE, core.SubComponent.Id ) ]
             [#local bucketName = formatSegmentBucketName(segmentSeed, "data") ]
+            
             [#if getExistingReference(formatS3DataId())?has_content ]
                 [#local bucketId = formatS3DataId() ]
                 [#local legacyS3 = true ]
@@ -60,7 +62,9 @@
             [#break]
 
         [#case "opsdata" ]
+            [#local bucketId = formatSegmentResourceId(AWS_S3_RESOURCE_TYPE, core.SubComponent.Id ) ]
             [#local bucketName = formatSegmentBucketName(segmentSeed, "ops") ]
+            
             [#if getExistingReference(formatS3OperationsId())?has_content ]
                 [#local bucketId = formatS3OperationsId() ]
                 [#local legacyS3 = true]

--- a/providers/shared/components/baseline/id.ftl
+++ b/providers/shared/components/baseline/id.ftl
@@ -15,15 +15,15 @@
 
     [#list baselineProfile as key,value ]
         [#if baselineComponentNames?seq_contains(key)]
-            [#switch key ]
-                [#case "OpsData" ]
-                [#case "AppData" ]
+            [#switch key?lower_case ]
+                [#case "opsdata" ]
+                [#case "appdata" ]
                     [#local subComponentType = "DataBucket" ]
                     [#break]
 
-                [#case "Encryption" ]
-                [#case "SSHKey" ]
-                [#case "CDNOriginKey" ]
+                [#case "encryption" ]
+                [#case "sshkey" ]
+                [#case "cdnoriginkey" ]
                     [#local subComponentType = "Key" ]
                     [#break]
 


### PR DESCRIPTION
Use standard bucket names for all other buckets in baseline except appData and opsdata which are treated as segment resources for backwards compatability