### PR TITLE
<fix> userpool don't show error in resources

### DIFF
--- a/providers/aws/components/userpool/setup.ftl
+++ b/providers/aws/components/userpool/setup.ftl
@@ -23,6 +23,14 @@
         [#local userPoolCustomDomainId = resources["customdomain"].Id ]
         [#local userPoolCustomDomainName = resources["customdomain"].Name ]
         [#local userPoolCustomDomainCertArn = resources["customdomain"].CertificateArn]
+
+        [#if ! userPoolCustomDomainCertArn?has_content ]
+            [@fatal 
+                message="ACM Certificate required in us-east-1"
+                context=resources
+                enabled=true
+            /]
+        [/#if]
     [/#if]
 
     [#local smsVerification = false]

--- a/providers/aws/components/userpool/state.ftl
+++ b/providers/aws/components/userpool/state.ftl
@@ -64,10 +64,7 @@
             [#local userPoolCustomBaseUrl = "https://" + userPoolCustomDomainName + "/" ]
 
             [#local certificateId = formatDomainCertificateId(certificateObject, userPoolDomainName)]
-            [#local certificateArn = (getExistingReference(certificateId, ARN_ATTRIBUTE_TYPE, "us-east-1" )?has_content)?then(
-                                            getExistingReference(certificateId, ARN_ATTRIBUTE_TYPE, "us-east-1" ),
-                                            "COTFatal: ACM Certificate required in us-east-1"
-                                    )]
+            [#local certificateArn = getExistingReference(certificateId, ARN_ATTRIBUTE_TYPE, "us-east-1")]
         [/#if]
 
         [#assign componentState =


### PR DESCRIPTION
Showing the COTFatal message in resources causes the blueprint generation to fail. It should only fail during generation 