### PR TITLE
<fix> ECS task parameters in wrong code section

### DIFF
--- a/providers/aws/components/ecs/setup.ftl
+++ b/providers/aws/components/ecs/setup.ftl
@@ -808,16 +808,6 @@
 
                         [#if deploymentSubsetRequired("epilogue", false)]
 
-                            [#local targetParameters = {
-                                "Arn" : getExistingReference(ecsId, ARN_ATTRIBUTE_TYPE),
-                                "Id" : taskId,
-                                "EcsParameters" : {
-                                    "TaskCount" : schedule.TaskCount,
-                                    "TaskDefinitionArn" : getReference(taskId, ARN_ATTRIBUTE_TYPE)
-                                },
-                                "RoleArn" : getReference(scheduleTaskRoleId, ARN_ATTRIBUTE_TYPE)
-                            }]
-
                             [@addToDefaultBashScriptOutput
                                 content=
                                     [
@@ -865,6 +855,16 @@
 
                     [#else]
                         [#if deploymentSubsetRequired("ecs", true) ]
+                            [#local targetParameters = {
+                                "Arn" : getExistingReference(ecsId, ARN_ATTRIBUTE_TYPE),
+                                "Id" : taskId,
+                                "EcsParameters" : {
+                                    "TaskCount" : schedule.TaskCount,
+                                    "TaskDefinitionArn" : getReference(taskId, ARN_ATTRIBUTE_TYPE)
+                                },
+                                "RoleArn" : getReference(scheduleTaskRoleId, ARN_ATTRIBUTE_TYPE)
+                            }]
+
                             [@createScheduleEventRule
                                 id=scheduleRuleId
                                 enabled=scheduleEnabled


### PR DESCRIPTION
Move target parameters for creating an ECS task to the correct location.
Looks like a bug that crept in with fargate support.