### PR TITLE
<feature> First cut of context based in-memory model

### DIFF
--- a/aws/templates/createApplicationTemplate.ftl
+++ b/aws/templates/createApplicationTemplate.ftl
@@ -23,6 +23,13 @@
             [/#if]
         [/#if]
         [#break]
+    [#case "model"]
+        [#if (deploymentUnitSubset!"") == "genplan"]
+            [@initialiseDefaultScriptOutput format=outputFormat /]
+            [@addDefaultGenerationPlan subsets="config" /]
+        [#else]
+            [#assign outputType = "model"]
+        [/#if]
 
 [/#switch]
 

--- a/engine/bootstrap.ftl
+++ b/engine/bootstrap.ftl
@@ -4,6 +4,7 @@
 [#include "base.ftl" ]
 
 [#-- Component handling --]
+[#include "context.ftl" ]
 [#include "component.ftl" ]
 [#include "setting.ftl" ]
 [#include "occurrence.ftl" ]

--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -186,9 +186,10 @@
             [/#if]
             [#return true]
         [#else]
-            [@fatal
+            [@debug
                 message="Unable to invoke any of the macro options"
                 context=macroOptions
+                enabled=false
             /]
         [/#if]
     [/#if]

--- a/engine/context.ftl
+++ b/engine/context.ftl
@@ -1,0 +1,223 @@
+[#ftl]
+
+[#-------------------------------------------
+-- Public functions for context processing --
+---------------------------------------------]
+
+[#-- Filters
+
+A filter consists of one or more values for each of one or more filter attributes.
+Filter comparison is a core mechanism of context processing.
+
+When filters need to be compared, a "MatchBehaviour" attribute controls the
+algorithm used. Algorithms are defined in terms of a "contextFilter" and a
+"matchFilter".
+
+The "any" behaviour requires that at least one value of the Any attribute of the
+matchFilter needs to match one value in any of the attributes of the contextFilter.
+
+The "onetoone" behaviour requires that a value of each attribute of the matchFilter
+must match a value of the same named attribute in the contextFilter, or
+the attribute must be absent from the contextFilter. A variant of this is the
+"exclusive onetoone" which requires every matchFilter attribute be present on
+the contextFilter.
+
+One way to think of filters is in terms of Venn Diagrams. Each filter
+defines/matches a set of configuration entities and if the intersection of the
+sets is not empty based on the MatchBehaviour, then the filters match.
+
+--]
+
+[#assign FILTER_ANY_MATCH_BEHAVIOUR = "any"]
+[#assign FILTER_ONETOONE_MATCH_BEHAVIOUR = "onetoone"]
+[#assign FILTER_EXCLUSIVE_ONETOONE_MATCH_BEHAVIOUR = "exclusive"]
+
+[#function filterMatch contextFilter matchFilter matchBehaviour]
+
+    [#switch matchBehaviour]
+        [#case FILTER_ANY_MATCH_BEHAVIOUR]
+            [#if !(matchFilter.Any??)]
+                [#return true]
+            [/#if]
+            [#list contextFilter as key, value]
+                [#if getArrayIntersection(value, matchFilter.Any)?has_content]
+                    [#return true]
+                [/#if]
+            [/#list]
+            [#break]
+
+        [#case FILTER_ONETOONE_MATCH_BEHAVIOUR]
+            [#list matchFilter as key,value]
+                [#if !(contextFilter.key??)]
+                    [#continue]
+                [/#if]
+                [#if !getArrayIntersection(contextFilter.key,value)?has_content]
+                    [#return false]
+                [/#if]
+            [/#list]
+            [#return true]
+            [#break]
+
+        [#case EXCLUSIVE_FILTER_ONETOONE_MATCH_BEHAVIOUR]
+            [#list matchFilter as key,value]
+                [#if !(contextFilter.key??)]
+                    [#return false]
+                [/#if]
+                [#if !getArrayIntersection(contextFilter.key,value)?has_content]
+                    [#return false]
+                [/#if]
+            [/#list]
+            [#return true]
+            [#break]
+    [/#switch]
+    [#return false]
+[/#function]
+
+[#-- Contexts
+
+A context represents a scoping boundary when performing searches for content. A
+context wraps the content, but treats it as opaque.
+
+Each context has a filter than can be used to determine if it should be
+considered during a search.
+
+Contexts are arranged hierarchically so that if a context filter does not match,
+the entire subtree can be excluded from further search activity.
+--]
+
+[#function createContext type content filter={} ]
+    [#return
+        {
+            "Type" : type?lower_case,
+            "Content" : content,
+            "Filter" : filter
+        }]
+[/#function]
+
+[#function createChildContext type content parent={} filterAttribute=""]
+    [#local filterValues = [] ]
+    [#if content.Id??]
+        [#local filterValues += [content.Id] ]
+    [/#if]
+    [#if content.Name??]
+        [#local filterValues += [content.Name] ]
+    [/#if]
+    [#return
+        createContext(
+            type,
+            content,
+            parent.Filter +
+            valueIfContent(
+                {
+                    contentIfContent(filterAttribute, type)?capitalize :
+                        getUniqueArrayElements(filterValues)
+                },
+                filterValues
+            )
+        ) ]
+[/#function]
+
+[#function addChildContexts context childContexts=[] ]
+    [#return
+        context +
+        {
+            "Children" : (context.Children![]) + childContexts
+        } ]
+[/#function]
+
+[#-- Context hierarchies
+
+Commonly used hierarchies
+
+Organisation - Aggregators -> Integrators -> Tenants -> Pods
+Product      - Products -> Environments -> Segments
+Solution     - Solutions -> Tiers -> Components -> SubComponents
+--]
+
+[#function createRootContext content={} ]
+    [#return createContext("root", content)]
+[/#function]
+
+[#function createAggregatorContext aggregator parent={} ]
+    [#return createChildContext("aggregator", aggregator, parent)]
+[/#function]
+
+[#function createIntegratorContext integrator parent={} ]
+    [#return createChildContext("integrator", integrator, parent)]
+[/#function]
+
+[#function createTenantContext tenant parent={} ]
+    [#return createChildContext("tenant", tenant, parent)]
+[/#function]
+
+[#function createPodContext pod parent={} ]
+    [#return createChildContext("pod", removeObjectAttributes(pod, ["Order", "Tiers"]), parent)]
+[/#function]
+
+[#function createProductContext product parent={} ]
+    [#return createChildContext("product", product, parent)]
+[/#function]
+
+[#function createEnvironmentContext environment parent={} ]
+    [#return createChildContext("environment", environment, parent)]
+[/#function]
+
+[#function createSegmentContext segment parent={} ]
+    [#return createChildContext("segment", segment, parent)]
+[/#function]
+
+[#function createSolutionContext parent={} ]
+    [#-- Solution has same filter as parent, but allows for a solution level ancestor --]
+    [#return createChildContext("solution", {}, parent)]
+[/#function]
+
+[#function createTierContext tier parent={} ]
+    [#return createChildContext("tier", removeObjectAttributes(tier, "Components"), parent)]
+[/#function]
+
+[#function createComponentContext component parent={} attribute="" ]
+    [#return createChildContext("component", component, parent, attribute)]
+[/#function]
+
+[#function getContextContent context]
+    [#return context.Content]
+[/#function]
+
+[#-- Context searches
+
+This is the core context searching mechanism which returns as an array the
+contents of all matching contexts.
+
+--]
+
+[#function filterContexts context matchFilter ancestors=true exclusive=true]
+
+    [#-- Terminate the search if no potential for a more specific match --]
+    [#if !filterMatch(context.Filter, matchFilter, FILTER_ONETOONE_MATCH_BEHAVIOUR)]
+        [#return [] ]
+    [/#if]
+
+    [#-- Check for a more specific match on a child --]
+    [#local childContent = [] ]
+    [#list context.Children as child]
+        [#local childContent += filterContexts(child, matchFilter, ancestors, exclusive)]
+    [/#list]
+
+    [#if childContent?has_content]
+        [#-- Optionally add this context as an ancestor and return the matching children --]
+        [return ancestors?then(context.Content, []) + childContent]
+    [#else]
+        [#-- No child matches so this is the last matching context --]
+        [#if exclusive &&
+            (!filterMatch(context.Filter, matchFilter, FILTER_EXCLUSIVE_ONETOONE_MATCH_BEHAVIOUR))]
+            [#-- Not an exclusive match --]
+            [#return [] ]
+        [#else]
+            [#return context.Content]
+        [/#if]
+    [/#if]
+[/#function]
+
+[#-----------------------------------------------------
+-- Internal support functions for context processing --
+-------------------------------------------------------]

--- a/engine/link.ftl
+++ b/engine/link.ftl
@@ -6,8 +6,8 @@
 
 [#function getLinkTarget occurrence link activeOnly=true activeRequired=false]
 
-    [#local instanceToMatch = link.Instance!getOccurrenceInstance(occurrence).Id ]
-    [#local versionToMatch = link.Version!getOccurrenceVersion(occurrence).Id ]
+    [#local instanceToMatch = link.Instance!(getOccurrenceInstance(occurrence).Id) ]
+    [#local versionToMatch = link.Version!(getOccurrenceVersion(occurrence).Id) ]
 
     [@debug
         message="Getting link Target"
@@ -92,7 +92,7 @@
             [#-- If occurrences do not match, overrides can be added --]
             [#-- to the link.                                       --]
             [#if (getOccurrenceInstance(targetSubOccurrence).Id != instanceToMatch) ||
-                (getOccurrenceInstance(targetSubOccurrence).Id != versionToMatch) ]
+                (getOccurrenceVersion(targetSubOccurrence).Id != versionToMatch) ]
                 [#continue]
             [/#if]
 

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -512,3 +512,98 @@
 
 [#include "commonApplication.ftl"]
 
+[#-- Build the context tree corresponding to the provided config --]
+
+[#function constructTiersContext parentContext tiers order=[] ]
+    [#local result = [] ]
+    [#local tierOrder = contentIfContent(order, tiers?keys) ]
+
+    [#list tierOrder as tierId]
+        [#if !(tiers[tierId]??)]
+            [#continue]
+        [/#if]
+        [#local tier = tiers[tierId] ]
+        [#local tierContext = createTierContext(tier, parentContext)]
+        [#local componentContexts = [] ]
+        [#list tier.Components!{} as componentId, component]
+            [#if component?is_hash]
+                [#local componentContexts += [createComponentContext(component, tierContext)] ]
+            [/#if]
+        [/#list]
+        [#local result += [addChildContexts(tierContext, componentContexts)]]
+    [/#list]
+    [#return result]
+[/#function]
+
+[#assign podSolutions =
+    [
+        {
+            "Id" : "default",
+            "Order" : ["region", "account"],
+            "Tiers" : {
+                "region" : {
+                    "Id" : "region",
+                    "Components" : {
+                        "Id" : regionId,
+                        regionId : regionObject
+                    }
+                },
+                "account" : {
+                    "Id" : "account",
+                    "Components" : {
+                        "Id" : accountId,
+                        accountId : accountObject
+                    }
+                }
+            }
+        }
+    ] ]
+
+[#assign rootContext = createRootContext() ]
+
+[#assign tenantContexts = [] ]
+[#list tenants as tenantId, tenant]
+    [#assign tenantContext = createTenantContext(tenantObject, rootContext)]
+
+    [#assign podContexts = [] ]
+    [#list podSolutions as podSolution]
+        [#assign podContext = createPodContext(podSolution, tenantContext)]
+        [#assign podContext =
+            addChildContexts(
+                podContext,
+                constructTiersContext(podContext, podSolution.Tiers!{}, podSolution.Order![])
+            ) ]
+        [#assign podContexts += [podContext]]
+    [/#list]
+
+    [#assign productContexts = [] ]
+    [#list arrayIfContent(productObject!{}, productObject!{}) as product]
+        [#assign productContext = createProductContext(product, tenantContext)]
+        [#assign environmentContexts = [] ]
+        [#list arrayIfContent(environmentObject!{}, environmentObject!{}) as environment]
+            [#assign environmentContext = createEnvironmentContext(environment, productContext)]
+            [#assign segmentContexts = [] ]
+            [#list arrayIfContent(segmentObject!{}, segmentObject!{}) as segment]
+                [#assign segmentContext = createSegmentContext(segment, environmentContext)]
+                [#assign segmentContexts =
+                    [
+                        addChildContexts(
+                            segmentContext,
+                            constructTiersContext(
+                                segmentContext,
+                                blueprintObject.Tiers,
+                                segmentObject.Tiers.Order
+                            )
+                        )
+                    ] ]
+            [/#list]
+            [#assign environmentContexts += [addChildContexts(environmentContext, segmentContexts)] ]
+        [/#list]
+        [#assign productContexts += [addChildContexts(productContext, environmentContexts)] ]
+    [/#list]
+
+    [#assign tenantContexts += [addChildContexts(tenantContext, podContexts + productContexts)] ]
+[/#list]
+
+[#assign rootContext = addChildContexts(rootContext, tenantContexts)]
+

--- a/providers/aws/components/federatedrole/setup.ftl
+++ b/providers/aws/components/federatedrole/setup.ftl
@@ -84,6 +84,8 @@
     [#local unauthenticatedRole = ""]
     [#local ruleAssignments = {} ]
 
+    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+
     [#list occurrence.Occurrences![] as subOccurrence]
 
         [#local subCore = subOccurrence.Core ]
@@ -105,7 +107,7 @@
                 "Instance" : core.Instance.Id,
                 "Version" : core.Version.Id,
                 "Links" : contextLinks,
-                "Policy" : standardPolicies(subOccurrence),
+                "Policy" : standardPolicies(subOccurrence, baselineComponentIds),
                 "ManagedPolicy" : [],
                 "Assignment" : subCore.SubComponent.Id
             }

--- a/providers/aws/components/user/setup.ftl
+++ b/providers/aws/components/user/setup.ftl
@@ -61,7 +61,7 @@
             "DefaultCoreVariables" : false,
             "DefaultEnvironmentVariables" : false,
             "DefaultLinkVariables" : false,
-            "Policy" : standardPolicies(occurrence)
+            "Policy" : standardPolicies(occurrence, baselineComponentIds)
         }
     ]
 

--- a/providers/shared/deploymentframeworks/default/output.ftl
+++ b/providers/shared/deploymentframeworks/default/output.ftl
@@ -7,6 +7,7 @@
 [#-- Default output types --]
 [#assign DEFAULT_OUTPUT_SCRIPT_TYPE = "script"]
 [#assign DEFAULT_OUTPUT_JSON_TYPE = "json"]
+[#assign DEFAULT_OUTPUT_MODEL_TYPE = "model"]
 
 [#-- Script output --]
 
@@ -129,4 +130,11 @@
                 }
             }
     /]
+[/#macro]
+
+[#-- DEFAULT_OUTPUT_MODEL_TYPE --]
+[#macro default_output_model level include]
+    [@initialiseJsonOutput name=DEFAULT_OUTPUT_JSON_TYPE /]
+    [@addToDefaultJsonOutput content=rootContext /]
+    [@serialiseOutput name=DEFAULT_OUTPUT_JSON_TYPE /]
 [/#macro]


### PR DESCRIPTION
In order to accommodate accounts and regions as well as cross-product
links, introduce a new in-memory model for processing based on contexts.
It has been designed to make link processing efficient along with
calculating hierarchical overrides and qualification.

So far the code generates a simplified model but doesn't do anything with it.

In order to assist in debugging the new model, a special unit of "model"
has been added to the application level. It produces a config file
containing the model prior to processing commencing.

This commit also fixes a bug with link processing where
instance/versioning processing was wasn't correct.

It also fixes a couple of instances where calls the standardPolices
weren't including the now mandatory baseline links parameter.