### PR TITLE
<feature> SPA config path control

### DIFF
--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -294,7 +294,7 @@
                         alias :
                           resource +
                           {
-                              "Deployed" : getExistingReference(resource.Id)?has_content
+                              "Deployed" : resource.Deployed!(getExistingReference(resource.Id)?has_content)
                           }
                     } ]
             [#else]

--- a/providers/aws/components/cdn/setup.ftl
+++ b/providers/aws/components/cdn/setup.ftl
@@ -237,6 +237,8 @@
                 [#local originBucket = getExistingReference(spaBaselineComponentIds["OpsData"]!"") ]
                 [#local cfAccess = getExistingReference(spaBaselineComponentIds["CDNOriginKey"]!"")]
 
+                [#local configPathPattern = originLinkTargetAttributes["CONFIG_PATH_PATTERN"]]
+
                 [#local spaOrigin =
                     getCFS3Origin(
                         originId,
@@ -270,7 +272,7 @@
 
                 [#local configCacheBehaviour = getCFSPACacheBehaviour(
                     configOrigin,
-                    formatAbsolutePath( behaviourPattern, "config/*"),
+                    formatAbsolutePath( behaviourPattern, configPathPattern),
                     { "Default" : 60 },
                     subSolution.Compress,
                     eventHandlers,
@@ -324,17 +326,18 @@
         [/#switch]
 
         [#list routeBehaviours as behaviour ]
-            [#if (behaviour.PathPattern!"")?has_content && originDefaultPath ]
+            [@debug message="behaviour check" context={ "Behaviour" : behaviour, "defaultPath" : originDefaultPath } enabled=true /]
+            [#if (behaviour.PathPattern!"")?has_content  ]
                 [#local cacheBehaviours += [ behaviour ] ]
             [#else]
-                [#if ! defaultCacheBehaviour?has_content ]
+                [#if ! defaultCacheBehaviour?has_content && originDefaultPath ]
                     [#local defaultCacheBehaviour = behaviour ]
                 [#else]
                     [@fatal
-                        message="Multiple default routes have been defined"
+                        message="Default route couldnt not be determined"
                         context=solution
-                        defailt="Check your routes to make sure PathPattern is different"
-                        enabled=true
+                        detail="Check your routes to make sure PathPattern is different and that one has been defined"
+                        enabled=false
                     /]
                 [/#if]
             [/#if]

--- a/providers/aws/components/spa/setup.ftl
+++ b/providers/aws/components/spa/setup.ftl
@@ -85,7 +85,7 @@
                         [#if linkDirection == "inbound" ]  
                             [#local distributions += [ { 
                                 "DistributionId" : subLinkAttributes["DISTRIBUTION_ID"],
-                                "PathPattern" :     subLinkResources["origin"].PathPattern
+                                "PathPattern" : subLinkResources["origin"].PathPattern
                             }]]   
                         [/#if]
                     [/#if]      
@@ -140,7 +140,7 @@
                     operationsBucket,
                     formatRelativePath(
                         getOccurrenceSettingValue(occurrence, "SETTINGS_PREFIX"),
-                        "config"
+                        solution.ConfigPath
                     )
                 ) /] 
     [/#if]

--- a/providers/aws/components/spa/state.ftl
+++ b/providers/aws/components/spa/state.ftl
@@ -25,6 +25,7 @@
                 {}
             ),
             "Attributes" : {
+                "CONFIG_PATH_PATTERN" : solution.ConfigPathPattern
             },
             "Roles" : {
                 "Inbound" : {},

--- a/providers/shared/components/spa/id.ftl
+++ b/providers/shared/components/spa/id.ftl
@@ -34,6 +34,18 @@
                 "Description" : "Invalidate all CDNs that host this content",
                 "Type" : BOOLEAN_TYPE,
                 "Default" : true
+            },
+            {
+                "Names" : "ConfigPathPattern",
+                "Description" : "The CDN pattern used to access the config",
+                "Type" : STRING_TYPE,
+                "Default" : "config/*"
+            },
+            {
+                "Names" : "ConfigPath",
+                "Description" : "The path appended to files that will be used for config",
+                "Type" : STRING_TYPE,
+                "Default" : "config"
             }
         ]
 /]


### PR DESCRIPTION
Adds the ability to control the location and CDN pattern used to provide the generated configuration file for spa components. 

This allows for integration with third party spas which have a config file location defined or you need to use the /config/* path ( our default ) in your actual SPA 

Also adds a fix for the resource deployment override setup