### PR TITLE
<feature> CDN Component

### DIFF
--- a/providers/aws/components/cdn/id.ftl
+++ b/providers/aws/components/cdn/id.ftl
@@ -1,0 +1,15 @@
+[#ftl]
+[@addResourceGroupInformation
+    type=CDN_COMPONENT_TYPE
+    attributes=[]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=
+        [
+            AWS_CLOUDFRONT_SERVICE,
+            AWS_WEB_APPLICATION_FIREWALL_SERVICE,
+            AWS_BASELINE_PSEUDO_SERVICE,
+            AWS_CERTIFICATE_MANAGER_SERVICE,
+            AWS_ROUTE53_SERVICE
+        ]
+/]

--- a/providers/aws/components/cdn/setup.ftl
+++ b/providers/aws/components/cdn/setup.ftl
@@ -1,0 +1,404 @@
+[#ftl]
+[#macro aws_cdn_cf_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
+
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@addDefaultGenerationPlan subsets=["template", "epilogue"] /]
+        [#return]
+    [/#if]
+
+    [#local core = occurrence.Core ]
+    [#local resources = occurrence.State.Resources]
+    [#local solution = occurrence.Configuration.Solution ]
+
+    [#local cfId                = resources["cf"].Id]
+    [#local cfName              = resources["cf"].Name]
+
+    [#local wafPresent          = isPresent(solution.WAF) ]
+    [#local wafAclId            = resources["wafacl"].Id]
+    [#local wafAclName          = resources["wafacl"].Name]
+
+    [#-- Baseline component lookup --]
+    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "CDNOriginKey", "OpsData" ])]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+    [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]!"") ]
+    [#local cfAccess         = getExistingReference(baselineComponentIds["CDNOriginKey"]!"") ]
+
+    [#local fragment = getOccurrenceFragmentBase(occurrence) ]
+
+    [#local _parentContext =
+        {
+            "Id" : fragment,
+            "Name" : fragment,
+            "Instance" : core.Instance.Id,
+            "Version" : core.Version.Id
+        }
+    ]
+    [#local fragmentId = formatFragmentId(_parentContext)]
+
+    [#local securityProfile = getSecurityProfile(solution.Profiles.Security, CDN_COMPONENT_TYPE)]
+
+    [#local certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers) ]
+    [#local hostName = getHostName(certificateObject, occurrence) ]
+    [#local certificateId = formatDomainCertificateId(certificateObject, hostName) ]
+    [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
+    [#local primaryFQDN = formatDomainName(hostName, primaryDomainObject)]
+
+    [#-- Get alias list --]
+    [#local aliases = [] ]
+    [#list certificateObject.Domains as domain]
+        [#local aliases += [ formatDomainName(hostName, domain.Name) ] ]
+    [/#list]
+
+    [#if !cfAccess?has_content]
+        [@precondition
+            function="solution_spa"
+            context=occurrence
+            detail="No CF Access Id found"
+        /]
+        [#return]
+    [/#if]
+
+    [#local origins = []]
+    [#local cacheBehaviours = []]
+    [#local defaultCacheBehaviour = []]
+
+    [#list occurrence.Occurrences![] as subOccurrence]
+        [#local subCore = subOccurrence.Core ]
+        [#local subSolution = subOccurrence.Configuration.Solution ]
+        [#local subResources = subOccurrence.State.Resources ]
+
+        [#local routeBehaviours = []]
+
+        [#local originId = subResources["origin"].Id ]
+
+        [#if !subSolution.Enabled]
+            [#continue]
+        [/#if]
+
+        [#local contextLinks = getLinkTargets(subOccurrence)]
+
+        [#assign _context =
+            {
+                "Id" : fragment,
+                "Name" : fragment,
+                "Instance" : subCore.Instance.Id,
+                "Version" : subCore.Version.Id,
+                "Environment" : {},
+                "Links" : contextLinks,
+                "BaselineLinks" : baselineLinks,
+                "DefaultEnvironment" : defaultEnvironment(subOccurrence, contextLinks, baselineLinks),
+                "DefaultCoreVariables" : false,
+                "DefaultEnvironmentVariables" : false,
+                "DefaultLinkVariables" : true,
+                "DefaultBaselineVariables" : false,
+                "Route" : subCore.SubComponent.Id
+            }
+        ]
+
+        [#-- Add in fragment specifics including override of defaults --]
+        [#include fragmentList?ensure_starts_with("/")]
+
+        [#local finalEnvironment = getFinalEnvironment(subOccurrence, _context ) ]
+        [#assign _context += finalEnvironment ]
+
+        [#-- Get any event handlers --]
+        [#local eventHandlerLinks = {} ]
+        [#local eventHandlers = []]
+
+        [#if subSolution.RedirectAliases.Enabled
+                    && ( aliases?size > 1) ]
+
+            [#local cfRedirectLink = {
+                "cfredirect" : {
+                    "Tier" : "gbl",
+                    "Component" : "cfredirect",
+                    "Version" : subSolution.RedirectAliases.RedirectVersion,
+                    "Instance" : "",
+                    "Function" : "cfredirect",
+                    "Action" : "origin-request"
+                }
+            }]
+
+            [#if getLinkTarget(occurrence, cfRedirectLink.cfredirect )?has_content ]
+                [#local eventHandlerLinks += cfRedirectLink]
+
+                [#assign _context +=
+                    {
+                        "ForwardHeaders" : (_context.ForwardHeaders![]) + [
+                            "Host"
+                        ]
+                    }]
+
+                [#assign _context +=
+                    {
+                        "CustomOriginHeaders" : (_context.CustomOriginHeaders![]) + [
+                            getCFHTTPHeader(
+                                "X-Redirect-Primary-Domain-Name",
+                                primaryFQDN ),
+                            getCFHTTPHeader(
+                                "X-Redirect-Response-Code",
+                                "301"
+                            )
+                        ]
+                    }]
+            [#else]
+                [@fatal
+                    message="Could not find cfredirect component"
+                    context=cfRedirectLink
+                /]
+            [/#if]
+        [/#if]
+
+        [#local eventHandlerLinks += subSolution.EventHandlers ]
+        [#list eventHandlerLinks?values as eventHandler]
+
+            [#local eventHandlerTarget = getLinkTarget(occurrence, eventHandler) ]
+
+            [@debug message="Event message handler" context=eventHandlerTarget enabled=false /]
+
+            [#if !eventHandlerTarget?has_content]
+                [#continue]
+            [/#if]
+
+            [#local eventHandlerCore = eventHandlerTarget.Core ]
+            [#local eventHandlerResources = eventHandlerTarget.State.Resources ]
+            [#local eventHandlerAttributes = eventHandlerTarget.State.Attributes ]
+            [#local eventHandlerConfiguration = eventHandlerTarget.Configuration ]
+
+            [#if (eventHandlerCore.Type) == LAMBDA_FUNCTION_COMPONENT_TYPE &&
+                    eventHandlerAttributes["DEPLOYMENT_TYPE"] == "EDGE" ]
+
+                    [#local eventHandlers += getCFEventHandler(
+                                                eventHandler.Action,
+                                                eventHandlerResources["version"].Id) ]
+            [#else]
+                [@fatal
+                    description="Invalid Event Handler Component - Must be Lambda - EDGE"
+                    context=occurrence
+                /]
+            [/#if]
+        [/#list]
+
+        [#local originLink = getLinkTarget(occurrence, subSolution.Origin.Link) ]
+
+        [#if !originLink?has_content]
+            [#continue]
+        [/#if]
+
+        [#local originLinkTargetCore = originLink.Core ]
+        [#local originLinkTargetConfiguration = originLink.Configuration ]
+        [#local originLinkTargetResources = originLink.State.Resources ]
+        [#local originLinkTargetAttributes = originLink.State.Attributes ]
+
+        [#switch originLinkTargetCore.Type]
+
+            [#case S3_COMPONENT_TYPE ]
+
+                [#if isPresent(originLinkTargetConfiguration.Solution.Website) ]
+                    [#local originBucket = (originLinkTargetAttributes["WEBSITE_URL"])?remove_beginning("http://") ]
+                [#else]
+                    [#local originBucket = originLinkTargetAttributes["NAME"] ]
+                [/#if]
+
+                [#local origin =
+                    getCFS3Origin(
+                        originId,
+                        originBucket,
+                        cfAccess,
+                        subSolution.Origin.BasePath,
+                        _context.CustomOriginHeaders)]
+                [#local origins += origin ]
+
+                [#local behaviour = getCFSPACacheBehaviour(
+                    origin,
+                    subSolution.PathPattern,
+                    {
+                        "Default" : subSolution.CachingTTL.Default,
+                        "Max" : subSolution.CachingTTL.Maximum,
+                        "Min" : subSolution.CachingTTL.Minimum
+                    },
+                    subSolution.Compress,
+                    eventHandlers,
+                    _context.ForwardHeaders)]
+                    [#local routeBehaviours += behaviour ]
+                [#break]
+
+            [#case SPA_COMPONENT_TYPE ]
+
+                [#local originBucket = "" ]
+                [#local spaOrigin =
+                    getCFS3Origin(
+                        originId,
+                        originBucket,
+                        cfAccess,
+                        formatAbsolutePath(getSettingsFilePrefix(occurrence), "spa"),
+                        _context.CustomOriginHeaders)]
+                [#local origins += spaOrigin ]
+
+                [#local configOrigin =
+                    getCFS3Origin(
+                        formatId(originId, "config"),
+                        originBucket,
+                        cfAccess,
+                        formatAbsolutePath(getSettingsFilePrefix(occurrence)),
+                        _context.CustomOriginHeaders)]
+                [#local origins += configOrigin ]
+
+                [#local spaCacheBehaviour = getCFSPACacheBehaviour(
+                    spaOrigin,
+                    subSolution.PathPattern,
+                    {
+                        "Default" : subSolution.CachingTTL.Default,
+                        "Max" : subSolution.CachingTTL.Maximum,
+                        "Min" : subSolution.CachingTTL.Minimum
+                    },
+                    subSolution.Compress,
+                    eventHandlers,
+                    _context.ForwardHeaders)]
+                [#local routeBehaviours += configCacheBehaviour ]
+
+                [#local configCacheBehaviour = getCFSPACacheBehaviour(
+                    configOrigin,
+                    formatAbsolutePath( subSolution.PathPattern, "config/*"),
+                    { "Default" : 60 },
+                    subSolution.Compress,
+                    eventHandlers,
+                    _context.ForwardHeaders) ]
+
+                [#local routeBehaviours += configCacheBehaviour ]
+                [#break]
+
+            [#case LB_PORT_COMPONENT_TYPE ]
+
+                [#local origin = 
+                            getCFHTTPOrigin(
+                                originId,
+                                originLinkTargetAttributes["FQDN"],
+                                _context.CustomOriginHeaders,
+                                formatAbsolutePath( originLinkTargetAttributes["PATH"], subSolution.Origin.BasePath )
+                            )]
+                [#local origins += origin ]
+
+                [#local behaviour = 
+                            getCFLBCacheBehaviour(
+                                origin,
+                                subSolution.PathPattern,
+                                subSolution.CachingTTL,
+                                subSolution.Compress,
+                                _context.ForwardHeaders,
+                                eventHandlers )]
+                [#local routeBehaviours += behaviour ]
+                [#break]
+        [/#switch]
+
+        [#list routeBehaviours as behaviour ]
+            [#if (behaviour.PathPattern!"")?has_content ]
+                [#local cacheBehaviours += routeBehaviours ]
+            [#else]
+                [#local defaultCacheBehaviour = behaviour ]
+            [/#if]
+        [/#list]
+
+        [#if subSolution.InvalidateOnUpdate ]
+            [#if deploymentSubsetRequired("epilogue", false)]
+                [@addToDefaultBashScriptOutput
+                    content=(getExistingReference(cfId)?has_content)?then(
+                        [
+                            "case $\{STACK_OPERATION} in",
+                            "  create|update)"
+                        ] +
+                        [
+                            "# Invalidate distribution",
+                            "info \"Invalidating cloudfront distribution ... \"",
+                            "invalidate_distribution" +
+                            " \"" + region + "\" " +
+                            " \"" + getExistingReference(cfId) + "\" || return $?"
+
+                        ] +
+                        [
+                            "       ;;",
+                            "       esac"
+                        ],
+                        []
+                    )
+                /]
+            [/#if]
+        [/#if]
+    [/#list]
+
+    [#if deploymentSubsetRequired(CDN_COMPONENT_TYPE, true)]
+        [#local restrictions = {} ]
+        [#if solution.CountryGroups?has_content]
+            [#list asArray(solution.CountryGroups) as countryGroup]
+                [#local group = (countryGroups[countryGroup])!{}]
+                [#if group.Locations?has_content]
+                    [#local restrictions +=
+                        getCFGeoRestriction(group.Locations, group.Blacklist!false) ]
+                    [#break]
+                [/#if]
+            [/#list]
+        [/#if]
+
+        [@createCFDistribution
+            id=cfId
+            aliases=
+                (isPresent(solution.Certificate))?then(
+                    aliases,
+                    []
+                )
+            cacheBehaviours=cacheBehaviours
+            certificate=valueIfTrue(
+                getCFCertificate(
+                    certificateId,
+                    securityProfile.HTTPSProfile,
+                    solution.AssumeSNI),
+                    isPresent(solution.Certificate)
+                )
+            comment=cfName
+            customErrorResponses=
+                getErrorResponse(
+                        404,
+                        200,
+                        (solution.Pages.NotFound)?has_content?then(
+                            solution.Pages.NotFound,
+                            solution.Pages.Error
+                        )) +
+                getErrorResponse(
+                        403,
+                        200,
+                        (solution.Pages.Denied)?has_content?then(
+                            solution.Pages.Denied,
+                            solution.Pages.Error
+                        ))
+            defaultCacheBehaviour=defaultCacheBehaviour
+            defaultRootObject=solution.Pages.Root
+            logging=valueIfTrue(
+                getCFLogging(
+                    operationsBucket,
+                    formatComponentAbsoluteFullPath(
+                        core.Tier,
+                        core.Component,
+                        occurrence
+                    )
+                ),
+                solution.EnableLogging)
+            origins=origins
+            restrictions=valueIfContent(
+                restrictions,
+                restrictions)
+            wafAclId=valueIfTrue(wafAclId, wafPresent)
+        /]
+
+        [#if wafPresent ]
+            [@createWAFAclFromSecurityProfile
+                id=wafAclId
+                name=wafAclName
+                metric=wafAclName
+                wafSolution=solution.WAF
+                securityProfile=securityProfile
+                occurrence=occurrence /]
+        [/#if]
+    [/#if]
+
+[/#macro]

--- a/providers/aws/components/cdn/setup.ftl
+++ b/providers/aws/components/cdn/setup.ftl
@@ -264,7 +264,7 @@
                     subSolution.Compress,
                     eventHandlers,
                     _context.ForwardHeaders)]
-                [#local routeBehaviours += configCacheBehaviour ]
+                [#local routeBehaviours += spaCacheBehaviour ]
 
                 [#local configCacheBehaviour = getCFSPACacheBehaviour(
                     configOrigin,
@@ -300,11 +300,21 @@
                 [#break]
         [/#switch]
 
+        
         [#list routeBehaviours as behaviour ]
             [#if (behaviour.PathPattern!"")?has_content && originDefaultPath ]
-                [#local cacheBehaviours += routeBehaviours ]
+                [#local cacheBehaviours += [ behaviour ] ]
             [#else]
-                [#local defaultCacheBehaviour = behaviour ]
+                [#if ! defaultCacheBehaviour?has_content ]
+                    [#local defaultCacheBehaviour = behaviour ]
+                [#else]
+                    [@fatal 
+                        message="Multiple default routes have been defined"
+                        context=solution 
+                        defailt="Check your routes to make sure PathPattern is different" 
+                        enabled=true
+                    /]
+                [/#if]
             [/#if]
         [/#list]
 

--- a/providers/aws/components/cdn/setup.ftl
+++ b/providers/aws/components/cdn/setup.ftl
@@ -19,7 +19,7 @@
     [#local wafAclName          = resources["wafacl"].Name]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData" ])]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData" ])]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]!"") ]
 
@@ -194,7 +194,7 @@
             [#case S3_COMPONENT_TYPE ]
 
                 [#local spaBaslineProfile = originLinkTargetConfiguration.Solution.Profiles.Baseline ]
-                [#local spaBaselineLinks = getBaselineLinks(spaBaslineProfile, [ "CDNOriginKey" ])]
+                [#local spaBaselineLinks = getBaselineLinks(originLink, [ "CDNOriginKey" ])]
                 [#local spaBaselineComponentIds = getBaselineComponentIds(spaBaselineLinks)]
                 [#local cfAccess = getExistingReference(spaBaselineComponentIds["CDNOriginKey"]!"")]
 
@@ -230,7 +230,7 @@
             [#case SPA_COMPONENT_TYPE ]
 
                 [#local spaBaslineProfile = originLinkTargetConfiguration.Solution.Profiles.Baseline ]
-                [#local spaBaselineLinks = getBaselineLinks(spaBaslineProfile, [ "OpsData", "CDNOriginKey" ])]
+                [#local spaBaselineLinks = getBaselineLinks(originLink, [ "OpsData", "CDNOriginKey" ])]
                 [#local spaBaselineComponentIds = getBaselineComponentIds(spaBaselineLinks)]
                 [#local originBucket = getExistingReference(spaBaselineComponentIds["OpsData"]!"") ]
                 [#local cfAccess = getExistingReference(spaBaselineComponentIds["CDNOriginKey"]!"")]

--- a/providers/aws/components/cdn/state.ftl
+++ b/providers/aws/components/cdn/state.ftl
@@ -1,0 +1,70 @@
+[#ftl]
+
+[#macro aws_cdn_cf_state occurrence parent={} baseState={}  ]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#local cfId  = formatComponentCFDistributionId(core.Tier, core.Component, occurrence)]
+    [#local cfName = formatComponentCFDistributionName(core.Tier, core.Component, occurrence)]
+
+    [#if isPresent(solution.Certificate) ]
+        [#local certificateObject = getCertificateObject(solution.Certificate!"", segmentQualifiers) ]
+        [#local hostName = getHostName(certificateObject, occurrence) ]
+        [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
+        [#local fqdn = formatDomainName(hostName, primaryDomainObject)]
+
+    [#else]
+            [#local fqdn = getExistingReference(cfId,DNS_ATTRIBUTE_TYPE)]
+    [/#if]
+
+    [#assign componentState =
+        {
+            "Resources" : {
+                "cf" : {
+                    "Id" : cfId,
+                    "Name" : cfName,
+                    "Type" : AWS_CLOUDFRONT_DISTRIBUTION_RESOURCE_TYPE
+                },
+                "wafacl" : {
+                    "Id" : formatDependentWAFAclId(cfId),
+                    "Name" : formatComponentWAFAclName(core.Tier, core.Component, occurrence),
+                    "Type" : AWS_WAF_ACL_RESOURCE_TYPE
+                }
+            },
+            "Attributes" : {
+                "FQDN" : fqdn,
+                "URL" : "https://" + fqdn
+            },
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#macro]
+
+
+[#macro aws_cdnroute_cf_state occurrence parent={} baseState={}  ]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#local parentAttributes = parent.State.Attributes ]
+
+    [#assign componentState =
+        {
+            "Resources" : {
+                "origin" : {
+                    "Id" : formatResourceId(AWS_CLOUDFRONT_ORIGIN_RESOURCE_TYPE, core.Id ),
+                    "Type" : AWS_CLOUDFRONT_ORIGIN_RESOURCE_TYPE
+                }
+            },
+            "Attributes" : parentAttributes + {
+                "URL" : formatAbsolutePath( parentAttributes["URL"], solution.PathPattern?remove_ending("*") )
+            },
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#macro]

--- a/providers/aws/components/cdn/state.ftl
+++ b/providers/aws/components/cdn/state.ftl
@@ -33,7 +33,8 @@
             },
             "Attributes" : {
                 "FQDN" : fqdn,
-                "URL" : "https://" + fqdn
+                "URL" : "https://" + fqdn,
+                "DISTRIBUTION_ID" : getExistingReference(cfId)
             },
             "Roles" : {
                 "Inbound" : {},
@@ -49,17 +50,33 @@
     [#local solution = occurrence.Configuration.Solution]
 
     [#local parentAttributes = parent.State.Attributes ]
+    [#local parentResources = parent.State.Resources ]
+
+    [#local cfId = parentResources["cf"].Id ]
+
+    [#local pathPattern = solution.PathPattern ]
+    [#local isDefaultPath = false ]
+    [#switch pathPattern?lower_case ]
+        [#case "" ]
+        [#case "_default"]
+        [#case "/"]
+            [#local isDefaultPath = true ]
+            [#local pathPattern = "/*" ]
+    [/#switch]
 
     [#assign componentState =
         {
             "Resources" : {
                 "origin" : {
                     "Id" : formatResourceId(AWS_CLOUDFRONT_ORIGIN_RESOURCE_TYPE, core.Id ),
-                    "Type" : AWS_CLOUDFRONT_ORIGIN_RESOURCE_TYPE
+                    "Type" : AWS_CLOUDFRONT_ORIGIN_RESOURCE_TYPE,
+                    "Deployed" : getExistingReference(cfId)?has_content,
+                    "PathPattern" : pathPattern,
+                    "DefaultPath" : isDefaultPath
                 }
             },
             "Attributes" : parentAttributes + {
-                "URL" : formatAbsolutePath( parentAttributes["URL"], solution.PathPattern?remove_ending("*") )
+                "URL" : formatAbsolutePath( parentAttributes["URL"], pathPattern?remove_ending("*") )
             },
             "Roles" : {
                 "Inbound" : {},

--- a/providers/aws/components/cdn/state.ftl
+++ b/providers/aws/components/cdn/state.ftl
@@ -4,8 +4,8 @@
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
-    [#local cfId  = formatComponentCFDistributionId(core.Tier, core.Component, occurrence)]
-    [#local cfName = formatComponentCFDistributionName(core.Tier, core.Component, occurrence)]
+    [#local cfId  = formatResourceId(AWS_CLOUDFRONT_DISTRIBUTION_RESOURCE_TYPE, core.Id)]
+    [#local cfName = core.FullName]
 
     [#if isPresent(solution.Certificate) ]
         [#local certificateObject = getCertificateObject(solution.Certificate!"", segmentQualifiers) ]

--- a/providers/aws/components/db/setup.ftl
+++ b/providers/aws/components/db/setup.ftl
@@ -181,7 +181,10 @@
         [/#if]
     [/#list]
 
-    [#local processorProfile = getProcessor(occurrence, "RDS")]
+    [#local processorProfile = (getProcessor(occurrence, "RDS")?has_content)?then(
+                                getProcessor(occurrence, "RDS"),
+                                getProcessor(occurrence, DB_COMPONENT_TYPE )
+                            )]
 
     [#if deploymentSubsetRequired("prologue", false)]
         [@addToDefaultBashScriptOutput

--- a/providers/aws/components/s3/state.ftl
+++ b/providers/aws/components/s3/state.ftl
@@ -29,17 +29,12 @@
                     "Id" : formatResourceId( AWS_IAM_ROLE_RESOURCE_TYPE, core.Id ),
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
                     "IncludeInDeploymentState" : false
-                }
-            } +
-            publicAccessEnabled?then(
-                {
-                    "bucketpolicy" : {
+                },
+                "bucketpolicy" : {
                         "Id" : formatResourceId(AWS_S3_BUCKET_POLICY_RESOURCE_TYPE, core.Id),
                         "Type" : AWS_S3_BUCKET_POLICY_RESOURCE_TYPE
-                    }
-                },
-                {}
-            ),
+                }
+            },
             "Attributes" : {
                 "NAME" : getExistingReference(id, NAME_ATTRIBUTE_TYPE),
                 "FQDN" : getExistingReference(id, DNS_ATTRIBUTE_TYPE),

--- a/providers/aws/components/spa/setup.ftl
+++ b/providers/aws/components/spa/setup.ftl
@@ -53,7 +53,7 @@
 
     [#assign _context += getFinalEnvironment(occurrence, _context) ]
 
-    [#list _context.Links as id,link ]
+    [#list _context.Links as id,linkTarget ]
 
         [#local linkTargetCore = linkTarget.Core ]
         [#local linkTargetConfiguration = linkTarget.Configuration ]

--- a/providers/aws/components/spa/state.ftl
+++ b/providers/aws/components/spa/state.ftl
@@ -5,56 +5,20 @@
     [#local solution = occurrence.Configuration.Solution]
 
     [#local cfId  = formatComponentCFDistributionId(core.Tier, core.Component, occurrence)]
-    [#local cfName = formatComponentCFDistributionName(core.Tier, core.Component, occurrence)]
-
-    [#if isPresent(solution.Certificate) ]
-        [#local certificateObject = getCertificateObject(solution.Certificate!"", segmentQualifiers) ]
-        [#local hostName = getHostName(certificateObject, occurrence) ]
-        [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
-        [#local fqdn = formatDomainName(hostName, primaryDomainObject)]
-
-    [#else]
-            [#local fqdn = getExistingReference(cfId,DNS_ATTRIBUTE_TYPE)]
-    [/#if]
-
-    [#local pathResources = {}]
-    [#list solution.CloudFront.Paths as id,path ]
-        [#local pathResources += {
-            id : {
-                "cforigin" : {
-                    "Id" : id,
-                    "Type" : AWS_CLOUDFRONT_ORIGIN_RESOURCE_TYPE
-                }
-            }
-        }]
-    [/#list]
 
     [#assign componentState =
         {
-            "Resources" : {
-                "cf" : {
-                    "Id" : cfId,
-                    "Name" : cfName,
-                    "Type" : AWS_CLOUDFRONT_DISTRIBUTION_RESOURCE_TYPE
-                },
-                "cforiginspa" : {
-                    "Id" : "spa",
-                    "Type" : AWS_CLOUDFRONT_ORIGIN_RESOURCE_TYPE
-                },
-                "cforiginconfig" : {
-                    "Id" : "config",
-                    "Type" : AWS_CLOUDFRONT_ORIGIN_RESOURCE_TYPE
-                },
-                "wafacl" : {
-                    "Id" : formatDependentWAFAclId(cfId),
-                    "Name" : formatComponentWAFAclName(core.Tier, core.Component, occurrence),
-                    "Type" : AWS_WAF_ACL_RESOURCE_TYPE
-                }
-            } +
-            attributeIfContent( "paths", pathResources ),
+            "Resources" : {} + 
+                getExistingReference(cfId)?has_content?then(
+                    {
+                        "legacyCF" : {
+                            "Id" : cfId,
+                            "Type" : AWS_CLOUDFRONT_DISTRIBUTION_RESOURCE_TYPE
+                        }
+                    },
+                    {}
+            ),
             "Attributes" : {
-                "FQDN" : fqdn,
-                "URL" : "https://" + fqdn
             },
             "Roles" : {
                 "Inbound" : {},
@@ -63,4 +27,3 @@
         }
     ]
 [/#macro]
-

--- a/providers/aws/components/spa/state.ftl
+++ b/providers/aws/components/spa/state.ftl
@@ -8,15 +8,21 @@
 
     [#assign componentState =
         {
-            "Resources" : {} + 
-                getExistingReference(cfId)?has_content?then(
-                    {
-                        "legacyCF" : {
-                            "Id" : cfId,
-                            "Type" : AWS_CLOUDFRONT_DISTRIBUTION_RESOURCE_TYPE
-                        }
-                    },
-                    {}
+            "Resources" : {
+                "site" :{
+                    "Id" : formatResourceId( SPA_COMPONENT_TYPE, core.Id ),
+                    "Deployed" : true,
+                    "Type" : SPA_COMPONENT_TYPE
+                }
+            } + 
+            getExistingReference(cfId, "", "", deploymentUnit)?has_content?then(
+                {
+                    "legacyCF" : {
+                        "Id" : cfId,
+                        "Type" : AWS_CLOUDFRONT_DISTRIBUTION_RESOURCE_TYPE
+                    }
+                },
+                {}
             ),
             "Attributes" : {
             },

--- a/providers/aws/masterData.ftl
+++ b/providers/aws/masterData.ftl
@@ -1080,8 +1080,7 @@
           "MultiAZ": true,
           "network": {
             "RouteTables": {
-              "internal": {
-              },
+              "internal": {},
               "external": {
                 "Public": true
               }
@@ -2112,6 +2111,11 @@
         "WAFValueSet": "default"
       },
       "spa": {
+        "HTTPSProfile": "TLSv1",
+        "WAFProfile": "OWASP2017",
+        "WAFValueSet": "default"
+      },
+      "cdn": {
         "HTTPSProfile": "TLSv1",
         "WAFProfile": "OWASP2017",
         "WAFValueSet": "default"

--- a/providers/aws/masterData.ftl
+++ b/providers/aws/masterData.ftl
@@ -1291,7 +1291,7 @@
         "Processor": "cache.t2.micro",
         "CountPerZone": 1
       },
-      "RDS": {
+      "db": {
         "Processor": "db.t2.small"
       },
       "ElasticSearch": {

--- a/providers/aws/masterData.json
+++ b/providers/aws/masterData.json
@@ -1287,7 +1287,7 @@
         "Processor": "cache.t2.micro",
         "CountPerZone": 1
       },
-      "RDS": {
+      "db": {
         "Processor": "db.t2.small"
       },
       "ElasticSearch": {

--- a/providers/aws/masterData.json
+++ b/providers/aws/masterData.json
@@ -1076,8 +1076,7 @@
           "MultiAZ": true,
           "network": {
             "RouteTables": {
-              "internal": {
-              },
+              "internal": {},
               "external": {
                 "Public": true
               }
@@ -2108,6 +2107,11 @@
         "WAFValueSet": "default"
       },
       "spa": {
+        "HTTPSProfile": "TLSv1",
+        "WAFProfile": "OWASP2017",
+        "WAFValueSet": "default"
+      },
+      "cdn": {
         "HTTPSProfile": "TLSv1",
         "WAFProfile": "OWASP2017",
         "WAFValueSet": "default"

--- a/providers/aws/services/cf/resource.ftl
+++ b/providers/aws/services/cf/resource.ftl
@@ -38,6 +38,20 @@
     ]
 [/#function]
 
+[#function getCFOriginPath path ]
+    [#return path?ensure_starts_with("/")?remove_ending("/") ]
+[/#function]
+
+[#function getCFBehaviourPath path ]
+    [#if path?has_content ]
+        [#local path = path?ensure_starts_with("/") ]
+        [#if path?ends_with("/") && path != "/" ]
+            [#local path += "*" ]
+        [/#if]
+    [/#if]
+    [#return path ]
+[/#function]
+
 [#function getCFS3Origin id bucket
             accessId
             path=""
@@ -52,7 +66,7 @@
                 }
             } +
             attributeIfContent("OriginCustomHeaders", asArray(headers)) +
-            attributeIfContent("OriginPath", path)
+            attributeIfContent("OriginPath", getCFOriginPath(path) )
         ]
     ]
 [/#function]
@@ -73,7 +87,7 @@
                 "CustomOriginConfig" : httpConfig
             } +
             attributeIfContent("OriginCustomHeaders", asArray(headers)) +
-            attributeIfContent("OriginPath", path)
+            attributeIfContent("OriginPath", getCFOriginPath(path))
         ]
     ]
 [/#function]
@@ -118,7 +132,7 @@
                 "TargetOriginId" : asString(origin, "Id"),
                 "ViewerProtocolPolicy" : viewerProtocolPolicy
             } +
-            attributeIfContent("PathPattern", path) +
+            attributeIfContent("PathPattern", getCFBehaviourPath(path)) +
             attributeIfContent("AllowedMethods", methods.Allowed![], asArray(methods.Allowed![])) +
             attributeIfContent("CachedMethods", methods.Cached![], asArray(methods.Cached![])) +
             attributeIfContent("DefaultTTL", (ttl.Default)!"") +

--- a/providers/aws/services/cf/resource.ftl
+++ b/providers/aws/services/cf/resource.ftl
@@ -132,7 +132,7 @@
                 "TargetOriginId" : asString(origin, "Id"),
                 "ViewerProtocolPolicy" : viewerProtocolPolicy
             } +
-            attributeIfContent("PathPattern", getCFBehaviourPath(path)) +
+            attributeIfContent("PathPattern", path ) +
             attributeIfContent("AllowedMethods", methods.Allowed![], asArray(methods.Allowed![])) +
             attributeIfContent("CachedMethods", methods.Cached![], asArray(methods.Cached![])) +
             attributeIfContent("DefaultTTL", (ttl.Default)!"") +

--- a/providers/shared/components/cdn/id.ftl
+++ b/providers/shared/components/cdn/id.ftl
@@ -1,0 +1,182 @@
+[#ftl]
+
+[@addComponent
+    type=CDN_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A content distribution network which provides caching and global distribution of content"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : ["Fragment", "Container"],
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            },
+            {
+                "Names" : "Links",
+                "Type" : OBJECT_TYPE,
+                "Default" : {}
+            },
+            {
+                "Names" : "WAF",
+                "Children" : wafChildConfiguration
+            },
+            {
+                "Names" : "Pages",
+                "Children" : [
+                    {
+                        "Names" : "Root",
+                        "Type" : STRING_TYPE,
+                        "Default" : "index.html"
+                    }
+                    {
+                        "Names" : "Error",
+                        "Type" : STRING_TYPE,
+                        "Default" : "/index.html"
+                    },
+                    {
+                        "Names" : "Denied",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "NotFound",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    }
+                ]
+            },
+            {
+                "Names" : "EnableLogging",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "CountryGroups",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            },
+            {
+                "Names" : "RedirectAliases",
+                "Description" : "Redirect secondary domains to the primary domain name",
+                "Children" : [
+                    {
+                        "Names" : "RedirectVersion",
+                        "Type" : STRING_TYPE,
+                        "Default" : "v1"
+                    }
+                ]
+            },
+            {
+                "Names" : "EventHandlers",
+                "Description" : "Attach a function to a stage in the Cloudfront Processing",
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Tier",
+                        "Type" : STRING_TYPE,
+                        "Mandatory" : true
+                    },
+                    {
+                        "Names" : "Component",
+                        "Type" : STRING_TYPE,
+                        "Mandatory" : true
+                    },
+                    {
+                        "Names" : "Function",
+                        "Type" : STRING_TYPE,
+                        "Mandatory" : true
+                    },
+                    {
+                        "Names" : "Instance",
+                        "Type" : STRING_TYPE
+                    },
+                    {
+                        "Names" : "Version",
+                        "Type" : STRING_TYPE
+                    },
+                    {
+                        "Names" : "Action",
+                        "Type" : STRING_TYPE,
+                        "Values" : [ "viewer-request", "viewer-response", "origin-request", "origin-response" ],
+                        "Mandatory" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "Certificate",
+                "Children" : certificateChildConfiguration
+            },
+            {
+                "Names" : "AssumeSNI",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : [
+                    {
+                        "Names" : "Security",
+                        "Type" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
+            }
+        ]
+/]
+
+
+                    {
+                        "Names" : "Paths",
+                        "Subobjects" : true,
+                        "Description" : "Additional path based routes to other components",
+                        "Children" : [
+                            {
+                                "Names" : "PathPattern",
+                                "Type" : STRING_TYPE,
+                                "Mandatory" : true
+                            },
+                            {
+                                "Names" : "Link",
+                                "Children" : linkChildrenConfiguration,
+                                "Mandatory" : true
+                            },
+                            {
+                                "Names" : "CachingTTL",
+                                "Children" : [
+                                    {
+                                        "Names" : "Default",
+                                        "Type" : NUMBER_TYPE,
+                                        "Default" : 600
+                                    },
+                                    {
+                                        "Names" : "Maximum",
+                                        "Type" : NUMBER_TYPE,
+                                        "Default" : 31536000
+                                    },
+                                    {
+                                        "Names" : "Minimum",
+                                        "Type" : NUMBER_TYPE,
+                                        "Default" : 0
+                                    }
+                                ]
+                            },
+                            {
+                                "Names" : "Compress",
+                                "Type" : BOOLEAN_TYPE,
+                                "Default" : false
+                            }
+                        ]
+                    }

--- a/providers/shared/components/cdn/id.ftl
+++ b/providers/shared/components/cdn/id.ftl
@@ -26,8 +26,8 @@
             },
             {
                 "Names" : "Links",
-                "Type" : OBJECT_TYPE,
-                "Default" : {}
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
             },
             {
                 "Names" : "WAF",
@@ -69,53 +69,6 @@
                 "Default" : []
             },
             {
-                "Names" : "RedirectAliases",
-                "Description" : "Redirect secondary domains to the primary domain name",
-                "Children" : [
-                    {
-                        "Names" : "RedirectVersion",
-                        "Type" : STRING_TYPE,
-                        "Default" : "v1"
-                    }
-                ]
-            },
-            {
-                "Names" : "EventHandlers",
-                "Description" : "Attach a function to a stage in the Cloudfront Processing",
-                "Subobjects" : true,
-                "Children" : [
-                    {
-                        "Names" : "Tier",
-                        "Type" : STRING_TYPE,
-                        "Mandatory" : true
-                    },
-                    {
-                        "Names" : "Component",
-                        "Type" : STRING_TYPE,
-                        "Mandatory" : true
-                    },
-                    {
-                        "Names" : "Function",
-                        "Type" : STRING_TYPE,
-                        "Mandatory" : true
-                    },
-                    {
-                        "Names" : "Instance",
-                        "Type" : STRING_TYPE
-                    },
-                    {
-                        "Names" : "Version",
-                        "Type" : STRING_TYPE
-                    },
-                    {
-                        "Names" : "Action",
-                        "Type" : STRING_TYPE,
-                        "Values" : [ "viewer-request", "viewer-response", "origin-request", "origin-response" ],
-                        "Mandatory" : true
-                    }
-                ]
-            },
-            {
                 "Names" : "Certificate",
                 "Children" : certificateChildConfiguration
             },
@@ -138,45 +91,130 @@
 /]
 
 
-                    {
-                        "Names" : "Paths",
-                        "Subobjects" : true,
-                        "Description" : "Additional path based routes to other components",
-                        "Children" : [
-                            {
-                                "Names" : "PathPattern",
-                                "Type" : STRING_TYPE,
-                                "Mandatory" : true
-                            },
-                            {
-                                "Names" : "Link",
-                                "Children" : linkChildrenConfiguration,
-                                "Mandatory" : true
-                            },
-                            {
-                                "Names" : "CachingTTL",
-                                "Children" : [
-                                    {
-                                        "Names" : "Default",
-                                        "Type" : NUMBER_TYPE,
-                                        "Default" : 600
-                                    },
-                                    {
-                                        "Names" : "Maximum",
-                                        "Type" : NUMBER_TYPE,
-                                        "Default" : 31536000
-                                    },
-                                    {
-                                        "Names" : "Minimum",
-                                        "Type" : NUMBER_TYPE,
-                                        "Default" : 0
-                                    }
-                                ]
-                            },
-                            {
-                                "Names" : "Compress",
-                                "Type" : BOOLEAN_TYPE,
-                                "Default" : false
-                            }
-                        ]
-                    }
+[@addChildComponent
+    type=CDN_ROUTE_COMPONENT_TYPE
+    parent=CDN_COMPONENT_TYPE
+    childAttribute="Routes"
+    linkAttributes="Route"
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A path based route on the CDN instance"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "PathPattern",
+            "Description" : "The path based pattern to match for this route to apply",
+            "Type" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "Origin",
+            "Children" : [
+                {
+                    "Names" : "BasePath",
+                    "Description" : "The base path at the origin destination",
+                    "Type" : STRING_TYPE,
+                    "Default" : ""
+                },
+                {
+                    "Names" : "Link",
+                    "Children" : linkChildrenConfiguration,
+                    "Mandatory" : true
+                }
+            ]
+        },
+        {
+            "Names" : "CachingTTL",
+            "Children" : [
+                {
+                    "Names" : "Default",
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 600
+                },
+                {
+                    "Names" : "Maximum",
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 31536000
+                },
+                {
+                    "Names" : "Minimum",
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 0
+                }
+            ]
+        },
+        {
+            "Names" : "Compress",
+            "Type" : BOOLEAN_TYPE,
+            "Default" : false
+        },
+        {
+            "Names" : "InvalidateOnUpdate",
+            "Type" : BOOLEAN_TYPE,
+            "Default" : true
+        }
+        {
+            "Names" : "RedirectAliases",
+            "Description" : "Redirect secondary domains to the primary domain name",
+            "Children" : [
+                {
+                    "Names" : "Enabled",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : true
+                }
+                {
+                    "Names" : "RedirectVersion",
+                    "Type" : STRING_TYPE,
+                    "Default" : "v1"
+                }
+            ]
+        },
+        {
+            "Names" : "EventHandlers",
+            "Description" : "Attach a function to a stage in the Cloudfront Processing",
+            "Subobjects" : true,
+            "Children" : [
+                {
+                    "Names" : "Tier",
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
+                },
+                {
+                    "Names" : "Component",
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
+                },
+                {
+                    "Names" : "Function",
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
+                },
+                {
+                    "Names" : "Instance",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Names" : "Version",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Names" : "Action",
+                    "Type" : STRING_TYPE,
+                    "Values" : [ "viewer-request", "viewer-response", "origin-request", "origin-response" ],
+                    "Mandatory" : true
+                }
+            ]
+        }
+    ]
+/]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -182,7 +182,11 @@
         {
             "Names" : [ "Assignment" ],
             "Type" : STRING_TYPE
-        }
+        },
+        {
+            "Names" : [ "Route" ],
+            "Type"  : STRING_TYPE
+        },
         {
             "Names" : "Instance",
             "Type" : STRING_TYPE

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -14,6 +14,9 @@
 
 [#assign CACHE_COMPONENT_TYPE = "cache" ]
 
+[#assign CDN_COMPONENT_TYPE = "cdn"]
+[#assign CDN_ROUTE_COMPONENT_TYPE = "cdnroute" ]
+
 [#assign COMPUTECLUSTER_COMPONENT_TYPE = "computecluster"]
 
 [#assign CONFIGSTORE_COMPONENT_TYPE = "configstore" ]

--- a/providers/shared/components/spa/id.ftl
+++ b/providers/shared/components/spa/id.ftl
@@ -6,7 +6,7 @@
         [
             {
                 "Type"  : "Description",
-                "Value" : "Object stored hosted web application with content distribution management"
+                "Value" : "A statically hosted web application"
             },
             {
                 "Type" : "Providers",
@@ -30,171 +30,10 @@
                 "Children" : linkChildrenConfiguration
             },
             {
-                "Names" : "WAF",
-                "Children" : wafChildConfiguration
-            },
-            {
-                "Names" : "CloudFront",
-                "Children" : [
-                    {
-                        "Names" : "AssumeSNI",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Names" : "EnableLogging",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Names" : "CountryGroups",
-                        "Type" : ARRAY_OF_STRING_TYPE,
-                        "Default" : []
-                    },
-                    {
-                        "Names" : "ErrorPage",
-                        "Type" : STRING_TYPE,
-                        "Default" : "/index.html"
-                    },
-                    {
-                        "Names" : "DeniedPage",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
-                    },
-                    {
-                        "Names" : "NotFoundPage",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
-                    },
-                    {
-                        "Names" : "CachingTTL",
-                        "Children" : [
-                            {
-                                "Names" : "Default",
-                                "Type" : NUMBER_TYPE,
-                                "Default" : 600
-                            },
-                            {
-                                "Names" : "Maximum",
-                                "Type" : NUMBER_TYPE,
-                                "Default" : 31536000
-                            },
-                            {
-                                "Names" : "Minimum",
-                                "Type" : NUMBER_TYPE,
-                                "Default" : 0
-                            }
-                        ]
-                    },
-                    {
-                        "Names" : "Compress",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : true
-                    },
-                    {
-                        "Names" : "RedirectAliases",
-                        "Description" : "Redirect secondary domains to the primary domain name",
-                        "Children" : [
-                            {
-                                "Names" : "RedirectVersion",
-                                "Type" : STRING_TYPE,
-                                "Default" : "v1"
-                            }
-                        ]
-                    },
-                    {
-                        "Names" : "EventHandlers",
-                        "Description" : "Attach a function to a stage in the Cloudfront Processing",
-                        "Subobjects" : true,
-                        "Children" : [
-                            {
-                                "Names" : "Tier",
-                                "Type" : STRING_TYPE,
-                                "Mandatory" : true
-                            },
-                            {
-                                "Names" : "Component",
-                                "Type" : STRING_TYPE,
-                                "Mandatory" : true
-                            },
-                            {
-                                "Names" : "Function",
-                                "Type" : STRING_TYPE,
-                                "Mandatory" : true
-                            },
-                            {
-                                "Names" : "Instance",
-                                "Type" : STRING_TYPE
-                            },
-                            {
-                                "Names" : "Version",
-                                "Type" : STRING_TYPE
-                            },
-                            {
-                                "Names" : "Action",
-                                "Type" : STRING_TYPE,
-                                "Values" : [ "viewer-request", "viewer-response", "origin-request", "origin-response" ],
-                                "Mandatory" : true
-                            }
-                        ]
-                    },
-                    {
-                        "Names" : "Paths",
-                        "Subobjects" : true,
-                        "Description" : "Additional path based routes to other components",
-                        "Children" : [
-                            {
-                                "Names" : "PathPattern",
-                                "Type" : STRING_TYPE,
-                                "Mandatory" : true
-                            },
-                            {
-                                "Names" : "Link",
-                                "Children" : linkChildrenConfiguration,
-                                "Mandatory" : true
-                            },
-                            {
-                                "Names" : "CachingTTL",
-                                "Children" : [
-                                    {
-                                        "Names" : "Default",
-                                        "Type" : NUMBER_TYPE,
-                                        "Default" : 600
-                                    },
-                                    {
-                                        "Names" : "Maximum",
-                                        "Type" : NUMBER_TYPE,
-                                        "Default" : 31536000
-                                    },
-                                    {
-                                        "Names" : "Minimum",
-                                        "Type" : NUMBER_TYPE,
-                                        "Default" : 0
-                                    }
-                                ]
-                            },
-                            {
-                                "Names" : "Compress",
-                                "Type" : BOOLEAN_TYPE,
-                                "Default" : false
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "Names" : "Certificate",
-                "Children" : certificateChildConfiguration
-            },
-            {
-                "Names" : "Profiles",
-                "Children" : [
-                    {
-                        "Names" : "Security",
-                        "Type" : STRING_TYPE,
-                        "Default" : "default"
-                    }
-                ]
+                "Names" : "InvalidateOnUpdate",
+                "Description" : "Invalidate all CDNs that host this content",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
             }
         ]
 /]


### PR DESCRIPTION
This PR adds support for a dedicated CDN solution level component and replaces the existing solution level SPA CDN deployment

A CDN component can be used by multiple HTTP based services to provide content distribution services and can also be used for routing between different origins while maintaining a consistent client facing endpoint 

The component itself manages the default configuration for the disribution, certificates, default error responses, default document etc 

A route subcomponent provides the link between the distribution and the origin. Multiple routes can be configured with each route having its own PathPattern applied. 

Example of the Solution Configuration 

```
        "web" : {
            "Components" : {
                "catalog-cdn" : {
                    "cdn" : {
                        "Instances" : {
                            "default" : {
                                "DeploymentUnits" : [ "catalog-cdn"]
                            }
                        },
                        "Certificate" : {
                            "IncludeInHost" : {
                                "Component": false,
                                "Host" : true
                            },
                            "Host" : "data"
                        },
                        "Routes" : {
                            "default" : {
                                "PathPattern" : "_default",
                                "Origin" : {
                                    "BasePath" : "public/",
                                    "Link" : {
                                        "Tier" : "web",
                                        "Component" : "catalog"
                                    }
                                }
                            }
                        }
                    }
                },
                "catalog" : {
                    "s3" : {
                        "Instances" : {
                            "default" : {
                                "DeploymentUnits" : [ "catalog"]
                            } 
                        },
                        "Links" : {
                            "cdn" : {
                                "Tier" : "web",
                                "Component" : "catalog-cdn",
                                "Route" : "default",
                                "Direction" : "inbound"
                            }
                        }
                    }
                }
            }
        },
``` 

This is an S3 Backed CDN which can be used for serving content which isn't specifically generated by a code build. 

The CDN has a single route called `default` which uses a path pattern of `_default` this means that for all requests that don't match another path pattern use this one 

The Origin.BasePath property allows you to specify where requests will be sent to in the S3 bucket 

The catalog s3 bucket also needs an inbound link to the CDN in order to enable OAI based access to the bukcet. This link also uses the Origin.BasePath paramter to specify the bucket permissions 

SPA application components must have at least one inbound link to a CDNRoute and the linking CDN should have a link to the SPA.

For an SPA this allows it to invalidate the cache for the data that it provides to the CDN 

