### PR TITLE
<fix> Default id and name for subobjects

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -434,19 +434,26 @@ behaviour.
                             [#local attributeResult +=
                                 {
                                   subobjectKey :
-                                      getCompositeObject(
-                                          [
-                                              {
-                                                  "Names" : "Id",
-                                                  "Mandatory" : true
-                                              },
-                                              {
-                                                  "Names" : "Name",
-                                                  "Mandatory" : true
-                                              }
-                                          ] +
-                                          attribute.Children,
-                                          subobjectValues)
+                                        getCompositeObject(
+                                            [
+                                                {
+                                                    "Names" : "Id",
+                                                    "Mandatory" : true
+                                                },
+                                                {
+                                                    "Names" : "Name",
+                                                    "Mandatory" : true
+                                                }
+                                            ] +
+                                            attribute.Children,
+                                            [
+                                                {
+                                                    "Id" : subobjectKey,
+                                                    "Name" : subobjectKey
+                                                }
+                                            ] +
+                                            subobjectValues
+                                        )
                                 }
                             ]
                         [/#list]


### PR DESCRIPTION
When generating subobject structures, default the subobject id and name
to the subobject key.

This avoids the need to add id/name explicitly to config files such as
the master data.