### PR TITLE
<fix> hibernation - fix for determinig deployment

### DIFF
--- a/providers/aws/components/cache/setup.ftl
+++ b/providers/aws/components/cache/setup.ftl
@@ -92,8 +92,7 @@
         [/#list]
     [/#list]
 
-    [#local hibernate = solution.Hibernate.Enabled  &&
-        (getExistingReference(cacheId)?has_content) ]
+    [#local hibernate = solution.Hibernate.Enabled && isOccurrenceDeployed(occurrence)]
 
     [#if deploymentSubsetRequired("cache", true)]
 

--- a/providers/aws/components/db/setup.ftl
+++ b/providers/aws/components/db/setup.ftl
@@ -115,8 +115,7 @@
         [#local rdsPassword = attributes.PASSWORD ]
     [/#if]
 
-    [#local hibernate = solution.Hibernate.Enabled  &&
-            (getExistingReference(rdsId)?has_content) ]
+    [#local hibernate = solution.Hibernate.Enabled && isOccurrenceDeployed(occurrence)]
 
     [#local hibernateStartUpMode = solution.Hibernate.StartUpMode ]
 

--- a/providers/aws/components/ecs/setup.ftl
+++ b/providers/aws/components/ecs/setup.ftl
@@ -26,8 +26,7 @@
     [#local defaultLogDriver = solution.LogDriver ]
     [#local fixedIP = solution.FixedIP ]
 
-    [#local hibernate = solution.Hibernate.Enabled &&
-                            getExistingReference(ecsId)?has_content ]
+    [#local hibernate = solution.Hibernate.Enabled && isOccurrenceDeployed(occurrence)]
 
     [#local processorProfile = getProcessor(occurrence, "ECS")]
     [#local storageProfile = getStorage(occurrence, "ECS")]


### PR DESCRIPTION
Instead of checking that the resource we are hibernating is around we should check that the occurrence is deployed 

For RDS where we remove the RDS instance doing a getExistingReference on the RDSId will end up with a loop of adding and removing the instance 