### PR TITLE
<refactor> Align default OWASP size limit to API limit

### DIFF
--- a/providers/aws/masterData.json
+++ b/providers/aws/masterData.json
@@ -1695,7 +1695,7 @@
       ],
       "maxuri": 1024,
       "maxquery": 1024,
-      "maxbody": 4096,
+      "maxbody": 10240,
       "maxcookie": 4093,
       "csrfsize": 36,
       "uristartswith": [


### PR DESCRIPTION
API Gateway has a hard payload size limit of 10MB so align the defaults
for OWASP to align with this,