### PR TITLE
<fix> Use log level in cleanup logic

### DIFF
--- a/aws/cleanupContext.sh
+++ b/aws/cleanupContext.sh
@@ -5,8 +5,7 @@
 # Context cleanup is only done from the script that set the context
 [[ -z "${GENERATION_CONTEXT_DEFINED_LOCAL}" ]] && return 0
 
-if [[ -z "${GENERATION_DEBUG}" ]]; then
-  [[ -n "${GENERATION_TMPDIR}" ]] && rm -rf "${GENERATION_TMPDIR}"
-fi
+! willLog "debug" &&
+    [[ -n "${GENERATION_TMPDIR}" ]] && rm -rf "${GENERATION_TMPDIR}"
 
 return 0


### PR DESCRIPTION
Cleanup logic did not retain temporary files unless GENERATION_DEBUG
was set.

Switch to using willLog which will still honour GENERATION_DEBUG
but will also honour GENERATION_LOG_LEVEL=debug