### PR TITLE
<refactor> APIGW: move deployment details in to swagger update

### DIFF
--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -677,47 +677,6 @@ function addJSONAncestorObjects() {
   runJQ "${pattern}" < "${file}"
 }
 
-# -- API Gateway --
-function add_host_to_apidoc() { 
-  # adds the API Host endpoint to the swagger spec
-  local apiHost="$1"; shift
-  local scheme="$1"; shift
-  local basePath="$1"; shift
-  local version="$1"; shift
-  local description="$1"; shift
-  local swaggerJson="$1"; shift
-  local tempSwaggerJson="${tmp_dir}/swagger-temp.json"
-
-  if [[ -f "${swaggerJson}" ]]; then  
-
-    if [[ -n "${basePath}" ]]; then 
-        jq -r --arg basePath "${basePath}" '.basePath = $basePath' < "${swaggerJson}" > "${tempSwaggerJson}"
-        mv "${tempSwaggerJson}" "${swaggerJson}"
-    fi
-
-    if [[ -n "${scheme}" ]]; then 
-        jq -r --arg scheme "${scheme}" '.schemes = ( $scheme / "," )' < "${swaggerJson}" > "${tempSwaggerJson}"
-        mv "${tempSwaggerJson}" "${swaggerJson}"
-    fi
-
-    if [[ -n "${apiHost}" ]]; then 
-        jq -r --arg apiHost "${apiHost}" '.host = $apiHost' < "${swaggerJson}" > "${tempSwaggerJson}"
-        mv "${tempSwaggerJson}" "${swaggerJson}"
-    fi
-
-    if [[ -n "${version}" ]]; then 
-        jq -r --arg version "${version}" '.info.version = $version' < "${swaggerJson}" > "${tempSwaggerJson}"
-        mv "${tempSwaggerJson}" "${swaggerJson}"
-    fi
-
-    if [[ -n "${description}" ]]; then
-        jq -r --arg description "${description}" '.info.description = .info.description + " \n" + $description' < "${swaggerJson}" > "${tempSwaggerJson}"
-        mv "${tempSwaggerJson}" "${swaggerJson}"
-    fi
-  fi
-
-  return 0
-}
 # -- KMS --
 function decrypt_kms_string() {
   local region="$1"; shift

--- a/engine/swagger.ftl
+++ b/engine/swagger.ftl
@@ -178,6 +178,37 @@
     [#return "" ]
 [/#function]
 
+[#function getSwaggerDeploymentDetails definitionVersion context description version ]
+    [#local version = formatName(version, context["BuildReference"])]
+    [#if definitionVersion gte 3 ]
+        [#return 
+            {
+                "servers" : [
+                    {
+                        "url" : context["Scheme"] + "://" + context["FQDN"] + formatAbsolutePath( context["BasePath"] ),
+                        "description" : context["Name"]
+                    }
+                ],
+                "info" : {
+                    "version" : version
+                }
+            }
+        ]
+    [#else]
+        [#return 
+            {
+                "basePath" : formatAbsolutePath(context["BasePath"]),
+                "schemes" : context["Scheme"],
+                "host" : context["FQDN"],
+                "info" : {
+                    "version" : version,
+                    "description" : "**COT Deployment** " + context["Name"] + "/n" + description
+                }
+            }
+        ]
+    [/#if]
+[/#function]
+
 [#function getSwaggerGlobalSecurity definitionVersion context  ]
     [#local result =
         {
@@ -529,6 +560,16 @@
     [#local globalConfiguration = mergeObjects(
                                         globalConfiguration, 
                                         getSwaggerGlobalSecurity(definitionMajorVersion, context) )]
+    
+    [#local globalConfiguration = mergeObjects(
+                                        globalConfiguration,
+                                        getSwaggerDeploymentDetails(
+                                            definitionMajorVersion, 
+                                            context, 
+                                            (definition.info.description)!"",
+                                            definition.info.version
+                                        )
+    )]
 
     [#local paths = {} ]
     [#list (definition.paths!{}) + getSwaggerProxyPaths(proxyRequired) as path, pathObject]

--- a/providers/aws/components/apigateway/setup.ftl
+++ b/providers/aws/components/apigateway/setup.ftl
@@ -11,6 +11,7 @@
     [#local solution = occurrence.Configuration.Solution ]
     [#local resources = occurrence.State.Resources ]
     [#local attributes = occurrence.State.Attributes ]
+    [#local buildSettings = occurrence.Configuration.Settings.Build ]
     [#local roles = occurrence.State.Roles]
 
     [#local apiId      = resources["apigateway"].Id]
@@ -546,6 +547,7 @@
     [/#list]
 
     [#-- Send API Specification to an external publisher --]
+     
     [#if solution.Publishers?has_content ]
         [#if deploymentSubsetRequired("epilogue", false ) ]
             [@addToDefaultBashScriptOutput
@@ -555,20 +557,12 @@
                     "  create|update)",
                     "   # Fetch the apidoc file",
                     "   info \"Building API Specification Document\"",
+                    "   mkdir -p \"$\{tmpdir}/dist\"",
                     "   copyFilesFromBucket" + " " +
                         regionId + " " +
                         operationsBucket + " " +
                         swaggerFileLocation + " " +
-                    "   \"$\{tmpdir}\" || return $?"
-                    "   # Insert host in Doc File ",
-                    "   add_host_to_apidoc" + " " +
-                    "   \"" + attributes.FQDN + "\" " +
-                    "   \"" +  attributes.SCHEME + "\" " +
-                    "   \"" +  attributes.BASE_PATH + "\" " +
-                    "   \"" +  getOccurrenceBuildReference(occurrence) + "\" " +
-                    "   \"**COT Deployment:** " + core.TypedFullName + "\" " +
-                    "   \"$\{tmpdir}/" + swaggerFileName + "\"  || return $?",
-                    "   mkdir \"$\{tmpdir}/dist\" && mv \"$\{tmpdir}/" + swaggerFileName + "\" \"$\{tmpdir}/dist/swagger.json\" || return $?",
+                    "   \"$\{tmpdir}/dist/swagger.json\" || return $?"
                     "   ;;",
                     " esac"
                 ]
@@ -687,7 +681,12 @@
                     {
                         "Account" : accountObject.AWSId,
                         "Region" : region,
-                        "CognitoPools" : cognitoPools
+                        "CognitoPools" : cognitoPools,
+                        "FQDN" : attributes["FQDN"],
+                        "Scheme" : attributes["SCHEME"],
+                        "BasePath" : attributes["BASE_PATH"],
+                        "BuildReference" : (buildSettings["APP_REFERENCE"].Value)!buildSettings["BUILD_REFERENCE"].Value,
+                        "Name" : apiName
                     } ]
 
                 [#-- Determine if there are any roles required by specific methods --]


### PR DESCRIPTION
Now that the api gateway updates are run as part of the setup script we can access the attributes for the deployment

This PR moves the updates added to a swagger spec as part of the publish process into the standard template extensions. As the deployment updates only affect information and try it now functionality this shouldn't impact the API deployment 

