### PR TITLE
<fix> Ignore iam/lg resources for deployment state

### DIFF
--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -780,7 +780,7 @@
         [#if resources?has_content ]
             [#list resources as alias,resource]
                 [#if resource.Id?has_content]
-                    [#if resource.Deployed]
+                    [#if resource.Deployed && resource.IncludeInDeploymentState!true]
                         [#return true]
                     [/#if]
                 [#else]

--- a/providers/aws/components/apigateway/state.ftl
+++ b/providers/aws/components/apigateway/state.ftl
@@ -331,12 +331,14 @@ created in either case.
                 "lg" : {
                     "Id" : lgId,
                     "Name" : lgName,
-                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 },
                 "accesslg" : {
                     "Id" : accessLgId,
                     "Name" : accessLgName,
-                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 }
             } +
             attributeIfContent("logMetrics", logMetrics) +

--- a/providers/aws/components/bastion/state.ftl
+++ b/providers/aws/components/bastion/state.ftl
@@ -36,7 +36,8 @@
                 "lg" : {
                     "Id" : formatLogGroupId(core.Id),
                     "Name" : core.FullAbsolutePath,
-                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 },
                 "launchConfig" : {
 

--- a/providers/aws/components/computecluster/state.ftl
+++ b/providers/aws/components/computecluster/state.ftl
@@ -29,7 +29,8 @@
                 "lg" : {
                     "Id" : formatLogGroupId(core.Id),
                     "Name" : core.FullAbsolutePath,
-                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 },
                 "launchConfig" : {
                     "Id" : solution.AutoScaling.AlwaysReplaceOnUpdate?then(

--- a/providers/aws/components/datafeed/state.ftl
+++ b/providers/aws/components/datafeed/state.ftl
@@ -27,17 +27,20 @@
                     "lg" : {
                         "Id" : lgId,
                         "Name" : core.FullAbsolutePath,
-                        "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+                        "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,
+                        "IncludeInDeploymentState" : false
                     },
                     "backuplgstream" : {
                         "Id" : formatDependentResourceId(AWS_CLOUDWATCH_LOG_GROUP_STREAM_RESOURCE_TYPE, lgId, "backup"),
                         "Name" : "S3Delivery",
-                        "Type" : AWS_CLOUDWATCH_LOG_GROUP_STREAM_RESOURCE_TYPE
+                        "Type" : AWS_CLOUDWATCH_LOG_GROUP_STREAM_RESOURCE_TYPE,
+                        "IncludeInDeploymentState" : false
                     },
                     "streamlgstream" : {
                         "Id" : formatDependentResourceId(AWS_CLOUDWATCH_LOG_GROUP_STREAM_RESOURCE_TYPE, lgId, "stream"),
                         "Name" : "ElasticsearchDelivery",
-                        "Type" : AWS_CLOUDWATCH_LOG_GROUP_STREAM_RESOURCE_TYPE
+                        "Type" : AWS_CLOUDWATCH_LOG_GROUP_STREAM_RESOURCE_TYPE,
+                        "IncludeInDeploymentState" : false
                     }
                 },
                 {}
@@ -46,7 +49,8 @@
                 {
                     "subscriptionRole" : {
                         "Id" : formatResourceId(AWS_IAM_ROLE_RESOURCE_TYPE, core.Id, "subscription"),
-                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                        "IncludeInDeploymentState" : false
                     }
                 },
                 {}

--- a/providers/aws/components/ec2/state.ftl
+++ b/providers/aws/components/ec2/state.ftl
@@ -51,7 +51,8 @@
                 "lg" : {
                     "Id" : formatLogGroupId(core.Id),
                     "Name" : core.FullAbsolutePath,
-                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 },
                 "Zones" : zoneResources
             },

--- a/providers/aws/components/ecs/state.ftl
+++ b/providers/aws/components/ecs/state.ftl
@@ -93,12 +93,14 @@
                 "lg" : {
                     "Id" : lgId,
                     "Name" : lgName,
-                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 },
                 "lgInstanceLog" : {
                     "Id" : lgInstanceLogId,
                     "Name" : lgInstanceLogName,
-                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 }
             } +
             attributeIfContent("logMetrics", logMetrics),

--- a/providers/aws/components/lambda/setup.ftl
+++ b/providers/aws/components/lambda/setup.ftl
@@ -128,9 +128,9 @@
                                         [#break]
                                     [#case TOPIC_COMPONENT_TYPE ]
                                         [#if linkTargetAttributes["ARN"]?has_content ]
-                                            [@createSNSSubscription 
+                                            [@createSNSSubscription
                                                 id=formatDependentSNSSubscriptionId(fn, "link", linkName)
-                                                topicId=linkTargetResources["topic"].Id 
+                                                topicId=linkTargetResources["topic"].Id
                                                 endpoint=getReference(fnId, ARN_ATTRIBUTE_TYPE)
                                                 protocol="lambda"
                                             /]

--- a/providers/aws/components/lambda/state.ftl
+++ b/providers/aws/components/lambda/state.ftl
@@ -63,7 +63,8 @@
                 "lg" : {
                     "Id" : formatLogGroupId(core.Id),
                     "Name" : lgName,
-                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 }
             } +
             attributeIfContent("logMetrics", logMetrics) +

--- a/providers/aws/components/mobilenotifier/state.ftl
+++ b/providers/aws/components/mobilenotifier/state.ftl
@@ -82,12 +82,14 @@
                 "lg" : {
                     "Id" : lgId,
                     "Name" : lgName,
-                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 },
                 "lgfailure" : {
                     "Id" : lgFailureId,
                     "Name" : lgFailureName,
-                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+                    "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 }
             } +
             attributeIfContent("logMetrics", logMetrics),


### PR DESCRIPTION
Iam and lg resources can be created via the iam and lg units before the corresponding occurrences actually exist.

This commit adds a flag that can be put on any resource in the state of an occurrence. The flag controls whether the resource is considered when deciding if the occurrence is deployed or not.