### PR TITLE
<feature> Core setting namespaces

### DIFF
--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -83,6 +83,7 @@
         (resourceGroup == DEFAULT_RESOURCE_GROUP) ]
         [#local extendedAttributes = [] ]
         [#local profileAttribute = coreProfileChildConfiguration[0] ]
+        [#local settingsNamespacesAttribute = coreSettingsNamespacesConfiguration[0]]
         [#list attributes as attribute ]
             [#if asArray(attribute.Names!attribute.Name)?seq_contains("Profiles")]
                 [#local profileAttribute +=
@@ -96,7 +97,7 @@
                 [#local extendedAttributes += [attribute] ]
             [/#if]
         [/#list]
-        [#local extendedAttributes += [profileAttribute] ]
+        [#local extendedAttributes += [profileAttribute, settingsNamespacesAttribute] ]
     [/#if]
     [@internalMergeComponentConfiguration
         type=type

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -280,6 +280,53 @@
         ) ]
 [/#function]
 
+[#function getSettingNamespaces occurrence namespaceObjects ]
+
+    [#local core = occurrence.Core ]
+    [#local namespaces = []]
+
+    [#list namespaceObjects as id,namespaceObject ]
+        [#local includes = namespaceObject.IncludeInNamespace!{} ]
+        [#local parts = []]
+        [#local order = namespaceObject.Order ]
+
+        [#list order as part]
+            [#if includes[part]!true]
+                [#switch part]
+                    [#case "Tier"]
+                        [#local parts += [core.Tier.Name!""] ]
+                        [#break]
+                    [#case "Component"]
+                        [#local parts += [ core.Component.Name!"" ] ]
+                        [#break]
+                    [#case "SubComponent"]
+                        [#local parts += [ core.SubComponent.Name!""] ]
+                        [#break]
+                    [#case "Instance"]
+                        [#local parts += [core.Instance.Name!""] ]
+                        [#break]
+                    [#case "Version"]
+                        [#local parts += [core.Version.Name!""] ]
+                        [#break]
+                    [#case "Name"]
+                        [#local parts += [namespaceObject.Name!""] ]
+                        [#break]
+                [/#switch]
+            [/#if]
+        [/#list]
+
+        [#local namespaces += 
+            [
+                { 
+                    "Key" : formatName(parts),
+                    "Match" : namespaceObject.Match
+                }
+            ]
+        ]
+    [/#list]
+    [#return namespaces]
+[/#function]
+
 [#--------------------------------------------------------
 -- Internal support functions for occurrence processing --
 ----------------------------------------------------------]
@@ -397,8 +444,13 @@
 
 [#function internalConstructOccurrenceBuildSettings occurrence]
     [#local deploymentUnit = (occurrence.Configuration.Solution.DeploymentUnits[0])!"" ]
+    [#local settingNamespaces = (occurrence.Configuration.Solution.SettingNamespaces)!{}]
 
     [#local alternatives =
+        settingNamespaces?has_content?then(
+            getSettingNamespaces(occurrence, settingNamespaces),
+            []
+        ) +
         [
             {"Key" : deploymentUnit, "Match" : "exact"},
             {"Key" : occurrence.Core.Name, "Match" : "partial"},
@@ -477,8 +529,13 @@
 
 [#function internalConstructOccurrenceProductSettings occurrence ]
     [#local deploymentUnit = (occurrence.Configuration.Solution.DeploymentUnits[0])!"" ]
+    [#local settingNamespaces = (occurrence.Configuration.Solution.SettingNamespaces)!{}]
 
     [#local alternatives =
+        settingNamespaces?has_content?then(
+            getSettingNamespaces(occurrence, settingNamespaces),
+            []
+        ) +
         [
             {"Key" : deploymentUnit, "Match" : "exact"},
             {"Key" : occurrence.Core.Name, "Match" : "partial"},
@@ -497,8 +554,13 @@
 
 [#function internalConstructOccurrenceSensitiveSettings occurrence]
     [#local deploymentUnit = (occurrence.Configuration.Solution.DeploymentUnits[0])!"" ]
+    [#local settingNamespaces = (occurrence.Configuration.Solution.SettingNamespaces)!{}]
 
     [#local alternatives =
+        settingNamespaces?has_content?then(
+            getSettingNamespaces(occurrence, settingNamespaces),
+            []
+        ) +
         [
             {"Key" : deploymentUnit, "Match" : "exact"},
             {"Key" : occurrence.Core.Name, "Match" : "partial"},

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -739,3 +739,78 @@
         ]
     }
 ] ]
+
+[#assign coreSettingsNamespacesConfiguration = [
+    {
+        "Names" : [ "SettingNamespaces" ],
+        "Description" : "Additional namespaces to use during settings lookups",
+        "Subobjects" : true,
+        "Children" : [
+            {
+                "Names" : "Match",
+                "Description" : "How to match the namespace with available settings",
+                "Type" : STRING_TYPE,
+                "Values" : [ "exact", "partial" ],
+                "Default" : "exact"
+            },
+            {
+                "Names" : "Order",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : [ 
+                    "Tier", 
+                    "Component",
+                    "Type", 
+                    "SubComponent", 
+                    "Instance", 
+                    "Version",
+                    "Name" 
+                ]
+            },
+            {
+                "Names" : "IncludeInNamespace",
+                "Children" : [
+                    {
+                        "Names" : "Tier",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "Component",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "Type",
+                        "Type"  : BOOLEAN_TYPE,
+                        "Default" : false
+                    }
+                    {
+                        "Names" : "SubComponent",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "Instance",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "Version",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "Name",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    }
+                ]
+            },
+            {
+                "Names" : "Name",
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            }
+        ]
+    }
+]]


### PR DESCRIPTION
Adds support for settings namespaces. Namespaces allow for custom settings structures for components. At the moment settings are lookedup based on fixed values based on the name of occurrence details. 

SettingNamespaces work in a similar way to domain naming where different occurrence name sections are combined to generate a new namespace. 

Combining Namespaces with deployment profiles offers a way to provide settings to groups of components 

Example 

```
    "DeploymentProfiles" : {
        "backend" : {
            "Modes" : {
                "*" : {
                    "service" : {
                        "SettingNamespaces" : {
                            "base" : {
                                "Name" : "backend",
                                "Match" : "partial",
                                "IncludeInNamespace" : {
                                    "Tier" : true,
                                    "Component" : false,
                                    "Type" : false,
                                    "SubComponent" : false, 
                                    "Instance" : true,
                                    "Version" : false,
                                    "Name" : true
                                }
                            }
                        }
                    },
                    "task" : {
                        "SettingNamespaces" : {
                            "base" : {
                                "Name" : "backend",
                                "Match" : "partial",
                                "IncludeInNamespace" : {
                                    "Tier" : true,
                                    "Component" : false,
                                    "Type" : false,
                                    "SubComponent" : false, 
                                    "Instance" : true,
                                    "Version" : false,
                                    "Name" : true
                                }
                            }
                        }
                    }
                }
            }
        }
    }
```

assuming the following occurrence properties and the backend profile assigned to a component 
- Tier: `application`
- Instance: `foo`

An extra lookup would be added during settings processing for a settings object with the key/folder name of
`application-foo-backend`

The order of the key can also be changed to accommodate partial Matching 