### PR TITLE
<feature> DB: Major version update support

### DIFF
--- a/providers/aws/components/db/setup.ftl
+++ b/providers/aws/components/db/setup.ftl
@@ -18,9 +18,6 @@
     [#-- Baseline component lookup --]
     [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
-
-    [@debug message="Baseline Ids" context=baselineComponentIds enabled=true /]
-
     [#local cmkKeyId = baselineComponentIds["Encryption"]!"" ]
     [#local cmkKeyArn = getReference(cmkKeyId, ARN_ATTRIBUTE_TYPE)]
 

--- a/providers/aws/components/db/setup.ftl
+++ b/providers/aws/components/db/setup.ftl
@@ -16,9 +16,12 @@
     [#local attributes = occurrence.State.Attributes ]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
-    [#local cmkKeyId = baselineComponentIds["Encryption"] ]
+
+    [@debug message="Baseline Ids" context=baselineComponentIds enabled=true /]
+
+    [#local cmkKeyId = baselineComponentIds["Encryption"]!"" ]
     [#local cmkKeyArn = getReference(cmkKeyId, ARN_ATTRIBUTE_TYPE)]
 
     [#local networkLink = getOccurrenceNetwork(occurrence).Link!{} ]
@@ -38,14 +41,6 @@
     [#local engine = solution.Engine]
     [#switch engine]
         [#case "mysql"]
-            [#local engineVersion =
-                valueIfContent(
-                    solution.EngineVersion!"",
-                    solution.EngineVersion!"",
-                    "5.6"
-                )
-            ]
-            [#local family = "mysql" + engineVersion]
             [#local port = solution.Port!"mysql" ]
             [#if (ports[port].Port)?has_content]
                 [#local port = ports[port].Port ]
@@ -55,14 +50,6 @@
             [#break]
 
         [#case "postgres"]
-            [#local engineVersion =
-                valueIfContent(
-                    solution.EngineVersion!"",
-                    solution.EngineVersion!"",
-                    "9.4"
-                )
-            ]
-            [#local family = "postgres" + engineVersion]
             [#local port = solution.Port!"postgresql" ]
             [#if (ports[port].Port)?has_content]
                 [#local port = ports[port].Port ]
@@ -87,7 +74,10 @@
     [#local rdsFullName = resources["db"].Name ]
     [#local rdsSubnetGroupId = resources["subnetGroup"].Id ]
     [#local rdsParameterGroupId = resources["parameterGroup"].Id ]
+    [#local rdsParameterGroupFamily = resources["parameterGroup"].Family ]
     [#local rdsOptionGroupId = resources["optionGroup"].Id ]
+
+    [#local engineVersion = solution.EngineVersion]
 
     [#local rdsSecurityGroupId =  formatDependentComponentSecurityGroupId(core.Tier, core.Component, rdsId) ]
     [#local rdsSecurityGroupIngressId = formatDependentSecurityGroupIngressId(
@@ -288,7 +278,7 @@
             type="AWS::RDS::DBParameterGroup"
             properties=
                 {
-                    "Family" : family,
+                    "Family" : rdsParameterGroupFamily,
                     "Description" : rdsFullName,
                     "Parameters" : dbParameters
                 }
@@ -406,8 +396,9 @@
                     parameterGroupId=getReference(rdsParameterGroupId)
                     optionGroupId=getReference(rdsOptionGroupId)
                     securityGroupId=getReference(rdsSecurityGroupId)
-                    autoMinorVersionUpgrade = solution.AutoMinorVersionUpgrade!RDSAutoMinorVersionUpgrade
-                    deleteAutomatedBackups = solution.Backup.DeleteAutoBackups
+                    allowMajorVersionUpgrade=solution.AllowMajorVersionUpgrade
+                    autoMinorVersionUpgrade=solution.AutoMinorVersionUpgrade!RDSAutoMinorVersionUpgrade
+                    deleteAutomatedBackups=solution.Backup.DeleteAutoBackups
                     deletionPolicy=deletionPolicy
                     updateReplacePolicy=updateReplacePolicy
                 /]

--- a/providers/aws/components/db/state.ftl
+++ b/providers/aws/components/db/state.ftl
@@ -7,6 +7,19 @@
     [#local id = formatResourceId(AWS_RDS_RESOURCE_TYPE, core.Id) ]
 
     [#local engine = occurrence.Configuration.Solution.Engine]
+    [#local engineVersion = occurrence.Configuration.Solution.EngineVersion]
+
+    [#switch engine]
+        [#case "mysql"]
+            [#local family = "mysql" + engineVersion]
+            [#break]
+        [#case "postgres" ]
+            [#local family = "postgres" + engineVersion]
+            [#break]
+        [#default]
+            [#local family = engine + engineVersion]
+    [/#switch]
+
     [#local fqdn = getExistingReference(id, DNS_ATTRIBUTE_TYPE)]
     [#local port = getExistingReference(id, PORT_ATTRIBUTE_TYPE)]
     [#local name = getExistingReference(id, DATABASENAME_ATTRIBUTE_TYPE)]
@@ -40,12 +53,18 @@
                     "Type" : AWS_RDS_SUBNET_GROUP_RESOURCE_TYPE
                 },
                 "parameterGroup" : {
-                    "Id" : formatResourceId(AWS_RDS_PARAMETER_GROUP_RESOURCE_TYPE, core.Id),
+                    "Id" : formatResourceId(AWS_RDS_PARAMETER_GROUP_RESOURCE_TYPE, core.Id, replaceAlphaNumericOnly(family, "X") ),
+                    "Family" : family,
                     "Type" : AWS_RDS_PARAMETER_GROUP_RESOURCE_TYPE
                 },
                 "optionGroup" : {
-                    "Id" : formatResourceId(AWS_RDS_OPTION_GROUP_RESOURCE_TYPE, core.Id),
+                    "Id" : formatResourceId(AWS_RDS_OPTION_GROUP_RESOURCE_TYPE, core.Id, replaceAlphaNumericOnly(family, "X")),
                     "Type" : AWS_RDS_OPTION_GROUP_RESOURCE_TYPE
+                },
+                "securityGroup" : {
+                    "Id" : formatDependentComponentSecurityGroupId(core.Tier, core.Component, id),
+                    "Name" : core.FullName,
+                    "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
                 }
             },
             "Attributes" : {

--- a/providers/aws/services/rds/resource.ftl
+++ b/providers/aws/services/rds/resource.ftl
@@ -57,6 +57,7 @@
     component=""
     dependencies=""
     outputId=""
+    allowMajorVersionUpgrade=true
     autoMinorVersionUpgrade=true
     deleteAutomatedBackups=true
     deletionPolicy="Snapshot"
@@ -74,6 +75,7 @@
             "DBInstanceClass" : processor,
             "AllocatedStorage": size,
             "AutoMinorVersionUpgrade": autoMinorVersionUpgrade,
+            "AllowMajorVersionUpgrade" : allowMajorVersionUpgrade,
             "DeleteAutomatedBackups" : deleteAutomatedBackups,
             "StorageType" : "gp2",
             "Port" : port,

--- a/providers/shared/components/db/id.ftl
+++ b/providers/shared/components/db/id.ftl
@@ -15,6 +15,16 @@
             {
                 "Type" : "ComponentLevel",
                 "Value" : "solution"
+            },
+            {
+                "Type" : "Note",
+                "Value" : "Major Version Upgrades - When performing a major version upgrade only change the EngineVersion",
+                "Severity" : "warning"
+            },
+            {
+                "Type" : "Note",
+                "Value" : "AWS RDS - Major Version - Follow this guide to select the right version when performing a major version update - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Upgrading.html".
+                "Sererity" : "information"
             }
         ]
     attributes=
@@ -25,7 +35,8 @@
             },
             {
                 "Names" : "EngineVersion",
-                "Type" : STRING_TYPE
+                "Type" : STRING_TYPE,
+                "Mandatory" : true
             },
             {
                 "Names" : "Port",
@@ -99,6 +110,12 @@
                         "Default" : "Snapshot"
                     }
                 ]
+            },
+            {
+                "Names" : "AllowMajorVersionUpgrade",
+                "Description" : "If the EngineVersion paramter is updated allow for major version updates to run",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
             },
             {
                 "Names" : "AutoMinorVersionUpgrade",


### PR DESCRIPTION
Adds support for major version upgrades in RDS 

By default when the engine version parameter is updated on an RDS instance the instance will be removed and replaced with a new instance instead of upgrading the instance 

This PR makes a couple of changes to support RDS upgrading an instance when the major version is changed 

- Parameter groups  - have some weird behaviour where the update of the family parameter can not be changed once it has been set, but the parameter does not trigger the replacement of the group. So instead we now create a new parameter group for each family ( engine + engine version ) combination 
- Option groups - Support having their version updated, however this requires replacement which means the instance is removed instead of the normal update process. So we also create a new option group per family. This also ensures compatibility with snapshots that have been manually created 
- EngineVersion - This parameter is now mandatory instead of defaulting to a value for each engine type. This ensures that we know the version of RDS that is running and removes the requirement for code changes when an engine version is deprecated by the cloud provider 


Tested with a new instance and upgraded from 9.4 -> 9.5 -> 9.6 and it went through smoothly 
