### PR TITLE
<fix> Ignore role resources in deployment state

### DIFF
--- a/providers/aws/components/bastion/state.ftl
+++ b/providers/aws/components/bastion/state.ftl
@@ -22,7 +22,8 @@
                 },
                 "role" : {
                     "Id" : formatResourceId( AWS_IAM_ROLE_RESOURCE_TYPE, core.Id ),
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 },
                 "instanceProfile" : {
                     "Id" : formatResourceId( AWS_EC2_INSTANCE_PROFILE_RESOURCE_TYPE, core.Id ),

--- a/providers/aws/components/computecluster/state.ftl
+++ b/providers/aws/components/computecluster/state.ftl
@@ -15,7 +15,8 @@
                 },
                 "role" : {
                     "Id" : formatResourceId( AWS_IAM_ROLE_RESOURCE_TYPE, core.Id ),
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 },
                 "instanceProfile" : {
                     "Id" : formatResourceId( AWS_EC2_INSTANCE_PROFILE_RESOURCE_TYPE, core.Id ),

--- a/providers/aws/components/datafeed/state.ftl
+++ b/providers/aws/components/datafeed/state.ftl
@@ -19,7 +19,8 @@
                 },
                 "role" : {
                     "Id" : formatResourceId(AWS_IAM_ROLE_RESOURCE_TYPE, core.Id),
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 }
             } +
             solution.Logging?then(

--- a/providers/aws/components/datapipeline/state.ftl
+++ b/providers/aws/components/datapipeline/state.ftl
@@ -21,12 +21,14 @@
                 "pipelineRole" : {
                     "Id" : formatResourceId( AWS_IAM_ROLE_RESOURCE_TYPE, core.Id, "pipeline" ),
                     "Name" : formatName(core.FullName, "pipeline"),
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 },
                 "resourceRole" : {
                     "Id" : formatResourceId( AWS_IAM_ROLE_RESOURCE_TYPE, core.Id, "resource" ),
                     "Name" : resourceRoleName,
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 },
                 "resourceInstanceProfile" : {
                     "Id" : formatResourceId( AWS_EC2_INSTANCE_PROFILE_RESOURCE_TYPE, core.Id ),

--- a/providers/aws/components/datavolume/state.ftl
+++ b/providers/aws/components/datavolume/state.ftl
@@ -65,11 +65,13 @@
                     },
                     "maintenanceServiceRole" : {
                         "Id" : formatResourceId( AWS_IAM_ROLE_RESOURCE_TYPE, "service", core.Id  ),
-                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                        "IncludeInDeploymentState" : false
                     },
                     "maintenanceLambdaRole" : {
                         "Id" : formatResourceId( AWS_IAM_ROLE_RESOURCE_TYPE, "lambda", core.Id ),
-                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                        "IncludeInDeploymentState" : false
                     }
                 },
                 {}

--- a/providers/aws/components/ec2/state.ftl
+++ b/providers/aws/components/ec2/state.ftl
@@ -46,7 +46,8 @@
                 },
                 "ec2Role" : {
                     "Id" : formatComponentRoleId(core.Tier, core.Component),
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 },
                 "lg" : {
                     "Id" : formatLogGroupId(core.Id),

--- a/providers/aws/components/ecs/state.ftl
+++ b/providers/aws/components/ecs/state.ftl
@@ -69,11 +69,13 @@
                 },
                 "role" : {
                     "Id" : formatComponentRoleId(core.Tier, core.Component),
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 },
                 "serviceRole" : {
                     "Id" : formatComponentRoleId(core.Tier, core.Component, "service"),
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 },
                 "instanceProfile" : {
                     "Id" : formatEC2InstanceProfileId(core.Tier, core.Component),
@@ -168,7 +170,8 @@
                 solution.UseTaskRole,
                 {
                     "Id" : formatDependentRoleId(taskId),
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 }
             ) +
             attributeIfTrue(
@@ -184,7 +187,8 @@
                 solution.Engine == "fargate",
                 {
                     "Id" : formatDependentRoleId(taskId, "execution"),
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 }
             ),
             "Attributes" : {
@@ -256,7 +260,8 @@
                 solution.UseTaskRole,
                 {
                     "Id" : taskRoleId,
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 }
             ) +
             attributeIfContent(
@@ -264,7 +269,8 @@
                 solution.Schedules,
                 {
                     "Id" : formatDependentRoleId(taskId, "schedule"),
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 }
             ) +
             attributeIfTrue(
@@ -280,7 +286,8 @@
                 solution.Engine == "fargate",
                 {
                     "Id" : formatDependentRoleId(taskId, "execution"),
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 }
             ),
             "Attributes" : {

--- a/providers/aws/components/es/state.ftl
+++ b/providers/aws/components/es/state.ftl
@@ -48,7 +48,8 @@
                     },
                     "servicerole" : {
                         "Id" : formatDependentRoleId(esId),
-                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                        "IncludeInDeploymentState" : false
                     }
                 },
                 "Attributes" : {

--- a/providers/aws/components/network/state.ftl
+++ b/providers/aws/components/network/state.ftl
@@ -101,12 +101,14 @@
                 { "flowlogs" : {
                     "flowLogRole" : {
                         "Id" : formatDependentRoleId(vpcId),
-                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                        "IncludeInDeploymentState" : false
                     },
                     "flowLogLg" : {
                         "Id" : formatDependentLogGroupId(vpcId, "all"),
                         "Name" : flowLogLgName,
-                        "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+                        "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,
+                        "IncludeInDeploymentState" : false
                     },
                     "flowLog" : {
                         "Id" : flowLogId,

--- a/providers/aws/components/s3/state.ftl
+++ b/providers/aws/components/s3/state.ftl
@@ -27,7 +27,8 @@
                 },
                 "role" : {
                     "Id" : formatResourceId( AWS_IAM_ROLE_RESOURCE_TYPE, core.Id ),
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 }
             } +
             publicAccessEnabled?then(


### PR DESCRIPTION
For most components, roles being deployed may not mean the component is deployed since they may have been created in an iam unit.