### PR TITLE
<fix> Minor fixes

### DIFF
--- a/aws/templates/fragment/fragment_jenkins.ftl
+++ b/aws/templates/fragment/fragment_jenkins.ftl
@@ -29,10 +29,17 @@
     [#assign javaOpts = (javaStandardOpts + javaExtraOpts)?join(" ")]
 
     [@Settings {
-            "ECS_ARN" :  getExistingReference(ecsId),
             "JAVA_OPTS" : javaOpts
         }
     /]
+
+    [#if ! settings["ECS_ARN"]?? ]
+        [@fatal
+            message="Could not find ecs host for agents - add a link to the ECS Host that will run your agents"
+            context=_context.Links 
+            detail="Add a link with the id ecs"
+        /]
+    [/#if]
 
     [@AltSettings
         {

--- a/aws/templates/fragment/fragment_jenkins.ftl
+++ b/aws/templates/fragment/fragment_jenkins.ftl
@@ -44,7 +44,7 @@
     [#if (settings["JENKINS_LOCAL_FQDN"]!"")?has_content ]
         [@Settings
             {
-                "AGENT_JNLP_TUNNEL" : settings["JENKINS_LOCAL_FQDN"],
+                "AGENT_JNLP_TUNNEL" : settings["JENKINS_LOCAL_FQDN"] + ":50000",
                 "AGENT_JENKINS_URL" : "http://" + settings["JENKINS_LOCAL_FQDN"] + ":8080"
             }
         /]

--- a/aws/templates/fragment/fragment_jenkins.ftl
+++ b/aws/templates/fragment/fragment_jenkins.ftl
@@ -41,10 +41,20 @@
         /]
     [/#if]
 
+    [#if (settings["JENKINS_LOCAL_FQDN"]!"")?has_content ]
+        [@Settings
+            {
+                "AGENT_JNLP_TUNNEL" : settings["JENKINS_LOCAL_FQDN"],
+                "AGENT_JENKINS_URL" : "http://" + settings["JENKINS_LOCAL_FQDN"] + ":8080"
+            }
+        /]
+    [/#if]
+
     [@AltSettings
         {
             "JENKINS_URL" : "JENKINSLB_URL"
-        }/]
+        }
+    /]
 
     [#-- Validate that the appropriate settings have been provided for the container to work --]
     [#switch settings["JENKINSENV_SECURITYREALM"]!""]

--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -996,7 +996,8 @@ behaviour.
             "Id" : targetLinkName,
             "Name" : targetLinkName,
             "Tier" : targetTierId,
-            "Component" : targetComponentId
+            "Component" : targetComponentId,
+            "Enabled" : (port.LB.Enabled)!true
         } +
         attributeIfTrue("Instance", port.LB.Instance??, port.LB.Instance!"") +
         attributeIfTrue("Version",  port.LB.Version??, port.LB.Version!"") +
@@ -1028,7 +1029,8 @@ behaviour.
             "Id" : targetLinkName,
             "Name" : targetLinkName,
             "Tier" : targetTierId,
-            "Component" : targetComponentId
+            "Component" : targetComponentId,
+            "Enabled" : (port.Registry.Enabled)!true
         } +
         attributeIfTrue("Instance", port.Registry.Instance??, port.Registry.Instance!"") +
         attributeIfTrue("Version",  port.Registry.Version??, port.Registry.Version!"") +

--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -539,9 +539,9 @@
             [/#if]
 
             [#if port.Registry.Configured]
-                [#local RegistryLink = getRegistryLink(task, port)]
+                [#local registryLink = getRegistryLink(task, port)]
 
-                [#if isDuplicateLink(containerLinks, RegistryLink) ]
+                [#if isDuplicateLink(containerLinks, registryLink) ]
                     [@fatal
                         message="Duplicate Link Name"
                         context=containerLinks
@@ -550,9 +550,10 @@
                 [/#if]
 
                 [#-- Add to normal container links --]
-                [#local containerLinks += RegistryLink]
 
-                [#list RegistryLink as key,serviceRegistry]
+                [#local containerLinks += registryLink]
+
+                [#list registryLink as key,serviceRegistry]
                     [#local containerPortMapping +=
                         {
                             "ServiceRegistry" :

--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -96,7 +96,7 @@
 [/#function]
 
 [#function getOutputContent name section="default"]
-    [#return outputs[name].Sections[section].Content ]
+    [#return (outputs[name].Sections[section].Content)!{} ]
 [/#function]
 
 [#function getOutputAttributes name]

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -179,7 +179,7 @@
 [#assign products = (blueprintObject.Products)!{} ]
 [#assign productObject = (blueprintObject.Product)!(products[product])!{} ]
 [#if productObject?has_content]
-    [#assign productId = productObject.Id!product]
+    [#assign productId = (productObject.Id!product)!"" ]
     [#assign productName = productObject.Name!productId]
     [#assign products +=
         {
@@ -207,7 +207,7 @@
 [#assign segments = (blueprintObject.Segments)!{} ]
 [#assign segmentObject = (blueprintObject.Segment)!(segments[segment])!{} ]
 [#if segmentObject?has_content]
-    [#assign segmentId = segmentObject.Id!segment]
+    [#assign segmentId = (segmentObject.Id!segment)!""]
     [#assign segmentName = segmentObject.Name!segmentId]
     [#assign segments +=
         {

--- a/providers/aws/components/ec2/setup.ftl
+++ b/providers/aws/components/ec2/setup.ftl
@@ -186,8 +186,8 @@
                 [#local configSets +=
                     getInitConfigEFSMount(
                         linkTargetCore.Id,
-                        linkTargetAttributes.EFS,
-                        linkTargetAttributes.DIRECTORY,
+                        linkTargetAttributes["EFS"],
+                        linkTargetAttributes["DIRECTORY"],
                         link.Id
                     )]
                 [#break]

--- a/providers/aws/components/ecs/setup.ftl
+++ b/providers/aws/components/ecs/setup.ftl
@@ -562,7 +562,13 @@
 
                         [#if portMapping.ServiceRegistry?has_content]
                             [#local serviceRegistry = portMapping.ServiceRegistry]
-                            [#local link = container.Links[serviceRegistry.Link] ]
+
+                            [#local link = (container.Links[serviceRegistry.Link])!{} ]
+                            [#if ! link?has_content ]
+                                [@fatal message="could not find registry link" context=serviceRegistry enabled=true /]
+                                [#continue]
+                            [/#if]
+
                             [@debug message="Link" context=link enabled=false /]
                             [#local linkCore = link.Core ]
                             [#local linkResources = link.State.Resources ]

--- a/providers/aws/components/ecs/setup.ftl
+++ b/providers/aws/components/ecs/setup.ftl
@@ -14,7 +14,6 @@
     [#local ecsId = resources["cluster"].Id ]
     [#local ecsName = resources["cluster"].Name ]
     [#local ecsRoleId = resources["role"].Id ]
-    [#local ecsServiceRoleId = resources["serviceRole"].Id ]
     [#local ecsInstanceProfileId = resources["instanceProfile"].Id ]
     [#local ecsAutoScaleGroupId = resources["autoScaleGroup"].Id ]
     [#local ecsLaunchConfigId = resources["launchConfig"].Id ]
@@ -150,12 +149,6 @@
                     linkPolicies)
         /]
 
-        [@createRole
-            id=ecsServiceRoleId
-            trustedServices=["ecs.amazonaws.com" ]
-            managedArns=["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"]
-        /]
-
     [/#if]
 
     [#if solution.ClusterLogGroup &&
@@ -187,12 +180,13 @@
             [#local linkTargetAttributes = linkTarget.State.Attributes ]
 
             [#switch linkTargetCore.Type]
+                
                 [#case EFS_MOUNT_COMPONENT_TYPE]
                     [#local configSets +=
                         getInitConfigEFSMount(
                             linkTargetCore.Id,
-                            linkTargetAttributes.EFS,
-                            linkTargetAttributes.DIRECTORY,
+                            linkTargetAttributes["EFS"],
+                            linkTargetAttributes["DIRECTORY"],
                             linkId
                         )]
                     [#break]
@@ -336,7 +330,6 @@
 
     [#local ecsId = parentResources["cluster"].Id ]
     [#local ecsSecurityGroupId = parentResources["securityGroup"].Id ]
-    [#local ecsServiceRoleId = parentResources["serviceRole"].Id ]
 
     [#-- Baseline component lookup --]
     [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption" ] )]
@@ -644,7 +637,6 @@
                     taskId=taskId
                     loadBalancers=loadBalancers
                     serviceRegistries=serviceRegistries
-                    roleId=ecsServiceRoleId
                     networkMode=networkMode
                     networkConfiguration=aswVpcNetworkConfiguration!{}
                     placement=solution.Placement

--- a/providers/aws/components/ecs/state.ftl
+++ b/providers/aws/components/ecs/state.ftl
@@ -25,6 +25,8 @@
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
 
+    [#local clusterId = formatResourceId(AWS_ECS_RESOURCE_TYPE, core.Id)]
+
     [#local lgId = formatLogGroupId(core.Id) ]
     [#local lgName = core.FullAbsolutePath ]
 
@@ -58,7 +60,7 @@
         {
             "Resources" : {
                 "cluster" : {
-                    "Id" : formatResourceId(AWS_ECS_RESOURCE_TYPE, core.Id),
+                    "Id" : clusterId,
                     "Name" : core.FullName,
                     "Type" : AWS_ECS_RESOURCE_TYPE,
                     "Monitored" : true
@@ -69,11 +71,6 @@
                 },
                 "role" : {
                     "Id" : formatComponentRoleId(core.Tier, core.Component),
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
-                    "IncludeInDeploymentState" : false
-                },
-                "serviceRole" : {
-                    "Id" : formatComponentRoleId(core.Tier, core.Component, "service"),
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
                     "IncludeInDeploymentState" : false
                 },
@@ -107,6 +104,7 @@
             } +
             attributeIfContent("logMetrics", logMetrics),
             "Attributes" : {
+                "ARN" : getExistingReference(clusterId, ARN_ATTRIBUTE_TYPE)
             },
             "Roles" : {
                 "Inbound" : {},

--- a/providers/aws/components/serviceregistry/id.ftl
+++ b/providers/aws/components/serviceregistry/id.ftl
@@ -7,7 +7,8 @@
     services=
         [
             AWS_CLOUDMAP_SERVICE,
-            AWS_ROUTE53_SERVICE
+            AWS_ROUTE53_SERVICE,
+            AWS_CERTIFICATE_MANAGER_SERVICE
         ]
 /]
 
@@ -19,6 +20,7 @@
     services=
         [
             AWS_CLOUDMAP_SERVICE,
-            AWS_ROUTE53_SERVICE
+            AWS_ROUTE53_SERVICE,
+            AWS_CERTIFICATE_MANAGER_SERVICE
         ]
 /]

--- a/providers/aws/deploymentframeworks/cf/output.ftl
+++ b/providers/aws/deploymentframeworks/cf/output.ftl
@@ -107,6 +107,10 @@
     [/#if]
 
     [#if maxTagCount gte 0 ]
+        [#local maxTagCount = ( maxTagCount -1 lt result?size )?then(
+                                    maxTagCount,
+                                    result?size
+        )]
         [#local result=result[0..( maxTagCount -1 )]]
     [/#if]
     [#return result]

--- a/providers/aws/services/ecs/resource.ftl
+++ b/providers/aws/services/ecs/resource.ftl
@@ -266,7 +266,6 @@
             engine
             networkMode=""
             networkConfiguration={}
-            roleId=""
             placement={}
             dependencies=""
     ]
@@ -307,12 +306,6 @@
                 {
                     "DesiredCount" : desiredCount
                 }
-            ) +
-            valueIfTrue(
-                {
-                    "Role" : getReference(roleId)
-                },
-                (loadBalancers![])?has_content && networkMode != "awsvpc"
             ) +
             attributeIfTrue(
                 "LaunchType",

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -43,7 +43,7 @@
 [#assign ECS_TASK_COMPONENT_TYPE = "task" ]
 
 [#assign EFS_COMPONENT_TYPE = "efs" ]
-[#assign EFS_MOUNT_COMPONENT_TYPE = "efsMount"]
+[#assign EFS_MOUNT_COMPONENT_TYPE = "efsmount"]
 
 [#assign ES_COMPONENT_TYPE = "es"]
 [#assign ES_LEGACY_COMPONENT_TYPE = "elasticsearch"]


### PR DESCRIPTION
A collection of minor fixes 

- Id/Name defaulting when generating account level templates which don't have a product or environment 
- A fix for when an output conditional generates content 
- Removes the ECS Service Role assignment in favour of the built in one ( https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html) 
    When using awsvpc network mode or assigning multiple load balancer target groups the Role value can no longer be assigned and the role that we previously created used the same permissions as the service linked role. The service linked role is created on the first deployment to ECS ( including cluster ) so should not be noticed
- Jenkins - the fragment was using a variable assigned in the setup section of ecs component. This is no longer available to the fragment file. Instead a link must be provided to the ECS host you want to use 
- Casing fixup for EFS mount state lookup