### PR TITLE
<fix> SPA baseline processing

### DIFF
--- a/providers/aws/components/spa/setup.ftl
+++ b/providers/aws/components/spa/setup.ftl
@@ -13,6 +13,13 @@
 
     [#local fragment = getOccurrenceFragmentBase(occurrence) ]
 
+    [#-- Baseline component lookup --]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "CDNOriginKey", "OpsData", "AppData" ])]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+    [#local cfAccess         = getExistingReference(baselineComponentIds["CDNOriginKey"]!"") ]
+    [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]!"") ]
+    [#local dataBucket       = getExistingReference(baselineComponentIds["AppData"]!"") ]
+
     [#local contextLinks = getLinkTargets(occurrence) ]
     [#assign _context =
         {
@@ -136,14 +143,6 @@
     [#if !getExistingReference(bucketId)?has_content ]
         [#local bucketId = formatS3OperationsId() ]
     [/#if]
-
-    [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "CDNOriginKey", "OpsData", "AppData" ] )]
-    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
-
-    [#local cfAccess         = getExistingReference(baselineComponentIds["CDNOriginKey"]) ]
-    [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
-    [#local dataBucket       = getExistingReference(baselineComponentIds["AppData"]) ]
 
     [#if !cfAccess?has_content]
         [@precondition

--- a/providers/aws/masterData.json
+++ b/providers/aws/masterData.json
@@ -1101,27 +1101,19 @@
           "baseline": {
             "DataBuckets": {
               "opsdata": {
-                "Id": "opsdata",
-                "Name": "opsdata",
                 "Role": "operations",
                 "Lifecycles": {
                   "awslogs": {
-                    "Id" : "awslogs",
-                    "Name" : "awslogs",
                     "Prefix": "AWSLogs",
                     "Expiration": "_operations",
                     "Offline": "_operations"
                   },
                   "cloudfront": {
-                    "Id" : "cloudfront",
-                    "Name" : "cloudfront",
                     "Prefix": "CLOUDFRONTLogs",
                     "Expiration": "_operations",
                     "Offline": "_operations"
                   },
                   "docker": {
-                    "Id" : "docker",
-                    "Name" : "docker",
                     "Prefix": "DOCKERLogs",
                     "Expiration": "_operations",
                     "Offline": "_operations"
@@ -1129,8 +1121,6 @@
                 },
                 "Links": {
                   "cf_key": {
-                    "Id" : "cf_key",
-                    "Name" : "cf_key",
                     "Tier": "mgmt",
                     "Component": "baseline",
                     "Instance": "",
@@ -1140,13 +1130,9 @@
                 }
               },
               "appdata": {
-                "Id": "appdata",
-                "Name": "appdata",
                 "Role": "appdata",
                 "Lifecycles": {
                   "global": {
-                    "Id" : "global",
-                    "Name" : "global",
                     "Expiration": "_data",
                     "Offline": "_data"
                   }
@@ -1155,18 +1141,12 @@
             },
             "Keys": {
               "ssh": {
-                "Id": "ssh",
-                "Name": "ssh",
                 "Engine": "ssh"
               },
               "cmk": {
-                "Id": "cmk",
-                "Name": "cmk",
                 "Engine": "cmk"
               },
               "oai": {
-                "Id": "oai",
-                "Name": "oai",
                 "Engine": "oai"
               }
             }

--- a/providers/shared/components/baseline/id.ftl
+++ b/providers/shared/components/baseline/id.ftl
@@ -9,6 +9,14 @@
 [#function getBaselineComponentIds links ]
     [#local ids = {}]
     [#list links as linkName, linkTarget ]
+        [#if !linkTarget?has_content]
+            [@precondition
+                function="getBaselineComponentIds"
+                context=links
+                detail="Link " + linkName + " has no target"
+            /]
+            [#continue]
+        [/#if]
         [#local linkTargetCore = linkTarget.Core ]
         [#local linkTargetSolution = linkTarget.Configuration.Solution ]
         [#local linkTargetResources = linkTarget.State.Resources ]
@@ -31,12 +39,11 @@
                         [#break]
                 [/#switch]
                 [#break]
-            
+
             [#default]
                 [@fatal
                     message="Unkown baseline subcomponent"
-                    context=key
-                    detail=subComponent
+                    context=linkTarget
                 /]
         [/#switch]
     [/#list]
@@ -81,9 +88,12 @@
             ]
             [#local baselineLinkTarget = getLinkTarget( {}, baselineLink, activeOnly, activeRequired )]
 
-            [#local baselineLinkTargets += {
-                    key : baselineLinkTarget
-            }]
+            [#-- Skip missing targets --]
+            [#if baselineLinkTarget?has_content]
+                [#local baselineLinkTargets += {
+                        key : baselineLinkTarget
+                    } ]
+            [/#if]
         [/#if]
     [/#list]
 


### PR DESCRIPTION
Ensure baseline links defined before use in generating _context and handle case of missing baseline components.

Improve error handling in baseline link routines so they don't result in freemarker exceptions. This way, the actual source of any errors can be reported.