### PR TITLE
<fix> SPA links should be subobjects

### DIFF
--- a/providers/shared/components/spa/id.ftl
+++ b/providers/shared/components/spa/id.ftl
@@ -26,8 +26,8 @@
             },
             {
                 "Names" : "Links",
-                "Type" : OBJECT_TYPE,
-                "Default" : {}
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
             },
             {
                 "Names" : "WAF",


### PR DESCRIPTION
This is a really old bit of config that didn't get picked up with the management of subobjects in the configuration.

A scan of all ftl files suggests this is the only place his error existed - all other definitions use subobjects.