### PR TITLE
<fix> userpool only validate cognito config during cli pass

### DIFF
--- a/providers/aws/components/es/setup.ftl
+++ b/providers/aws/components/es/setup.ftl
@@ -233,11 +233,13 @@
                 }
             ]
         [#else]
-            [@fatal
-                message="Incomplete Cognito integration"
-                context=component
-                detail="You must provide a link to both a federated role and a userpool to enabled authentication"
-            /]
+            [#if deploymentSubsetRequired("cli", false)]
+                [@fatal
+                    message="Incomplete Cognito integration"
+                    context=component
+                    detail="You must provide a link to both a federated role and a userpool to enabled authentication"
+                /]
+            [/#if]
         [/#if]
 
     [/#if]


### PR DESCRIPTION
Only check the cognito -> ES configuration setup during the cli subset. This allows for the IAM pass to complete so that updates can be made to cloudroles