### PR TITLE
<fix> SPA generate solution level genplan with warning about deprecation

### DIFF
--- a/providers/aws/components/spa/setup.ftl
+++ b/providers/aws/components/spa/setup.ftl
@@ -1,4 +1,19 @@
 [#ftl]
+[#macro aws_spa_cf_solution occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@addDefaultGenerationPlan subsets=["prologue" ] /]
+        [#return]
+    [/#if]
+
+    [#if deploymentSubsetRequired("prologue", false)]
+        [@addToDefaultBashScriptOutput
+            [
+                "warning \"solution level spa components have been deprecated. Please remove this component\""
+            ]
+        /]
+    [/#if]
+[/#macro]
+
 [#macro aws_spa_cf_application occurrence  ]
     [@debug message="Entering" context=occurrence enabled=false /]
 


### PR DESCRIPTION
Adds a basic genplan and prologue script so that the solution level component can be deleted through the stop deployment mode. If no gen plan is found the template generation fails and the component cannot be deleted