### PR TITLE
<refactor> Remove id/name defaulting

### DIFF
--- a/aws/setContext.sh
+++ b/aws/setContext.sh
@@ -181,7 +181,7 @@ if [[ (("${GENERATION_USE_CACHE}" != "true") &&
 
     debug "BLUEPRINT=${blueprint_array[*]}"
     if [[ ! $(arrayIsEmpty "blueprint_array") ]]; then
-        ${GENERATION_DIR}/manageJSON.sh -d -o "${COMPOSITE_BLUEPRINT}" "${blueprint_array[@]}"
+        ${GENERATION_DIR}/manageJSON.sh -o "${COMPOSITE_BLUEPRINT}" "${blueprint_array[@]}"
     else
         echo "{}" > "${COMPOSITE_BLUEPRINT}"
     fi
@@ -206,8 +206,11 @@ export REGION="${REGION:-$COMPONENT_REGION}"
 [[ -z "${REGION}" ]] && fatalCantProceed "The region must be defined in the Product blueprint section." && exit 1
 
 BLUEPRINT_ACCOUNT=$(runJQ -r '.Account.Name | select(.!=null)' < ${COMPOSITE_BLUEPRINT})
+[[ -z "${BLUEPRINT_ACCOUNT}" ]] && BLUEPRINT_ACCOUNT=$(runJQ -r '.Account.Id | select(.!=null)' < ${COMPOSITE_BLUEPRINT})
 BLUEPRINT_PRODUCT=$(runJQ -r '.Product.Name | select(.!=null)' < ${COMPOSITE_BLUEPRINT})
+[[ -z "${BLUEPRINT_PRODUCT}" ]] && BLUEPRINT_PRODUCT=$(runJQ -r '.Product.Id | select(.!=null)' < ${COMPOSITE_BLUEPRINT})
 BLUEPRINT_SEGMENT=$(runJQ -r '.Segment.Name | select(.!=null)' < ${COMPOSITE_BLUEPRINT})
+[[ -z "${BLUEPRINT_SEGMENT}" ]] && BLUEPRINT_SEGMENT=$(runJQ -r '.Segment.Id | select(.!=null)' < ${COMPOSITE_BLUEPRINT})
 [[ (-n "${ACCOUNT}") &&
     ("${BLUEPRINT_ACCOUNT}" != "Account") &&
     ("${ACCOUNT}" != "${BLUEPRINT_ACCOUNT}") ]] &&

--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -602,26 +602,6 @@ behaviour.
     [#return result ]
 [/#function]
 
-[#-- treat the value "default" for version/instance as the same as blank --]
-[#function getContextId context]
-    [#return
-        (context.Id == "default")?then(
-            "",
-            context.Id
-        )
-    ]
-[/#function]
-
-[#function getContextName context]
-    [#return
-        getContextId(context)?has_content?then(
-            context.Name,
-            ""
-        )
-    ]
-[/#function]
-
-
 [#function getOccurrenceCoreTags occurrence={} name="" zone="" propagate=false flatten=false maxTagCount=-1]
     [#return getCfTemplateCoreTags(name, (occurrence.Core.Tier)!"", (occurrence.Core.Component)!"", zone, propagate, flatten, maxTagCount)]
 [/#function]

--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -373,23 +373,29 @@
 
 [#-- Get a component within a tier --]
 [#function getComponent tierId componentId type=""]
-    [#list ((getTier(tierId).Components)!{})?values as component]
-        [#if
-            component?is_hash &&
-            (
-                (component.Id == componentId) ||
-                (
-                  type?has_content &&
-                  (getComponentId(component) == componentId) &&
-                  (getComponentType(component) == type)
-                )
-            ) ]
-            [#return
-                component +
+    [#list (getTier(tierId).Components)!{} as key, value]
+        [#if value?is_hash]
+            [#local component =
                 {
-                    "Type" : getComponentType(component),
-                    "Tier" : tierId
-                }]
+                    "Id" : key,
+                    "Name" : key
+                } + value ]
+            [#if
+                (
+                    (component.Id == componentId) ||
+                    (
+                    type?has_content &&
+                    (getComponentId(component) == componentId) &&
+                    (getComponentType(component) == type)
+                    )
+                ) ]
+                [#return
+                    component +
+                    {
+                        "Type" : getComponentType(component),
+                        "Tier" : tierId
+                    }]
+            [/#if]
         [/#if]
     [/#list]
     [#return {} ]

--- a/engine/context.ftl
+++ b/engine/context.ftl
@@ -148,7 +148,8 @@ Solution     - Solutions -> Tiers -> Components -> SubComponents
             instanceContext =
                 createInstanceContext(
                     {
-                        "Id" : instanceId
+                        "Id" : instanceId,
+                        "Name" : instanceId
                     } +
                     removeObjectAttributes(instance, ["Versions", componentChildrenAttributes]),
                     parent
@@ -205,7 +206,8 @@ Solution     - Solutions -> Tiers -> Components -> SubComponents
             versionContext =
                 createVersionContext(
                     {
-                        "Id" : versionId
+                        "Id" : versionId,
+                        "Name" : versionId
                     } +
                     removeObjectAttributes(version, ["Instances", componentChildrenAttributes]),
                     parent
@@ -319,6 +321,7 @@ Solution     - Solutions -> Tiers -> Components -> SubComponents
                                     constructComponentContext(
                                         {
                                             "Id" : childComponentId,
+                                            "Name" : childComponentId,
                                             "Type" : getComponentChildType(child)
                                         } + childComponent,
                                         componentContext,
@@ -368,13 +371,20 @@ Solution     - Solutions -> Tiers -> Components -> SubComponents
         [#local
             tierContext =
                 createTierContext(
-                    {"Id" : tierId} + removeObjectAttributes(tier, ["Components"]),
+                    {
+                        "Id" : tierId,
+                        "Name" : tierId
+                    } + removeObjectAttributes(tier, ["Components"]),
                     parent
                 ) ]
         [#local componentContexts = [] ]
         [#list tier.Components!{} as componentId, component]
             [#if component?is_hash]
-                [#local componentObject = { "Id" : "componentId" } + component ]
+                [#local componentObject =
+                    {
+                        "Id" : componentId,
+                        "Name" : componentId
+                    } + component ]
                 [#-- Determine the type specific attribute, if any --]
                 [#local componentTypeAttribute = getComponentTypeObjectAttribute(componentObject) ]
                 [#if componentTypeAttribute?has_content]

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -478,6 +478,24 @@
         getSettingsAsEnvironment(occurrence.Configuration.Settings.Product, format) ]
 [/#function]
 
+[#-- treat the value "default" for version/instance as the same as blank --]
+[#function getContextId context]
+    [#return
+        (context.Id == "default")?then(
+            "",
+            context.Id
+        )
+    ]
+[/#function]
+
+[#function getContextName context]
+    [#return
+        getContextId(context)?has_content?then(
+            context.Name,
+            ""
+        )
+    ]
+[/#function]
 
 [#-- Get the occurrences of versions/instances of a component           --]
 [#-- This function should NOT be called directly - it is for the use of --]
@@ -521,13 +539,15 @@
 
     [#local occurrences=[] ]
 
-    [#list (typeObject.Instances!{"default" : {"Id" : "default"}})?values as instance]
-        [#if instance?is_hash ]
+    [#list typeObject.Instances!{"default" : {}} as instanceKey, instanceValue]
+        [#if instanceValue?is_hash ]
+            [#local instance = {"Id" : instanceKey, "Name" : instanceKey} + instanceValue]
             [#local instanceId = getContextId(instance) ]
             [#local instanceName = getContextName(instance) ]
 
-            [#list (instance.Versions!{"default" : {"Id" : "default"}})?values as version]
-                [#if version?is_hash ]
+            [#list instance.Versions!{"default" : {}} as versionKey, versionValue]
+                [#if versionValue?is_hash ]
+                    [#local version = {"Id" : versionKey, "Name" : versionKey} + versionValue]
                     [#local versionId = getContextId(version) ]
                     [#local versionName = getContextName(version) ]
                     [#local occurrenceContexts = componentContexts + [instance, version] ]

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -69,9 +69,17 @@
 [#assign tenants = (blueprintObject.Tenants)!{} ]
 [#assign tenantObject = (blueprintObject.Tenant)!(tenants[tenant])!{} ]
 [#if tenantObject?has_content]
-    [#assign tenantId = tenantObject.Id]
-    [#assign tenantName = tenantObject.Name]
-    [#assign tenants += {tenantId : tenantObject} ]
+    [#assign tenantId = tenantObject.Id!tenant]
+    [#assign tenantName = tenantObject.Name!tenantId]
+    [#assign tenants +=
+        {
+            tenantId :
+                {
+                    "Id" : tenantId,
+                    "Name" : tenantName
+                } +
+                tenantObject
+        } ]
 [/#if]
 
 [#-- Domains --]
@@ -84,9 +92,17 @@
 [#assign accounts = (blueprintObject.Accounts)!{} ]
 [#assign accountObject = (blueprintObject.Account)!(accounts[account])!{} ]
 [#if accountObject?has_content]
-    [#assign accountId = accountObject.Id]
-    [#assign accountName = accountObject.Name]
-    [#assign accounts += {accountId : accountObject} ]
+    [#assign accountId = accountObject.Id!account]
+    [#assign accountName = accountObject.Name!accountId]
+    [#assign accounts +=
+        {
+            accountId :
+                {
+                    "Id" : accountId,
+                    "Name" : accountName
+                } +
+                accountObject
+        } ]
 
     [#assign credentialsBucket = getExistingReference(formatAccountS3Id("credentials")) ]
     [#assign codeBucket = getExistingReference(formatAccountS3Id("code")) ]
@@ -161,9 +177,17 @@
 [#assign products = (blueprintObject.Products)!{} ]
 [#assign productObject = (blueprintObject.Product)!(products[product])!{} ]
 [#if productObject?has_content]
-    [#assign productId = productObject.Id]
-    [#assign productName = productObject.Name]
-    [#assign products += {productId : productObject} ]
+    [#assign productId = productObject.Id!product]
+    [#assign productName = productObject.Name!productId]
+    [#assign products +=
+        {
+            productId :
+                {
+                    "Id" : productId,
+                    "Name" : productName
+                } +
+                productObject
+        } ]
 
     [#assign productDomain = productObject.Domain!""]
 
@@ -181,17 +205,35 @@
 [#assign segments = (blueprintObject.Segments)!{} ]
 [#assign segmentObject = (blueprintObject.Segment)!(segments[segment])!{} ]
 [#if segmentObject?has_content]
-    [#assign segmentId = segmentObject.Id]
-    [#assign segmentName = segmentObject.Name]
-    [#assign segments += {segmentId : segmentObject} ]
+    [#assign segmentId = segmentObject.Id!segment]
+    [#assign segmentName = segmentObject.Name!segmentId]
+    [#assign segments +=
+        {
+            segmentId :
+                {
+                    "Id" : segmentId,
+                    "Name" : segmentName
+                } +
+                segmentObject
+        } ]
 
     [#if blueprintObject.Environment?? ]
         [#assign environmentId = blueprintObject.Environment.Id ]
-        [#assign environmentObject = environments[environmentId]]
-        [#assign environmentName = environmentObject.Name]
-        [#assign categoryId = segmentObject.Category!environmentObject.Category]
-        [#assign categoryName = segmentObject.Category!environmentObject.Category]
-        [#assign categoryObject = categories[categoryId]]
+        [#assign environmentObject =
+            {
+                "Id" : environmentId,
+                "Name" : environmentId
+            } +
+            environments[environmentId] ]
+        [#assign environmentName = environmentObject.Name ]
+        [#assign categoryId = segmentObject.Category!environmentObject.Category ]
+        [#assign categoryName = categoryId ]
+        [#assign categoryObject =
+            {
+                "Id" : categoryId,
+                "Name" : categoryName
+            } +
+            categories[categoryId] ]
 
         [#assign shortNamePrefixes += [environmentId] ]
         [#assign fullNamePrefixes += [environmentName] ]
@@ -303,7 +345,15 @@
                 [/#if]
             [/#list]
         [/#if]
-        [#assign tiers += [ blueprintTier +  { "Network" : tierNetwork } ] ]
+        [#assign tiers +=
+            [
+                {
+                    "Id" : tierId,
+                    "Name" : tierId
+                } +
+                blueprintTier +
+                { "Network" : tierNetwork }
+            ] ]
     [/#if]
 [/#list]
 
@@ -314,6 +364,10 @@
         [#assign zone = regions[region].Zones[zoneId] ]
         [#assign zones +=
             [
+                {
+                    "Id" : zoneId,
+                    "Name" : zoneId
+                } +
                 zone +
                 {
                     "Index" : zoneId?index
@@ -388,7 +442,12 @@
         [#if value?is_hash]
             [#local result +=
                 {
-                    key : getEffectiveIPAddressGroup(value)
+                    key :
+                        getEffectiveIPAddressGroup(
+                            {
+                                "Id" : key,
+                                "Name" : key
+                            } + value)
                 } ]
         [/#if]
     [/#list]

--- a/providers/aws/masterData.ftl
+++ b/providers/aws/masterData.ftl
@@ -9,15 +9,11 @@
       "Locality": "Tokyo",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "ap-northeast-1a"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "ap-northeast-1c"
@@ -39,15 +35,11 @@
       "Locality": "Seoul",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "ap-northeast-2a"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "ap-northeast-2c"
@@ -69,15 +61,11 @@
       "Locality": "Mumbai",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "ap-south-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "ap-south-1b"
@@ -99,16 +87,12 @@
       "Locality": "Singapore",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "Index": 0,
           "AWSZone": "ap-southeast-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Singapore Zone B",
           "Index": 1,
@@ -131,8 +115,6 @@
       "Locality": "Sydney",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "ap-southeast-2a",
@@ -260,8 +242,6 @@
           ]
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "ap-southeast-2b",
@@ -389,8 +369,6 @@
           ]
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "ap-southeast-2c",
@@ -534,15 +512,11 @@
       "Locality": "Central",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "ca-central-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "ca-central-1b"
@@ -564,15 +538,11 @@
       "Locality": "Beijing",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "cn-north-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "cn-north-1b"
@@ -593,15 +563,11 @@
       "Locality": "Frankfurt",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "eu-central-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "eu-central-1b"
@@ -623,22 +589,16 @@
       "Locality": "Ireland",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "eu-west-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "eu-west-1b"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "eu-west-1c"
@@ -660,15 +620,11 @@
       "Locality": "London",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "eu-west-2a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "eu-west-2b"
@@ -690,15 +646,11 @@
       "Locality": "Paris",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "eu-west-3a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "eu-west-3b"
@@ -720,22 +672,16 @@
       "Locality": "Sao Paulo",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "sa-east-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "sa-east-1b"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "sa-east-1c"
@@ -757,29 +703,21 @@
       "Locality": "North Virginia",
       "Zones": {
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "us-east-1b"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "us-east-1c"
         },
         "d": {
-          "Id": "d",
-          "Name": "d",
           "Title": "Zone D",
           "Description": "Zone D",
           "AWSZone": "us-east-1d"
         },
         "e": {
-          "Id": "e",
-          "Name": "e",
           "Title": "Zone E",
           "Description": "Zone E",
           "AWSZone": "us-east-1e"
@@ -801,22 +739,16 @@
       "Locality": "Ohio",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "us-east-2a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "us-east-2b"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "us-east-2c"
@@ -838,15 +770,11 @@
       "Locality": "US",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "us-gov-west-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "us-gov-west-1b"
@@ -867,15 +795,11 @@
       "Locality": "North California",
       "Zones": {
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "us-west-1b"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "us-west-1c"
@@ -897,22 +821,16 @@
       "Locality": "Oregon",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "us-west-2a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "us-west-2b"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "us-west-2c"
@@ -934,22 +852,16 @@
       "Locality": "Stockholm",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "eu-north-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "eu-north-1b"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "eu-north-1c"
@@ -1073,31 +985,23 @@
     "mgmt": {
       "Components": {
         "seg-cert": {
-          "Id": "seg-cert",
-          "Name": "seg-cert",
           "DeploymentUnits": [
             "cert"
           ]
         },
         "seg-dns": {
-          "Id": "seg-dns",
-          "Name": "seg-dns",
           "DeploymentUnits": [
             "dns"
           ],
           "Enabled": false
         },
         "seg-dashboard": {
-          "Id": "seg-dashboard",
-          "Name": "seg-dashboard",
           "DeploymentUnits": [
             "dashboard"
           ],
           "Enabled": false
         },
         "baseline": {
-          "Id": "baseline",
-          "Name": "baseline",
           "DeploymentUnits": [
             "baseline"
           ],
@@ -1156,8 +1060,6 @@
           }
         },
         "ssh": {
-          "Id": "ssh",
-          "Name": "ssh",
           "DeploymentUnits": [
             "ssh"
           ],
@@ -1172,8 +1074,6 @@
           }
         },
         "vpc": {
-          "Id": "vpc",
-          "Name": "vpc",
           "DeploymentUnits": [
             "vpc"
           ],
@@ -1181,23 +1081,15 @@
           "network": {
             "RouteTables": {
               "internal": {
-                "Id": "internal",
-                "Name": "internal"
               },
               "external": {
-                "Id": "external",
-                "Name": "external",
                 "Public": true
               }
             },
             "NetworkACLs": {
               "open": {
-                "Id": "open",
-                "Name": "open",
                 "Rules": {
                   "in": {
-                    "Id": "in",
-                    "Name": "in",
                     "Priority": 200,
                     "Action": "allow",
                     "Source": {
@@ -1214,8 +1106,6 @@
                     "ReturnTraffic": false
                   },
                   "out": {
-                    "Id": "out",
-                    "Name": "out",
                     "Priority": 200,
                     "Action": "allow",
                     "Source": {
@@ -1237,8 +1127,6 @@
           }
         },
         "igw": {
-          "Id": "igw",
-          "Name": "igw",
           "DeploymentUnits": [
             "igw"
           ],
@@ -1246,8 +1134,6 @@
             "Engine": "igw",
             "Destinations": {
               "default": {
-                "Id": "default",
-                "Name": "default",
                 "IPAddressGroups": "_global",
                 "Links": {
                   "external": {
@@ -1263,8 +1149,6 @@
           }
         },
         "nat": {
-          "Id": "nat",
-          "Name": "nat",
           "DeploymentUnits": [
             "nat"
           ],
@@ -1272,8 +1156,6 @@
             "Engine": "natgw",
             "Destinations": {
               "default": {
-                "Id": "default",
-                "Name": "default",
                 "IPAddressGroups": "_global",
                 "Links": {
                   "internal": {
@@ -1289,8 +1171,6 @@
           }
         },
         "vpcendpoint": {
-          "Id": "vpcendpoint",
-          "Name": "vpcendpoint",
           "DeploymentUnits": [
             "vpcendpoint"
           ],
@@ -1298,8 +1178,6 @@
             "Engine": "vpcendpoint",
             "Destinations": {
               "default": {
-                "Id": "default",
-                "Name": "default",
                 "NetworkEndpointGroups": [
                   "storage",
                   "logs"
@@ -1329,17 +1207,11 @@
     "gbl": {
       "Components": {
         "cfredirect": {
-          "Id": "cfredirect",
-          "Name": "cfredirect",
           "Lambda": {
             "Instances": {
               "default": {
-                "Id": "default",
-                "Name": "default",
                 "Versions": {
                   "v1": {
-                    "Id": "v1",
-                    "Name": "v1",
                     "DeploymentUnits": [
                       "cfredirect-v1"
                     ],
@@ -1356,8 +1228,6 @@
             "FixedCodeVersion": {},
             "Functions": {
               "cfredirect": {
-                "Id": "cfredirect",
-                "Name": "cfredirect",
                 "Handler": "index.handler",
                 "VPCAccess": false,
                 "Permissions": {

--- a/providers/aws/masterData.json
+++ b/providers/aws/masterData.json
@@ -5,15 +5,11 @@
       "Locality": "Tokyo",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "ap-northeast-1a"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "ap-northeast-1c"
@@ -35,15 +31,11 @@
       "Locality": "Seoul",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "ap-northeast-2a"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "ap-northeast-2c"
@@ -65,15 +57,11 @@
       "Locality": "Mumbai",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "ap-south-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "ap-south-1b"
@@ -95,16 +83,12 @@
       "Locality": "Singapore",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "Index": 0,
           "AWSZone": "ap-southeast-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Singapore Zone B",
           "Index": 1,
@@ -127,8 +111,6 @@
       "Locality": "Sydney",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "ap-southeast-2a",
@@ -256,8 +238,6 @@
           ]
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "ap-southeast-2b",
@@ -385,8 +365,6 @@
           ]
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "ap-southeast-2c",
@@ -530,15 +508,11 @@
       "Locality": "Central",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "ca-central-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "ca-central-1b"
@@ -560,15 +534,11 @@
       "Locality": "Beijing",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "cn-north-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "cn-north-1b"
@@ -589,15 +559,11 @@
       "Locality": "Frankfurt",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "eu-central-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "eu-central-1b"
@@ -619,22 +585,16 @@
       "Locality": "Ireland",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "eu-west-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "eu-west-1b"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "eu-west-1c"
@@ -656,15 +616,11 @@
       "Locality": "London",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "eu-west-2a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "eu-west-2b"
@@ -686,15 +642,11 @@
       "Locality": "Paris",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "eu-west-3a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "eu-west-3b"
@@ -716,22 +668,16 @@
       "Locality": "Sao Paulo",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "sa-east-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "sa-east-1b"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "sa-east-1c"
@@ -753,29 +699,21 @@
       "Locality": "North Virginia",
       "Zones": {
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "us-east-1b"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "us-east-1c"
         },
         "d": {
-          "Id": "d",
-          "Name": "d",
           "Title": "Zone D",
           "Description": "Zone D",
           "AWSZone": "us-east-1d"
         },
         "e": {
-          "Id": "e",
-          "Name": "e",
           "Title": "Zone E",
           "Description": "Zone E",
           "AWSZone": "us-east-1e"
@@ -797,22 +735,16 @@
       "Locality": "Ohio",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "us-east-2a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "us-east-2b"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "us-east-2c"
@@ -834,15 +766,11 @@
       "Locality": "US",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "us-gov-west-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "us-gov-west-1b"
@@ -863,15 +791,11 @@
       "Locality": "North California",
       "Zones": {
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "us-west-1b"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "us-west-1c"
@@ -893,22 +817,16 @@
       "Locality": "Oregon",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "us-west-2a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "us-west-2b"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "us-west-2c"
@@ -930,22 +848,16 @@
       "Locality": "Stockholm",
       "Zones": {
         "a": {
-          "Id": "a",
-          "Name": "a",
           "Title": "Zone A",
           "Description": "Zone A",
           "AWSZone": "eu-north-1a"
         },
         "b": {
-          "Id": "b",
-          "Name": "b",
           "Title": "Zone B",
           "Description": "Zone B",
           "AWSZone": "eu-north-1b"
         },
         "c": {
-          "Id": "c",
-          "Name": "c",
           "Title": "Zone C",
           "Description": "Zone C",
           "AWSZone": "eu-north-1c"
@@ -1069,31 +981,23 @@
     "mgmt": {
       "Components": {
         "seg-cert": {
-          "Id": "seg-cert",
-          "Name": "seg-cert",
           "DeploymentUnits": [
             "cert"
           ]
         },
         "seg-dns": {
-          "Id": "seg-dns",
-          "Name": "seg-dns",
           "DeploymentUnits": [
             "dns"
           ],
           "Enabled": false
         },
         "seg-dashboard": {
-          "Id": "seg-dashboard",
-          "Name": "seg-dashboard",
           "DeploymentUnits": [
             "dashboard"
           ],
           "Enabled": false
         },
         "baseline": {
-          "Id": "baseline",
-          "Name": "baseline",
           "DeploymentUnits": [
             "baseline"
           ],
@@ -1152,8 +1056,6 @@
           }
         },
         "ssh": {
-          "Id": "ssh",
-          "Name": "ssh",
           "DeploymentUnits": [
             "ssh"
           ],
@@ -1168,8 +1070,6 @@
           }
         },
         "vpc": {
-          "Id": "vpc",
-          "Name": "vpc",
           "DeploymentUnits": [
             "vpc"
           ],
@@ -1177,23 +1077,15 @@
           "network": {
             "RouteTables": {
               "internal": {
-                "Id": "internal",
-                "Name": "internal"
               },
               "external": {
-                "Id": "external",
-                "Name": "external",
                 "Public": true
               }
             },
             "NetworkACLs": {
               "open": {
-                "Id": "open",
-                "Name": "open",
                 "Rules": {
                   "in": {
-                    "Id": "in",
-                    "Name": "in",
                     "Priority": 200,
                     "Action": "allow",
                     "Source": {
@@ -1210,8 +1102,6 @@
                     "ReturnTraffic": false
                   },
                   "out": {
-                    "Id": "out",
-                    "Name": "out",
                     "Priority": 200,
                     "Action": "allow",
                     "Source": {
@@ -1233,8 +1123,6 @@
           }
         },
         "igw": {
-          "Id": "igw",
-          "Name": "igw",
           "DeploymentUnits": [
             "igw"
           ],
@@ -1242,8 +1130,6 @@
             "Engine": "igw",
             "Destinations": {
               "default": {
-                "Id": "default",
-                "Name": "default",
                 "IPAddressGroups": "_global",
                 "Links": {
                   "external": {
@@ -1259,8 +1145,6 @@
           }
         },
         "nat": {
-          "Id": "nat",
-          "Name": "nat",
           "DeploymentUnits": [
             "nat"
           ],
@@ -1268,8 +1152,6 @@
             "Engine": "natgw",
             "Destinations": {
               "default": {
-                "Id": "default",
-                "Name": "default",
                 "IPAddressGroups": "_global",
                 "Links": {
                   "internal": {
@@ -1285,8 +1167,6 @@
           }
         },
         "vpcendpoint": {
-          "Id": "vpcendpoint",
-          "Name": "vpcendpoint",
           "DeploymentUnits": [
             "vpcendpoint"
           ],
@@ -1294,8 +1174,6 @@
             "Engine": "vpcendpoint",
             "Destinations": {
               "default": {
-                "Id": "default",
-                "Name": "default",
                 "NetworkEndpointGroups": [
                   "storage",
                   "logs"
@@ -1325,17 +1203,11 @@
     "gbl": {
       "Components": {
         "cfredirect": {
-          "Id": "cfredirect",
-          "Name": "cfredirect",
           "Lambda": {
             "Instances": {
               "default": {
-                "Id": "default",
-                "Name": "default",
                 "Versions": {
                   "v1": {
-                    "Id": "v1",
-                    "Name": "v1",
                     "DeploymentUnits": [
                       "cfredirect-v1"
                     ],
@@ -1352,8 +1224,6 @@
             "FixedCodeVersion": {},
             "Functions": {
               "cfredirect": {
-                "Id": "cfredirect",
-                "Name": "cfredirect",
                 "Handler": "index.handler",
                 "VPCAccess": false,
                 "Permissions": {

--- a/providers/shared/deploymentframeworks/default/legacy.ftl
+++ b/providers/shared/deploymentframeworks/default/legacy.ftl
@@ -7,7 +7,12 @@
     [#local start = .now]
     [@timing message="Starting component processing ..." /]
     [#list tiers as tier]
-        [#list (tier.Components!{})?values as component]
+        [#list (tier.Components!{}) as key, value]
+            [#local component =
+                {
+                    "Id" : key,
+                    "Name" : key
+                } + value ]
             [#if deploymentRequired(component, deploymentUnit)]
                 [#assign multiAZ = component.MultiAZ!solnMultiAZ]
                 [#local occurrenceStart = .now]

--- a/providers/shared/deploymentframeworks/default/model.ftl
+++ b/providers/shared/deploymentframeworks/default/model.ftl
@@ -37,12 +37,25 @@
 
     [#local tenantContexts = [] ]
     [#list tenants as tenantId, tenant]
-        [#local tenantContext = createTenantContext(tenantObject, rootContext)]
+        [#local tenantContext =
+            createTenantContext(
+                {
+                    "Id" : tenantId,
+                    "Name" : tenantId
+                } + tenant,
+                rootContext)]
 
         [#local podContexts = [] ]
         [#list pods.PodOrder as podId]
             [#local pod = pods.Pods[podId] ]
-            [#local podContext = createPodContext({"Id" : podId} + removeObjectAttributes(pod, "Solution"), tenantContext) ]
+            [#local podContext =
+                createPodContext(
+                    {
+                        "Id" : podId,
+                        "Name" : podId
+                    } + removeObjectAttributes(pod, "Solution"),
+                    tenantContext
+                ) ]
             [#local solutionContext = createSolutionContext({}, podContext) ]
             [#local solutionContext =
                 addChildContexts(

--- a/providers/shared/masterData.ftl
+++ b/providers/shared/masterData.ftl
@@ -5,8 +5,6 @@
     {
       "Environments": {
         "alm": {
-          "Id" : "alm",
-          "Name" : "alm",
           "Title": "Application Lifecycle Management Environment",
           "Description": "Normally only one environment for the alm. Entry mainly here for naming consistency",
           "Category": "alm",
@@ -18,8 +16,6 @@
           }
         },
         "shared": {
-          "Id" : "shared",
-          "Name" : "shared",
           "Title": "Shared Services Environment",
           "Description": "One shared environment per account. Entry mainly here for naming consistency",
           "Category": "alm",
@@ -28,8 +24,6 @@
           }
         },
         "dev": {
-          "Id" : "dev",
-          "Name": "development",
           "Title": "Development Environment",
           "Description": "Potentially holds individual dev servers for multiple devs",
           "Category": "dev",
@@ -41,8 +35,6 @@
           }
         },
         "alpha": {
-          "Id" : "alpha",
-          "Name" : "alpha",
           "Title": "Alpha Environment",
           "Description": "Prototyping environment according to DTO classification",
           "Category": "test",
@@ -54,8 +46,6 @@
           }
         },
         "beta": {
-          "Id" : "beta",
-          "Name" : "beta",
           "Title": "Beta Environment",
           "Description": "Preproduction environment according to DTO classification",
           "Category": "stg",
@@ -68,7 +58,6 @@
           }
         },
         "int": {
-          "Id" : "int",
           "Name": "integration",
           "Title": "Integration Environment",
           "Description": "Mainly for devs to confirm components work together",
@@ -81,7 +70,6 @@
           }
         },
         "aat": {
-          "Id" : "aat",
           "Name": "automatedacceptance",
           "Title": "Automated Acceptance Environment",
           "Description": "Execution of automated tests",
@@ -94,7 +82,6 @@
           }
         },
         "uat": {
-          "Id" : "uat",
           "Name": "useracceptance",
           "Title": "User Acceptance Environment",
           "Description": "Manual customer testing",
@@ -107,7 +94,6 @@
           }
         },
         "system": {
-          "Id" : "system",
           "Name" : "system",
           "Title": "System Test Environment",
           "Description": "Same as UAT",
@@ -121,7 +107,6 @@
           }
         },
         "preprod": {
-          "Id" : "preprod",
           "Name": "preproduction",
           "Title": "Preproduction Environment",
           "Description": "Deployment, performance, volume testing",
@@ -135,7 +120,6 @@
           }
         },
         "stg": {
-          "Id" : "stg",
           "Name": "staging",
           "Title": "Staging Environment",
           "Description": "Deployment, performance, volume testing. Staging is used both as a specific environment and as a category of environments.",
@@ -149,7 +133,6 @@
           }
         },
         "prod": {
-          "Id" : "prod",
           "Name": "production",
           "Title": "Production Environment",
           "Description": "Kind of obvious...",
@@ -163,7 +146,6 @@
           }
         },
         "trn": {
-          "Id" : "trn",
           "Name": "training",
           "Title": "Training Environment",
           "Description": "",
@@ -178,39 +160,30 @@
       },
       "Categories": {
         "alm": {
-          "Id" : "alm",
-          "Name" : "alm",
           "Title": "Application Lifecycle Management Environments"
         },
         "account": {
-          "Id" : "account",
-          "Name" : "account",
           "Title": "Account Resources"
         },
         "dev": {
-          "Id" : "dev",
           "Name": "development",
           "Title": "Development Environments"
         },
         "test": {
-          "Id" : "test",
           "Name": "testing",
           "Title": "Testing Environments"
         },
         "stg": {
-          "Id" : "stg",
           "Name": "staging",
           "Title": "Staging Environments"
         },
         "prod": {
-          "Id" : "prod",
           "Name": "production",
           "Title": "Production Environments"
         }
       },
       "Tiers": {
         "web": {
-          "Id" : "web",
           "Name" : "web",
           "Title": "Web Tier",
           "Description": "Supports HMI",
@@ -227,7 +200,6 @@
           }
         },
         "api": {
-          "Id" : "api",
           "Name" : "api",
           "Title": "API Tier",
           "Description": "Supports externally exposed APIs",
@@ -244,7 +216,6 @@
           }
         },
         "msg": {
-          "Id" : "msg",
           "Name": "messaging",
           "Title": "Messaging Tier",
 
@@ -262,7 +233,6 @@
           }
         },
         "app": {
-          "Id" : "app",
           "Name": "application",
           "Title": "Applications Tier",
           "Description": "Supports application logic execution",
@@ -279,7 +249,6 @@
           }
         },
         "db": {
-          "Id" : "db",
           "Name": "database",
           "Title": "Database Tier",
           "Description": "Supports long term storage of content and customer data",
@@ -296,7 +265,6 @@
           }
         },
         "dir": {
-          "Id" : "dir",
           "Name": "directories",
           "Title": "Directories Tier",
           "Description": "Supports directories or domain controllers",
@@ -313,7 +281,6 @@
           }
         },
         "ana": {
-          "Id" : "ana",
           "Name": "analytics",
           "Title": "Analytics Tier",
           "Description": "Suports things like search engines",
@@ -330,7 +297,6 @@
           }
         },
         "elb": {
-          "Id" : "elb",
           "Name" : "elb",
           "Title": "External Load Balancer Tier",
           "Description": "Publically accessible application load balancers",
@@ -347,7 +313,6 @@
           }
         },
         "ilb": {
-          "Id" : "ilb",
           "Name" : "ilb",
           "Title": "Internal Load Balancer Tier",
           "Description": "Internally accessible application load balancers",
@@ -364,7 +329,6 @@
           }
         },
         "mgmt": {
-          "Id" : "mgmt",
           "Name": "management",
           "Title": "Management Tier",
           "Description": "Supports ssh based host access and internet access for internal hosts",
@@ -381,7 +345,6 @@
           }
         },
         "shared": {
-          "Id" : "shared",
           "Name" : "shared",
           "Title": "Shared Tier",
           "Description": "Shared Tier",
@@ -398,7 +361,6 @@
           }
         },
         "docs": {
-          "Id" : "docs",
           "Name": "documentation",
           "Title": "Docs Tier",
           "Description": "Non-network Tier For documentation generation",
@@ -407,7 +369,6 @@
           }
         },
         "gbl": {
-          "Id" : "global",
           "Name": "global",
           "Title": "Global Tier",
           "Description": "Components which are used for Global Services",


### PR DESCRIPTION
Id and Name attributes are now no longer added to the blueprint if not
present. Instead, they are explicitly defaulted based on attribute keys.

To confirm it is working as expected, all the Ids in the master data that matched the attribute key were removed.

This will also fix an issue where the tier name was using the id not the
name.