### PR TITLE
moved unused attributes from Shared to aws provider

### DIFF
--- a/providers/aws/components/s3/id.ftl
+++ b/providers/aws/components/s3/id.ftl
@@ -1,7 +1,81 @@
 [#ftl]
 [@addResourceGroupInformation
     type=S3_COMPONENT_TYPE
-    attributes=[]
+    attributes=
+        [
+            {
+                "Names" : "Lifecycle",
+                "Children" : [
+                    {
+                        "Names" : "Expiration",
+                        "Types" : [STRING_TYPE, NUMBER_TYPE],
+                        "Description" : "Provide either a date or a number of days"
+                    },
+                    {
+                        "Names" : "Offline",
+                        "Types" : [STRING_TYPE, NUMBER_TYPE],
+                        "Description" : "Provide either a date or a number of days"
+                    },
+                    {
+                        "Names" : "Versioning",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    }
+                ]
+            },
+            {
+                "Names" : "Website",
+                "Children" : [
+                    {
+                        "Names": "Index",
+                        "Type" : STRING_TYPE,
+                        "Default": "index.html"
+                    },
+                    {
+                        "Names": "Error",
+                        "Type" : STRING_TYPE,
+                        "Default": ""
+                    }
+                ]
+            },
+            {
+                "Names" : "PublicAccess",
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "Permissions",
+                        "Type" : STRING_TYPE,
+                        "Values" : ["ro", "wo", "rw"],
+                        "Default" : "ro"
+                    },
+                    {
+                        "Names" : "IPAddressGroups",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Default" : [ "_localnet" ]
+                    },
+                    {
+                        "Names" : "Paths",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Default" : [ ]
+                    }
+                ]
+            },
+            {
+                "Names" : "Style",
+                "Type" : STRING_TYPE,
+                "Description" : "TODO(mfl): Think this can be removed"
+            },
+            {
+                "Names" : "Notifications",
+                "Subobjects" : true,
+                "Children" : s3NotificationChildConfiguration
+            },
+        ]
     provider=AWS_PROVIDER
     resourceGroup=DEFAULT_RESOURCE_GROUP
     services=

--- a/providers/shared/components/s3/id.ftl
+++ b/providers/shared/components/s3/id.ftl
@@ -21,75 +21,23 @@
         [
             {
                 "Names" : "Lifecycle",
-                "Children" : [
-                    {
-                        "Names" : "Expiration",
-                        "Types" : [STRING_TYPE, NUMBER_TYPE],
-                        "Description" : "Provide either a date or a number of days"
-                    },
-                    {
-                        "Names" : "Offline",
-                        "Types" : [STRING_TYPE, NUMBER_TYPE],
-                        "Description" : "Provide either a date or a number of days"
-                    },
-                    {
-                        "Names" : "Versioning",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : false
-                    }
-                ]
+                "Subobjects" : true,
+                "Children" : []
             },
             {
                 "Names" : "Website",
-                "Children" : [
-                    {
-                        "Names": "Index",
-                        "Type" : STRING_TYPE,
-                        "Default": "index.html"
-                    },
-                    {
-                        "Names": "Error",
-                        "Type" : STRING_TYPE,
-                        "Default": ""
-                    }
-                ]
+                "Subobjects" : true,
+                "Children" : []
             },
             {
                 "Names" : "PublicAccess",
                 "Subobjects" : true,
-                "Children" : [
-                    {
-                        "Names" : "Enabled",
-                        "Type" : BOOLEAN_TYPE,
-                        "Default" : false
-                    },
-                    {
-                        "Names" : "Permissions",
-                        "Type" : STRING_TYPE,
-                        "Values" : ["ro", "wo", "rw"],
-                        "Default" : "ro"
-                    },
-                    {
-                        "Names" : "IPAddressGroups",
-                        "Type" : ARRAY_OF_STRING_TYPE,
-                        "Default" : [ "_localnet" ]
-                    },
-                    {
-                        "Names" : "Paths",
-                        "Type" : ARRAY_OF_STRING_TYPE,
-                        "Default" : [ ]
-                    }
-                ]
-            },
-            {
-                "Names" : "Style",
-                "Type" : STRING_TYPE,
-                "Description" : "TODO(mfl): Think this can be removed"
+                "Children" : []
             },
             {
                 "Names" : "Notifications",
                 "Subobjects" : true,
-                "Children" : s3NotificationChildConfiguration
+                "Children" : []
             },
             {
                 "Names" : "CORSBehaviours",


### PR DESCRIPTION
Drafting because I think we should talk about this - I suspect this is going to happen a lot, where the vast majority of attributes wont be shared. 

I was thinking that shared\id.ftl could contain a skeleton of high-level attribute headings, which we could then fill in within each provider. Some of these we already have - Notifications, Lifecycle etc. as well as some like Links. This would provide a logical place to then add into in provider\component\id.ftl, whilst not really requiring a debate about what to call every single attribute or shoe-horning an existing shared attribute into a place it doesn't fit. 

Thoughts?