### PR TITLE
<fix> Allow resources to be always marked as deployed

### DIFF
--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -169,7 +169,7 @@
                         alias :
                           resource +
                           {
-                              "Deployed" : getExistingReference(resource.Id)?has_content
+                              "Deployed" : (resource.Deployed)!getExistingReference(resource.Id)?has_content
                           }
                     } ]
             [#else]


### PR DESCRIPTION
Allow for resources to have their deployed status defined in their definition. Can be used for forcing some units to be deployed or to use nonstandard logic to determine the state