### PR TITLE
<feature> APIGW: publish with filename control

### DIFF
--- a/providers/aws/components/apigateway/setup.ftl
+++ b/providers/aws/components/apigateway/setup.ftl
@@ -577,9 +577,16 @@
 
         [#list solution.Publishers as id,publisher ]
 
-            [#local publisherPath = getContentPath( occurrence, publisher.Path )]
             [#local publisherLinks = getLinkTargets(occurrence, publisher.Links )]
 
+            [#local publisherPath = getContentPath( occurrence, publisher.Path )]
+            [#if publisher.UsePathInName ]
+                [#local fileName = formatName( publisherPath, "swagger.json") ]
+                [#local publisherPath = "" ]
+            [#else]
+                [#local fileName = "swagger.json" ]
+            [/#if]
+            
             [#list publisherLinks as publisherLinkId, publisherLinkTarget ]
                 [#local publisherLinkTargetCore = publisherLinkTarget.Core ]
                 [#local publisherLinkTargetAttributes = publisherLinkTarget.State.Attributes ]
@@ -592,12 +599,13 @@
                                 [
                                     "case $\{STACK_OPERATION} in",
                                     "  create|update)",
-                                    "info \"Sending API Specification to " + id + "-" + publisherLinkId + "\"",
-                                    "  copy_contentnode_file \"$\{tmpdir}/dist/swagger.json\" " +
+                                    "info \"Sending API Specification to " + id + "-" + publisherLinkTargetCore.FullName + "\"",
+                                    " cp \"$\{tmpdir}/dist/swagger.json\" \"$\{tmpdir}/dist/" + fileName + "\" ",
+                                    "  copy_contentnode_file \"$\{tmpdir}/dist/" + fileName + "\" " +
                                     "\"" +    publisherLinkTargetAttributes.ENGINE + "\" " +
                                     "\"" +    publisherLinkTargetAttributes.REPOSITORY + "\" " +
                                     "\"" +    publisherLinkTargetAttributes.PREFIX + "\" " +
-                                    "\"" +    publisherPath + "\" " +
+                                    "\""  +    publisherPath + "\" " +
                                     "\"" +    publisherLinkTargetAttributes.BRANCH + "\" || return $? ",
                                     "       ;;",
                                     " esac"

--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -166,6 +166,12 @@ object.
                     {
                         "Names" : "Path",
                         "Children" : pathChildConfiguration
+                    },
+                    {
+                        "Names" : "UsePathInName",
+                        "Description" : "Name the Swagger Spec file using the path",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
                     }
                 ]
             },


### PR DESCRIPTION
Adds ability to use the path in the name of the swagger spec file copied to a publishing endpoint. This is mainly to align with the codeontap/townplanner layout