### PR TITLE
<fix> Userpool role creation resource dependency

### DIFF
--- a/providers/aws/components/userpool/setup.ftl
+++ b/providers/aws/components/userpool/setup.ftl
@@ -243,7 +243,7 @@
 
     [#if ((solution.MFA) || ( solution.VerifyPhone))]
         [#if (deploymentSubsetRequired("iam", true) || deploymentSubsetRequired("userpool", true)) &&
-            isPartOfCurrentDeploymentUnit(userPoolId)]
+            isPartOfCurrentDeploymentUnit(userPoolRoleId)]
 
                 [@createRole
                     id=userPoolRoleId


### PR DESCRIPTION
Check for the correct deployment unit should use the role id not the pool id.

@roleyfoley please confirm this won't break any other deployments for products using user pools.