### PR TITLE
<fix> Add dummy dataset deployment

### DIFF
--- a/providers/aws/components/dataset/setup.ftl
+++ b/providers/aws/components/dataset/setup.ftl
@@ -1,0 +1,15 @@
+[#ftl]
+[#macro aws_dataset_cf_application occurrence ]
+    [#if deploymentSubsetRequired("genplan", false)]
+        [@addDefaultGenerationPlan subsets=[ "prologue" ] /]
+        [#return]
+    [/#if]
+
+    [#if deploymentSubsetRequired("prologue", false)]
+        [@addToDefaultBashScriptOutput
+            [
+                "info \"Dataset deployment. Nothing to Do...\""
+            ]
+        /]
+    [/#if]
+[/#macro]


### PR DESCRIPTION
All of the dataset component lives in the state routine, however with the introduction of generation plans they are no required. 

This makes sense and also provides feedback if you try and deploy something that doesn't exist so I think this approach of adding a dummy template to deploy makes sense. It also adds wiggle room for future extensions