### PR TITLE
<fix> Baseline Attributes in default Env

### DIFF
--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -259,13 +259,7 @@
             occurrence.State!{},
             {
                 "ResourceGroups" : groupState,
-                "Attributes" :
-                    contentIfContent(
-                            attributes,
-                            {
-                                "NOATTRIBUTES" : "Attributes not found"
-                            }
-                    )
+                "Attributes" : attributes
             } +
             removeObjectAttributes(legacyState, "Attributes")
         ) ]

--- a/providers/aws/components/apigateway/setup.ftl
+++ b/providers/aws/components/apigateway/setup.ftl
@@ -33,7 +33,8 @@
                                                 swaggerFileName)]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData" ] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
 
@@ -44,10 +45,12 @@
             "Name" : fragment,
             "Instance" : core.Instance.Id,
             "Version" : core.Version.Id,
-            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks),
+            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks, baselineLinks),
             "Environment" : {},
             "Links" : contextLinks,
+            "BaselineLinks" : baselineLinks,
             "DefaultCoreVariables" : false,
+            "DefaultBaselineVariables" : false,
             "DefaultEnvironmentVariables" : false,
             "DefaultLinkVariables" : false,
             "Policy" : []
@@ -60,7 +63,7 @@
         [#include fragmentList?ensure_starts_with("/")]
     [/#if]
 
-    [#local stageVariables += getFinalEnvironment(occurrence, _context, operationsBucket, dataBucket).Environment ]
+    [#local stageVariables += getFinalEnvironment(occurrence, _context ).Environment ]
 
     [#local cognitoPools = {} ]
 

--- a/providers/aws/components/baseline/setup.ftl
+++ b/providers/aws/components/baseline/setup.ftl
@@ -51,7 +51,9 @@
     [/#if]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "Encryption" ], true, false, false )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "Encryption" ], true, false, false )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+    
     [#local cmkKeyId = baselineComponentIds["Encryption" ]]
 
     [@debug message={ "KeyId" : cmkKeyId } enabled=true /]

--- a/providers/aws/components/baseline/state.ftl
+++ b/providers/aws/components/baseline/state.ftl
@@ -89,7 +89,7 @@
                 }
             },
             "Attributes" : {
-                "ID" : bucketId
+                "BUCKET" : getExistingReference(bucketId)
             },
             "Roles" : {
                 "Inbound" : {},
@@ -107,9 +107,6 @@
     [#local parentState = parent.State ]
 
     [#local resources = {}]
-    [#local attributes = {
-                "ID" : "COTFatal: Id missing for subcomponent"
-    }]
 
     [#switch solution.Engine ]
         [#case "cmk"]
@@ -146,7 +143,6 @@
                     }
                 }
             ]
-            [#local attributes = { "ID" : cmkOutputId }]
 
             [#break]
 
@@ -179,7 +175,6 @@
                 }
             ]
 
-            [#local attributes = { "ID" : keyPairId } ]
             [#break]
         [#case "oai"]
 
@@ -195,12 +190,6 @@
                     }
                 }
             ]
-            [#local oaiIdAttribute = getExistingReference(OAIId, ALLOCATION_ATTRIBUTE_TYPE)?has_content?then(
-                                                getExistingReference(OAIId,ALLOCATION_ATTRIBUTE_TYPE),
-                                                OAIId
-            )]
-            [#local attributes += { "ID" : oaiIdAttribute } ]
-
             [#break]
         [#default]
             [@fatal
@@ -213,7 +202,7 @@
     [#assign componentState =
         {
             "Resources" : resources,
-            "Attributes" : attributes,
+            "Attributes" : {},
             "Roles" : {
                 "Inbound" : {},
                 "Outbound" : {}

--- a/providers/aws/components/computecluster/setup.ftl
+++ b/providers/aws/components/computecluster/setup.ftl
@@ -30,7 +30,8 @@
     [#local bootstrapProfile = getBootstrapProfile(occurrence, "ComputeCluster")]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
 
@@ -121,12 +122,14 @@
             "Name" : fragment,
             "Instance" : core.Instance.Id,
             "Version" : core.Version.Id,
-            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks),
+            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks, baselineLinks),
             "Environment" : {},
             "Links" : contextLinks,
+            "BaselineLinks" : baselineLinks,
             "DefaultCoreVariables" : true,
             "DefaultEnvironmentVariables" : true,
             "DefaultLinkVariables" : true,
+            "DefaultBaselineVariables" : true,
             "Policy" : [],
             "ManagedPolicy" : [],
             "Files" : {},
@@ -138,7 +141,7 @@
     [#local fragmentId = formatFragmentId(_context)]
     [#include fragmentList?ensure_starts_with("/")]
 
-    [#local environmentVariables += getFinalEnvironment(occurrence, _context, operationsBucket, dataBucket ).Environment ]
+    [#local environmentVariables += getFinalEnvironment(occurrence, _context ).Environment ]
 
     [#local configSets +=
         getInitConfigEnvFacts(environmentVariables, false) +

--- a/providers/aws/components/configstore/setup.ftl
+++ b/providers/aws/components/configstore/setup.ftl
@@ -16,7 +16,8 @@
     [#local tableSortKey = parentResources["table"].SortKey!"" ]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData" ] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
 
@@ -91,10 +92,12 @@
                 "Version" : parentCore.Version.Id,
                 "Environment" : {},
                 "Links" : contextLinks,
-                "DefaultEnvironment" : defaultEnvironment(subOccurrence, contextLinks),
+                "BaselineLinks" : baselineLinks,
+                "DefaultEnvironment" : defaultEnvironment(subOccurrence, contextLinks, baselineLinks),
                 "DefaultCoreVariables" : false,
                 "DefaultEnvironmentVariables" : false,
                 "DefaultLinkVariables" : true,
+                "DefaultBaselineVariables" : false,
                 "Branch" : formatName(itemPrimaryKey + itemSecondaryKey)
             }
         ]
@@ -102,7 +105,7 @@
         [#-- Add in fragment specifics including override of defaults --]
         [#include fragmentList?ensure_starts_with("/")]
 
-        [#local finalEnvironment = getFinalEnvironment(subOccurrence, _context, operationsBucket, dataBucket ) ]
+        [#local finalEnvironment = getFinalEnvironment(subOccurrence, _context ) ]
         [#assign _context += finalEnvironment ]
 
         [#assign _context +=

--- a/providers/aws/components/datafeed/setup.ftl
+++ b/providers/aws/components/datafeed/setup.ftl
@@ -33,7 +33,8 @@
     [#local streamProcessors = []]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "AppData", "Encryption"] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "AppData", "Encryption"] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#local dataBucketId        = baselineComponentIds["AppData"]]
     [#local dataBucket          = getExistingReference(dataBucketId) ]

--- a/providers/aws/components/datapipeline/setup.ftl
+++ b/providers/aws/components/datapipeline/setup.ftl
@@ -29,7 +29,8 @@
     [#local emrProcessorProfile = getProcessor(occurrence, "EMR")]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
     [#local sshKeyPairId = baselineComponentIds["SSHKey"] ]
@@ -86,13 +87,15 @@
             "Name" : fragment,
             "Instance" : core.Instance.Id,
             "Version" : core.Version.Id,
-            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks),
+            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks, baselineLinks),
             "Environment" : {},
             "Links" : contextLinks,
+            "BaselineLinks" : baselineLinks,
             "Policy" : standardPolicies(occurrence, baselineComponentIds),
             "DefaultCoreVariables" : true,
             "DefaultEnvironmentVariables" : true,
-            "DefaultLinkVariables" : true
+            "DefaultLinkVariables" : true,
+            "DefaultBaselineVariables" : true
         }
     ]
 
@@ -101,7 +104,7 @@
         [#include fragmentList?ensure_starts_with("/")]
     [/#if]
 
-    [#assign _context += getFinalEnvironment(occurrence, _context, operationsBucket, dataBucket) ]
+    [#assign _context += getFinalEnvironment(occurrence, _context ) ]
     [#local parameterValues += _context.Environment ]
 
     [#local myParameterValues = {}]

--- a/providers/aws/components/datavolume/setup.ftl
+++ b/providers/aws/components/datavolume/setup.ftl
@@ -16,7 +16,8 @@
 
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "Encryption"] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "Encryption"] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#local cmkKeyId = baselineComponentIds["Encryption" ]]
 

--- a/providers/aws/components/ec2/setup.ftl
+++ b/providers/aws/components/ec2/setup.ftl
@@ -29,7 +29,8 @@
     [#local bootstrapProfile       = getBootstrapProfile(occurrence, "EC2")]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
     [#local sshKeyPairId = baselineComponentIds["SSHKey"] ]
@@ -101,12 +102,14 @@
             "Name" : fragment,
             "Instance" : core.Instance.Id,
             "Version" : core.Version.Id,
-            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks),
+            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks, baselineLinks),
             "Environment" : {},
             "Links" : contextLinks,
+            "BaselineLinks" : baselineLinks,
             "DefaultCoreVariables" : true,
             "DefaultEnvironmentVariables" : false,
             "DefaultLinkVariables" : true,
+            "DefaultBaselineVariables" : true,
             "Policy" : [],
             "ManagedPolicy" : [],
             "Files" : {},
@@ -119,7 +122,7 @@
     [#local fragmentId = formatFragmentId(_context)]
     [#include fragmentList?ensure_starts_with("/")]
 
-    [#local environmentVariables += getFinalEnvironment(occurrence, _context, operationsBucket, dataBucket ).Environment ]
+    [#local environmentVariables += getFinalEnvironment(occurrence, _context ).Environment ]
 
     [#local configSets +=
         getInitConfigEnvFacts(environmentVariables, false) +

--- a/providers/aws/components/ecs/setup.ftl
+++ b/providers/aws/components/ecs/setup.ftl
@@ -35,7 +35,8 @@
     [#local bootstrapProfile = getBootstrapProfile(occurrence, "ECS")]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
@@ -81,12 +82,14 @@
             "Name" : fragment,
             "Instance" : core.Instance.Id,
             "Version" : core.Version.Id,
-            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks),
+            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks, baselineLinks),
             "Environment" : {},
             "Links" : contextLinks,
+            "BaselineLinks" : baselineLinks,
             "DefaultCoreVariables" : true,
             "DefaultEnvironmentVariables" : true,
             "DefaultLinkVariables" : true,
+            "DefaultBaselineVariables" : true,
             "Policy" : [],
             "ManagedPolicy" : [],
             "Files" : {},
@@ -98,7 +101,7 @@
     [#local fragmentId = formatFragmentId(_context)]
     [#include fragmentList?ensure_starts_with("/")]
 
-    [#local environmentVariables += getFinalEnvironment(occurrence, _context, operationsBucket, dataBucket ).Environment ]
+    [#local environmentVariables += getFinalEnvironment(occurrence, _context).Environment ]
 
     [#local configSets +=
         getInitConfigEnvFacts(environmentVariables, false) +
@@ -337,7 +340,8 @@
     [#local ecsServiceRoleId = parentResources["serviceRole"].Id ]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(parentSolution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption" ] )]
+    [#local baselineLinks = getBaselineLinks(parentSolution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
 
     [#local occurrenceNetwork = getOccurrenceNetwork(occurrence) ]

--- a/providers/aws/components/efs/setup.ftl
+++ b/providers/aws/components/efs/setup.ftl
@@ -38,7 +38,8 @@
                                             efsPort)]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "Encryption"] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "Encryption"] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local cmkKeyId = baselineComponentIds["Encryption" ]]
 
     [#if deploymentSubsetRequired("efs", true) ]

--- a/providers/aws/components/es/setup.ftl
+++ b/providers/aws/components/es/setup.ftl
@@ -20,7 +20,8 @@
     [#local master = processorProfile.Master!{}]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local cmkKeyId = baselineComponentIds["Encryption"] ]
 
     [#local esUpdateCommand = "updateESDomain" ]

--- a/providers/aws/components/federatedrole/setup.ftl
+++ b/providers/aws/components/federatedrole/setup.ftl
@@ -84,7 +84,8 @@
     [#local unauthenticatedRole = ""]
     [#local ruleAssignments = {} ]
 
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#list occurrence.Occurrences![] as subOccurrence]
 

--- a/providers/aws/components/lambda/setup.ftl
+++ b/providers/aws/components/lambda/setup.ftl
@@ -24,7 +24,9 @@
         [#local fnLgName = resources["lg"].Name ]
 
         [#-- Baseline component lookup --]
-        [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption" ] )]
+        [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption" ] )]
+        [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+
         [#local cmkKeyId = baselineComponentIds["Encryption" ]]
         [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
         [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
@@ -55,7 +57,7 @@
                 "Name" : fragment,
                 "Instance" : core.Instance.Id,
                 "Version" : core.Version.Id,
-                "DefaultEnvironment" : defaultEnvironment(fn, contextLinks),
+                "DefaultEnvironment" : defaultEnvironment(fn, contextLinks, baselineLinks),
                 "Environment" : {},
                 "S3Bucket" : getRegistryEndPoint("lambda", occurrence),
                 "S3Key" :
@@ -66,9 +68,11 @@
                         "lambda.zip"
                     ),
                 "Links" : contextLinks,
+                "BaselineLinks" : baselineLinks,
                 "DefaultCoreVariables" : true,
                 "DefaultEnvironmentVariables" : true,
                 "DefaultLinkVariables" : true,
+                "DefaultBaselineVariables" : true,
                 "Policy" : standardPolicies(fn, baselineComponentIds),
                 "ManagedPolicy" : [],
                 "CodeHash" : solution.FixedCodeVersion.CodeHash
@@ -152,8 +156,8 @@
             }]
         [/#if]
 
-        [#local finalEnvironment = getFinalEnvironment(fn, _context, operationsBucket, dataBucket, solution.Environment) ]
-        [#local finalAsFileEnvironment = getFinalEnvironment(fn, _context, operationsBucket, dataBucket, solution.Environment + {"AsFile" : false}) ]
+        [#local finalEnvironment = getFinalEnvironment(fn, _context, solution.Environment) ]
+        [#local finalAsFileEnvironment = getFinalEnvironment(fn, _context, solution.Environment + {"AsFile" : false}) ]
         [#assign _context += finalEnvironment ]
 
         [#local roleId = formatDependentRoleId(fnId)]

--- a/providers/aws/components/mobileapp/state.ftl
+++ b/providers/aws/components/mobileapp/state.ftl
@@ -20,7 +20,8 @@
             )
     ]
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData" ] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     

--- a/providers/aws/components/rds/setup.ftl
+++ b/providers/aws/components/rds/setup.ftl
@@ -16,7 +16,8 @@
     [#local attributes = occurrence.State.Attributes ]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local cmkKeyId = baselineComponentIds["Encryption"] ]
     [#local cmkKeyArn = getReference(cmkKeyId, ARN_ATTRIBUTE_TYPE)]
 

--- a/providers/aws/components/spa/setup.ftl
+++ b/providers/aws/components/spa/setup.ftl
@@ -20,7 +20,7 @@
             "Name" : fragment,
             "Instance" : core.Instance.Id,
             "Version" : core.Version.Id,
-            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks),
+            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks, baselineLinks),
             "Environment" : {},
             "Links" : contextLinks,
             "DefaultCoreVariables" : false,
@@ -138,7 +138,8 @@
     [/#if]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "CDNOriginKey", "OpsData", "AppData" ] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "CDNOriginKey", "OpsData", "AppData" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#local cfAccess         = getExistingReference(baselineComponentIds["CDNOriginKey"]) ]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
@@ -350,7 +351,8 @@
 
     [#local fragment = getOccurrenceFragmentBase(occurrence) ]
 
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData"] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData"] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
 
@@ -361,12 +363,14 @@
             "Name" : fragment,
             "Instance" : core.Instance.Id,
             "Version" : core.Version.Id,
-            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks),
+            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks, baselineLinks),
             "Environment" : {},
             "Links" : contextLinks,
+            "BaselineLinks" : baselineLinks,
             "DefaultCoreVariables" : false,
             "DefaultEnvironmentVariables" : false,
-            "DefaultLinkVariables" : false
+            "DefaultLinkVariables" : false,
+            "DefaultBaselineVariables" : false
         }
     ]
 
@@ -374,7 +378,7 @@
     [#local fragmentId = formatFragmentId(_context)]
     [#include fragmentList?ensure_starts_with("/")]
 
-    [#assign _context += getFinalEnvironment(occurrence, _context, operationsBucket, dataBucket ) ]
+    [#assign _context += getFinalEnvironment(occurrence, _context) ]
 
     [#if deploymentSubsetRequired("config", false)]
         [@addToDefaultJsonOutput

--- a/providers/aws/components/topic/setup.ftl
+++ b/providers/aws/components/topic/setup.ftl
@@ -15,7 +15,8 @@
     [#local topicName = resources["topic"].Name ]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "Encryption" ] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "Encryption" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local cmkKeyId = baselineComponentIds["Encryption"] ]
 
     [#if deploymentSubsetRequired(TOPIC_COMPONENT_TYPE, true)]

--- a/providers/aws/components/user/setup.ftl
+++ b/providers/aws/components/user/setup.ftl
@@ -17,7 +17,8 @@
     [#local apikeyName = resources["apikey"].Name]
 
     [#-- Baseline component lookup --]
-    [#local baselineComponentIds = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local cmkKeyId = baselineComponentIds["Encryption"] ]
     [#local cmkKeyArn = getExistingReference(cmkKeyId, ARN_ATTRIBUTE_TYPE)]
 
@@ -55,7 +56,7 @@
             "Name" : fragment,
             "Instance" : core.Instance.Id,
             "Version" : core.Version.Id,
-            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks),
+            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks, baselineLinks),
             "Environment" : {},
             "Links" : contextLinks,
             "DefaultCoreVariables" : false,


### PR DESCRIPTION
Reworks the baseline link setup to work in a similar way to other link processing when determining attributes and environment. 

Previously we treated the baseline attributes as special named attributes applied in the environment as default options. 

This aligns baseline links with existing links so that any baseline component can contribute environment variables to components which use them. At the moment this just covers the existing APPDATA_BUCKET and OPSDATA_BUCKET variables but could change in the future

This fixes an issue with the baseline attributes being removed from the defaultEnvironment which meant they wern't available to fragment files 

Also removes a default Attribute of NOATTRIBUTES and instead relies on the environment variable settings processing to determine if this is a problem or not. Mostly because some baseline components don't really have attributes ( KMS keys etc ) 