### PR TITLE
<refactor> Use occurrence to determine baseline links

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -395,7 +395,7 @@
         occurrence.Configuration.Environment.General +
         occurrence.Configuration.Environment.Build +
         occurrence.Configuration.Environment.Sensitive +
-        getDefaultLinkVariables(links, true) + 
+        getDefaultLinkVariables(links, true) +
         getDefaultBaselineVariables(baselineLinks)
     ]
 [/#function]
@@ -479,7 +479,7 @@
     [#local solution = task.Configuration.Solution ]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption" ] )]
+    [#local baselineLinks = getBaselineLinks(task, [ "OpsData", "AppData", "Encryption" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]

--- a/providers/aws/components/apigateway/setup.ftl
+++ b/providers/aws/components/apigateway/setup.ftl
@@ -34,7 +34,7 @@
                                                 swaggerFileName)]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
@@ -547,7 +547,7 @@
     [/#list]
 
     [#-- Send API Specification to an external publisher --]
-     
+
     [#if solution.Publishers?has_content ]
         [#if deploymentSubsetRequired("epilogue", false ) ]
             [@addToDefaultBashScriptOutput
@@ -579,7 +579,7 @@
             [#else]
                 [#local fileName = "swagger.json" ]
             [/#if]
-            
+
             [#list publisherLinks as publisherLinkId, publisherLinkTarget ]
                 [#local publisherLinkTargetCore = publisherLinkTarget.Core ]
                 [#local publisherLinkTargetAttributes = publisherLinkTarget.State.Attributes ]

--- a/providers/aws/components/baseline/setup.ftl
+++ b/providers/aws/components/baseline/setup.ftl
@@ -51,10 +51,10 @@
     [/#if]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "Encryption" ], false, false )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption" ], false, false )]
 
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
-    
+
     [#local cmkKeyId = baselineComponentIds["Encryption" ]]
 
     [@debug message={ "KeyId" : cmkKeyId } enabled=true /]
@@ -90,7 +90,7 @@
                 [#local legacyOAIId = formatDependentCFAccessId(bucketId)]
                 [#local legacyOAI =  getExistingReference(legacyOAIId, CANONICAL_ID_ATTRIBUTE_TYPE) ]
 
-                [#if legacyOAI?has_content] 
+                [#if legacyOAI?has_content]
                     [#local cfAccessCanonicalIds += [ legacyOAI ]]
                 [/#if]
 
@@ -141,7 +141,7 @@
                                                 formatS3NotificationPolicyId(
                                                     bucketId,
                                                     resourceId) ]
-                                            
+
                                             [#local bucketDependencies += [policyId] ]
 
                                             [#if deploymentSubsetRequired("s3", true)]
@@ -162,7 +162,7 @@
                                                 formatS3NotificationPolicyId(
                                                     bucketId,
                                                     resourceId) ]
-                                                    
+
                                             [#local bucketDependencies += [ policyId ]]
 
                                             [#if deploymentSubsetRequired("s3", true )]
@@ -175,8 +175,8 @@
                                     [/#switch]
 
                                     [#list notification.Events as event ]
-                                        [#local notifications += 
-                                                getS3Notification(resourceId, resourceType, event, notification.Prefix, notification.Suffix) ]     
+                                        [#local notifications +=
+                                                getS3Notification(resourceId, resourceType, event, notification.Prefix, notification.Suffix) ]
                                     [/#list]
                                 [/#if]
                             [/#if]
@@ -371,11 +371,11 @@
                                 "  #"
                             ] +
                             pseudoStackOutputScript(
-                                "SSH Key Pair", 
-                                { 
-                                    ec2KeyPairId : "$\{key_pair_name}", 
+                                "SSH Key Pair",
+                                {
+                                    ec2KeyPairId : "$\{key_pair_name}",
                                     formatId(ec2KeyPairId, "name") : "$\{key_pair_name}"
-                                }, 
+                                },
                                 "keypair"
                             ) +
                             valueIfTrue(

--- a/providers/aws/components/bastion/setup.ftl
+++ b/providers/aws/components/bastion/setup.ftl
@@ -30,7 +30,7 @@
     [#local sshInVpc = getExistingReference(bastionSecurityGroupFromId, "", "", "vpc")?has_content ]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]

--- a/providers/aws/components/computecluster/setup.ftl
+++ b/providers/aws/components/computecluster/setup.ftl
@@ -30,7 +30,7 @@
     [#local bootstrapProfile = getBootstrapProfile(occurrence, "ComputeCluster")]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]

--- a/providers/aws/components/configstore/setup.ftl
+++ b/providers/aws/components/configstore/setup.ftl
@@ -16,7 +16,7 @@
     [#local tableSortKey = parentResources["table"].SortKey!"" ]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]

--- a/providers/aws/components/datafeed/setup.ftl
+++ b/providers/aws/components/datafeed/setup.ftl
@@ -33,7 +33,7 @@
     [#local streamProcessors = []]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "AppData", "Encryption"] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "AppData", "Encryption"] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#local dataBucketId        = baselineComponentIds["AppData"]]

--- a/providers/aws/components/datapipeline/setup.ftl
+++ b/providers/aws/components/datapipeline/setup.ftl
@@ -29,7 +29,7 @@
     [#local emrProcessorProfile = getProcessor(occurrence, "EMR")]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]

--- a/providers/aws/components/datavolume/setup.ftl
+++ b/providers/aws/components/datavolume/setup.ftl
@@ -16,7 +16,7 @@
 
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "Encryption"] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption"] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#local cmkKeyId = baselineComponentIds["Encryption" ]]

--- a/providers/aws/components/db/setup.ftl
+++ b/providers/aws/components/db/setup.ftl
@@ -16,7 +16,7 @@
     [#local attributes = occurrence.State.Attributes ]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local cmkKeyId = baselineComponentIds["Encryption"] ]
     [#local cmkKeyArn = getReference(cmkKeyId, ARN_ATTRIBUTE_TYPE)]

--- a/providers/aws/components/ec2/setup.ftl
+++ b/providers/aws/components/ec2/setup.ftl
@@ -29,7 +29,7 @@
     [#local bootstrapProfile       = getBootstrapProfile(occurrence, "EC2")]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]

--- a/providers/aws/components/ecs/setup.ftl
+++ b/providers/aws/components/ecs/setup.ftl
@@ -34,7 +34,7 @@
     [#local bootstrapProfile = getBootstrapProfile(occurrence, "ECS")]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]

--- a/providers/aws/components/efs/setup.ftl
+++ b/providers/aws/components/efs/setup.ftl
@@ -38,7 +38,7 @@
                                             efsPort)]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "Encryption"] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption"] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local cmkKeyId = baselineComponentIds["Encryption" ]]
 

--- a/providers/aws/components/es/setup.ftl
+++ b/providers/aws/components/es/setup.ftl
@@ -20,7 +20,7 @@
     [#local master = processorProfile.Master!{}]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local cmkKeyId = baselineComponentIds["Encryption"] ]
 

--- a/providers/aws/components/federatedrole/setup.ftl
+++ b/providers/aws/components/federatedrole/setup.ftl
@@ -48,7 +48,7 @@
             [#switch linkTargetCore.Type]
                 [#case USERPOOL_CLIENT_COMPONENT_TYPE ]
                 [#case USERPOOL_COMPONENT_TYPE ]
-                    
+
                     [#local userPoolName = linkTargetAttributes["USER_POOL_NAME"] ]
                     [#local userPoolClient = linkTargetAttributes["CLIENT"] ]
 
@@ -84,7 +84,7 @@
     [#local unauthenticatedRole = ""]
     [#local ruleAssignments = {} ]
 
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#list occurrence.Occurrences![] as subOccurrence]
@@ -258,7 +258,7 @@
     [/#if]
 
     [#if ! authenticatedRole?has_content ]
-        [@fatal 
+        [@fatal
             message="A default Authenticated Rule Assigment must be provided"
             context=solution
         /]

--- a/providers/aws/components/lambda/setup.ftl
+++ b/providers/aws/components/lambda/setup.ftl
@@ -24,7 +24,7 @@
         [#local fnLgName = resources["lg"].Name ]
 
         [#-- Baseline component lookup --]
-        [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption" ] )]
+        [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption" ] )]
         [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
         [#local cmkKeyId = baselineComponentIds["Encryption" ]]

--- a/providers/aws/components/lb/setup.ftl
+++ b/providers/aws/components/lb/setup.ftl
@@ -18,7 +18,7 @@
     [#local lbSecurityGroupIds = [] ]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
 

--- a/providers/aws/components/mobileapp/setup.ftl
+++ b/providers/aws/components/mobileapp/setup.ftl
@@ -13,7 +13,7 @@
     [#local attributes = occurrence.State.Attributes ]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
@@ -29,18 +29,18 @@
                                     getOccurrenceBuildUnit(occurrence),
                                     getOccurrenceBuildReference(occurrence))]
 
-    [#local buildConfig = 
+    [#local buildConfig =
         {
-            "RUN_ID"            : runId, 
+            "RUN_ID"            : runId,
             "CODE_SRC_BUCKET"   : codeSrcBucket,
             "CODE_SRC_PREFIX"   : codeSrcPrefix,
             "APP_BUILD_FORMATS" : solution.BuildFormats?join(","),
             "BUILD_REFERENCE"   : getOccurrenceBuildReference(occurrence)
-        } + 
+        } +
         attributes +
         defaultEnvironment(occurrence, {}, baselineLinks)
     ]
-    
+
     [#local fragment = getOccurrenceFragmentBase(occurrence) ]
 
     [#local contextLinks = getLinkTargets(occurrence) ]
@@ -66,22 +66,22 @@
     [#include fragmentList?ensure_starts_with("/")]
 
     [#local finalEnvironment = getFinalEnvironment(
-            occurrence, 
+            occurrence,
             _context,
-            { 
-                "Json" : { 
-                    "Include" : { 
-                        "Sensitive" : false 
+            {
+                "Json" : {
+                    "Include" : {
+                        "Sensitive" : false
                     }
                 }
             }
     )]
-    
+
     [#if deploymentSubsetRequired("config", false)]
-        [@addToDefaultJsonOutput 
+        [@addToDefaultJsonOutput
             content={
                 "BuildConfig" : buildConfig,
-                "AppConfig" : finalEnvironment.Environment 
+                "AppConfig" : finalEnvironment.Environment
             }
         /]
     [/#if]

--- a/providers/aws/components/mobileapp/state.ftl
+++ b/providers/aws/components/mobileapp/state.ftl
@@ -13,18 +13,18 @@
     [#local otaPrefix = ""]
     [#local otaURL = ""]
 
-    [#local releaseChannel = 
+    [#local releaseChannel =
         getOccurrenceSettingValue(occurrence, "RELEASE_CHANNEL", true)?has_content?then(
                 getOccurrenceSettingValue(occurrence, "RELEASE_CHANNEL", true),
                 environmentName
             )
     ]
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
-    
+
     [#local configFilePath = formatRelativePath(
                                 getOccurrenceSettingValue(occurrence, "SETTINGS_PREFIX"),
                                 "config" )]

--- a/providers/aws/components/spa/setup.ftl
+++ b/providers/aws/components/spa/setup.ftl
@@ -14,7 +14,7 @@
     [#local fragment = getOccurrenceFragmentBase(occurrence) ]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "CDNOriginKey", "OpsData", "AppData" ])]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "CDNOriginKey", "OpsData", "AppData" ])]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local cfAccess         = getExistingReference(baselineComponentIds["CDNOriginKey"]!"") ]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]!"") ]
@@ -350,7 +350,7 @@
 
     [#local fragment = getOccurrenceFragmentBase(occurrence) ]
 
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData"] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData"] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]

--- a/providers/aws/components/topic/setup.ftl
+++ b/providers/aws/components/topic/setup.ftl
@@ -15,14 +15,14 @@
     [#local topicName = resources["topic"].Name ]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "Encryption" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local cmkKeyId = baselineComponentIds["Encryption"] ]
 
     [#if deploymentSubsetRequired(TOPIC_COMPONENT_TYPE, true)]
-        [@createSNSTopic 
-            id=topicId 
-            name=topicName 
+        [@createSNSTopic
+            id=topicId
+            name=topicName
             encrypted=solution.Encrypted
             kmsKeyId=cmkKeyId
             fixedName=solution.FixedName
@@ -70,7 +70,7 @@
         [#local core = subOccurrence.Core ]
         [#local solution = subOccurrence.Configuration.Solution ]
         [#local resources = subOccurrence.State.Resources ]
-        
+
         [#switch core.Type]
 
             [#case TOPIC_SUBSCRIPTION_COMPONENT_TYPE  ]
@@ -79,7 +79,7 @@
                 [#local links = solution.Links ]
 
                 [#list links as linkId,link]
-                
+
                     [#local linkTarget = getLinkTarget(occurrence, link) ]
 
                     [@debug message="Link Target" context=linkTarget enabled=false /]
@@ -95,7 +95,7 @@
 
                     [#local endpoint = ""]
                     [#local deliveryPolicy = {}]
-                    
+
                     [#switch linkTargetCore.Type ]
                         [#case "external" ]
                             [#local endpoint = linkTargetAttributes["SUBSCRIPTION_ENDPOINT"] ]
@@ -118,7 +118,7 @@
                             detail="Could not determine protocol and endpoint for link"
                         /]
                     [/#if]
-                    
+
 
                     [#switch protocol ]
                         [#case "http"]
@@ -128,15 +128,15 @@
                     [/#switch]
 
                     [#if deploymentSubsetRequired(TOPIC_COMPONENT_TYPE, true)]
-                        [@createSNSSubscription 
+                        [@createSNSSubscription
                             id=formatId(subscriptionId, link.Id)
-                            topicId=topicId 
+                            topicId=topicId
                             endpoint=endpoint
                             protocol=protocol
-                            rawMessageDelivery=solution.RawMessageDelivery 
+                            rawMessageDelivery=solution.RawMessageDelivery
                             deliveryPolicy=deliveryPolicy
                         /]
-                    [/#if]                    
+                    [/#if]
                 [/#list]
                 [#break]
         [/#switch]

--- a/providers/aws/components/user/setup.ftl
+++ b/providers/aws/components/user/setup.ftl
@@ -17,7 +17,7 @@
     [#local apikeyName = resources["apikey"].Name]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(solution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local cmkKeyId = baselineComponentIds["Encryption"] ]
     [#local cmkKeyArn = getExistingReference(cmkKeyId, ARN_ATTRIBUTE_TYPE)]

--- a/providers/shared/components/baseline/id.ftl
+++ b/providers/shared/components/baseline/id.ftl
@@ -50,8 +50,8 @@
     [#return ids ]
 [/#function]
 
-[#function getBaselineLinks baselineProfileName baselineComponentNames activeOnly=true activeRequired=true  ]
-    [#local baselineProfile = baselineProfiles[baselineProfileName] ]
+[#function getBaselineLinks occurrence baselineComponentNames activeOnly=true activeRequired=true  ]
+    [#local baselineProfile = baselineProfiles[occurrence.Configuration.Solution.Profiles.Baseline] ]
 
     [#local baselineLinkTargets = {} ]
 


### PR DESCRIPTION
Refactor the getBaselineLinks routine to accept an occurrence and use this to determine the baseline profile.

The next step as part of the move to use of the context based model will be to use the occurrence in the call to getLinkTarget, so that the correct baseline is used in the situation of multiple products being
available simultaneously.