### PR TITLE
<fix> SPA: primary domain lookup fixes

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -848,7 +848,7 @@ behaviour.
     [#if primaryNotSeen && (result?size > 0) ]
         [#local forcedResult = [ result[0] + { "Role" : DOMAIN_ROLE_PRIMARY } ] ]
         [#if (result?size > 1) ]
-            [#local forceResult += result[1..] ]
+            [#local forcedResult += result[1..] ]
         [/#if]
         [#local result = forcedResult]
     [/#if]

--- a/providers/aws/components/spa/state.ftl
+++ b/providers/aws/components/spa/state.ftl
@@ -8,9 +8,11 @@
     [#local cfName = formatComponentCFDistributionName(core.Tier, core.Component, occurrence)]
 
     [#if isPresent(solution.Certificate) ]
-            [#local certificateObject = getCertificateObject(solution.Certificate!"", segmentQualifiers) ]
-            [#local hostName = getHostName(certificateObject, occurrence) ]
-            [#local fqdn = formatDomainName(hostName, certificateObject.Domains[0].Name)]
+        [#local certificateObject = getCertificateObject(solution.Certificate!"", segmentQualifiers) ]
+        [#local hostName = getHostName(certificateObject, occurrence) ]
+        [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
+        [#local fqdn = formatDomainName(hostName, primaryDomainObject)]
+
     [#else]
             [#local fqdn = getExistingReference(cfId,DNS_ATTRIBUTE_TYPE)]
     [/#if]


### PR DESCRIPTION
A couple of minor fixes to the SPA domain lookup
- Typo fix primary domain lookup
- SPA - adds the primary domain lookup instead of using the first domain in the array