### PR TITLE
<Refactor> Revert OWASP body size limits

### DIFF
--- a/providers/aws/masterData.ftl
+++ b/providers/aws/masterData.ftl
@@ -1699,7 +1699,7 @@
       ],
       "maxuri": 1024,
       "maxquery": 1024,
-      "maxbody": 10240,
+      "maxbody": 4096,
       "maxcookie": 4093,
       "csrfsize": 36,
       "uristartswith": [

--- a/providers/aws/masterData.json
+++ b/providers/aws/masterData.json
@@ -1695,7 +1695,7 @@
       ],
       "maxuri": 1024,
       "maxquery": 1024,
-      "maxbody": 10240,
+      "maxbody": 4096,
       "maxcookie": 4093,
       "csrfsize": 36,
       "uristartswith": [


### PR DESCRIPTION
Revert limit to 4k. If a product requires a higher limit, it should explicitly override the default. 