### PR TITLE
<feature> Expo build - skip OTA

### DIFF
--- a/aws/runExpoAppPublish.sh
+++ b/aws/runExpoAppPublish.sh
@@ -287,7 +287,7 @@ function main() {
   # Create a build for the SDK
   info "Creating an OTA for this version of the SDK"
   expo export --public-url "${PUBLIC_URL}" --output-dir "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}"  || return $?
-  if [[ "${DISABLE_OTA}" == "true" ]]; then 
+  if [[ "${DISABLE_OTA}" == "false" ]]; then 
     info "Copying OTA to CDN"
     aws --region "${AWS_REGION}" s3 sync --delete "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}" "s3://${PUBLIC_BUCKET}/${PUBLIC_PREFIX}/packages/${EXPO_SDK_VERSION}" || return $?
 
@@ -394,7 +394,7 @@ function main() {
 
                 # Get the bundle file name from the manifest
                 BUNDLE_URL="$( jq -r '.bundleUrl' < "${BINARY_BUNDLE_FILE}")"
-                BUNDLE_FILE_NAME="$( basename "${BUNDLE_URL}")"
+                BUNDLE_FILE_NAME="$( basename "${BUNDLE_URL}")"  
 
                 if [[ "${DISABLE_OTA}" == "false" ]]; then
                     cp "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}/bundles/${BUNDLE_FILE_NAME}" "${SRC_PATH}/ios/${EXPO_PROJECT_SLUG}/Supporting/shell-app.bundle"

--- a/aws/runExpoAppPublish.sh
+++ b/aws/runExpoAppPublish.sh
@@ -388,12 +388,17 @@ function main() {
 
                 # Update Expo Details and seed with latest expo expot bundles
                 BINARY_BUNDLE_FILE="${SRC_PATH}/ios/${EXPO_PROJECT_SLUG}/Supporting/shell-app-manifest.json"
-                cp "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}/ios-index.json" "${BINARY_BUNDLE_FILE}"
+                if [[ "${DISABLE_OTA}" == "false" ]]; then
+                    cp "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}/ios-index.json" "${BINARY_BUNDLE_FILE}"
+                fi
 
                 # Get the bundle file name from the manifest
                 BUNDLE_URL="$( jq -r '.bundleUrl' < "${BINARY_BUNDLE_FILE}")"
-                BUNDLE_FILE_NAME="$( basename "${BUNDLE_URL}")"  
-                cp "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}/bundles/${BUNDLE_FILE_NAME}" "${SRC_PATH}/ios/${EXPO_PROJECT_SLUG}/Supporting/shell-app.bundle"
+                BUNDLE_FILE_NAME="$( basename "${BUNDLE_URL}")"
+
+                if [[ "${DISABLE_OTA}" == "false" ]]; then
+                    cp "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}/bundles/${BUNDLE_FILE_NAME}" "${SRC_PATH}/ios/${EXPO_PROJECT_SLUG}/Supporting/shell-app.bundle"
+                fi
 
                 jq --arg RELEASE_CHANNEL "${RELEASE_CHANNEL}" --arg MANIFEST_URL "${EXPO_MANIFEST_URL}" '.manifestUrl=$MANIFEST_URL | .releaseChannel=$RELEASE_CHANNEL' <  "ios/${EXPO_PROJECT_SLUG}/Supporting/EXShell.json" > "${tmpdir}/EXShell.json"  
                 mv "${tmpdir}/EXShell.json" "ios/${EXPO_PROJECT_SLUG}/Supporting/EXShell.json"


### PR DESCRIPTION
Adds the option to skip the publishing of an OTA to the CDN but still keep the OTA for injection into a binary build. This would allow for preparing a new binary with libraries before deploying an OTA which enables them