### PR TITLE
<fix> ECS Volumes and LB Base Path redirects

### DIFF
--- a/providers/aws/components/lb/setup.ftl
+++ b/providers/aws/components/lb/setup.ftl
@@ -236,7 +236,7 @@
                 [#if solution.Path == "default" ]
                     [#local path = "*"]
                 [#else]
-                    [#if solution.Path?ends_with("/")]
+                    [#if solution.Path?ends_with("/") && solution.Path != "/" ]
                         [#local path = solution.Path?ensure_ends_with("*")]
                     [#else]
                         [#local path = solution.Path ]

--- a/providers/aws/services/ecs/resource.ftl
+++ b/providers/aws/services/ecs/resource.ftl
@@ -89,7 +89,8 @@
     dependencies=""]
 
     [#local definitions = [] ]
-    [#local volumes = [] ]
+    [#local volumes = []]
+    [#local volumeNames = [] ]
 
     [#local memoryTotal = 0]
     [#local cpuTotal = 0]
@@ -106,44 +107,48 @@
                 ]
             ]
 
-            [#local dockerVolumeConfiguration = {} +
-                volume.PersistVolume?then(
-                    {
-                        "Scope" : "shared",
-                        "Autoprovision", volume.AutoProvision
-                    },
-                    {}
-                ) +
-                (volume.Driver != "local")?then(
-                    {
-                        "Driver" : volume.Driver
-                    },
-                    {}
-                ) +
-                (volume.DriverOpts?has_content)?then(
-                    {
-                        "DriverOpts" : volume.DriverOpts
-                    },
-                    {}
-                )
-            ]
+            [#if ! volumeNames?seq_contains(name) ]
 
-            [#local volumes +=
-                [
-                    {
-                        "Name" : name
-                    } +
-                    attributeIfTrue(
-                        "Host",
-                        volume.HostPath?has_content,
-                        {"SourcePath" : volume.HostPath!""}) +
-                    attributeIfTrue(
-                        "DockerVolumeConfiguration",
-                        dockerVolumeConfiguration?has_content,
-                        dockerVolumeConfiguration
+                [#local dockerVolumeConfiguration = {} +
+                    volume.PersistVolume?then(
+                        {
+                            "Scope" : "shared",
+                            "Autoprovision", volume.AutoProvision
+                        },
+                        {}
+                    ) +
+                    (volume.Driver != "local")?then(
+                        {
+                            "Driver" : volume.Driver
+                        },
+                        {}
+                    ) +
+                    (volume.DriverOpts?has_content)?then(
+                        {
+                            "DriverOpts" : volume.DriverOpts
+                        },
+                        {}
                     )
                 ]
-            ]
+
+                [#local volumes +=
+                    [
+                        {
+                            "Name" : name
+                        } +
+                        attributeIfTrue(
+                            "Host",
+                            volume.HostPath?has_content,
+                            {"SourcePath" : volume.HostPath!""}) +
+                        attributeIfTrue(
+                            "DockerVolumeConfiguration",
+                            dockerVolumeConfiguration?has_content,
+                            dockerVolumeConfiguration
+                        )
+                    ]
+                ]
+            [/#if]
+            [#local volumeNames += [ name ] ]
         [/#list]
         [#local portMappings = [] ]
         [#list (container.PortMappings![]) as portMapping]


### PR DESCRIPTION
A couple of minor fixes 
- ECS Volumes - Allow for the same volume to be shared between containers - Only add one volume entry to the task definition 
- LB - Allow for the creation of a base path only path condition