### PR TITLE
<fix> base link lookup for ecs components

### DIFF
--- a/providers/aws/components/ecs/setup.ftl
+++ b/providers/aws/components/ecs/setup.ftl
@@ -339,7 +339,7 @@
     [#local ecsServiceRoleId = parentResources["serviceRole"].Id ]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(parentSolution.Profiles.Baseline, [ "OpsData", "AppData", "Encryption" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
 


### PR DESCRIPTION
`getBaselineLinks` function expects a hash, not a string as occurrence parameter 