### PR TITLE
<fix> contentndoe sync modes

### DIFF
--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -871,7 +871,8 @@ function copy_contentnode_file() {
   local path="$1"; shift
   local prefix="$1"; shift
   local nodepath="$1"; shift
-  local branch="$1"; 
+  local branch="$1"; shift
+  local copymode="$1"; shift
 
   local contentnodedir="${tmp_dir}/contentnode"
   local contenthubdir="${tmp_dir}/contenthub"
@@ -917,7 +918,7 @@ function copy_contentnode_file() {
           
           create|update)
             if [[ -n "${hubpath}" ]]; then
-              if [[ -d "${hubpath}" ]]; then 
+              if [[ -d "${hubpath}" && "${copymode}" == "replace" ]]; then 
                 rm -rf "${hubpath}" || return $?
               fi 
               mkdir -p "${hubpath}"

--- a/providers/aws/components/apigateway/setup.ftl
+++ b/providers/aws/components/apigateway/setup.ftl
@@ -605,8 +605,9 @@
                                     "\"" +    publisherLinkTargetAttributes.ENGINE + "\" " +
                                     "\"" +    publisherLinkTargetAttributes.REPOSITORY + "\" " +
                                     "\"" +    publisherLinkTargetAttributes.PREFIX + "\" " +
-                                    "\""  +    publisherPath + "\" " +
-                                    "\"" +    publisherLinkTargetAttributes.BRANCH + "\" || return $? ",
+                                    "\"" +    publisherPath + "\" " +
+                                    "\"" +    publisherLinkTargetAttributes.BRANCH + "\" " +
+                                    "\"update\" || return $? ",
                                     "       ;;",
                                     " esac"
                                 ]

--- a/providers/aws/components/contentnode/setup.ftl
+++ b/providers/aws/components/contentnode/setup.ftl
@@ -63,7 +63,8 @@
                                         "\"" +    linkTargetAttributes.REPOSITORY + "\" " +
                                         "\"" +    linkTargetAttributes.PREFIX + "\" " +
                                         "\"" +    pathObject + "\" " +
-                                        "\"" +    linkTargetAttributes.BRANCH + "\" ",
+                                        "\"" +    linkTargetAttributes.BRANCH + "\" " + 
+                                        "\"replace\" || return $? ",
                                 "}",
                                 "#",
                                 "get_contentnode_file"


### PR DESCRIPTION
Adds a sync mode to content nodes which allows for updates to common directory from multiple sources instead of replacing the directory on each upload 