### PR TITLE
<fix> userpool add optional mfa config

### DIFF
--- a/providers/aws/services/cognito/resource.ftl
+++ b/providers/aws/services/cognito/resource.ftl
@@ -223,7 +223,7 @@
             {
                 "UserPoolName" : name,
                 "UserPoolTags" : tagMap,
-                "MfaConfiguration" : mfa?then("ON","OFF"),
+                "MfaConfiguration" : mfa,
                 "AdminCreateUserConfig" : getUserPoolAdminCreateUserConfig(
                                                 adminCreatesUser,
                                                 unusedTimeout,

--- a/providers/shared/components/userpool/id.ftl
+++ b/providers/shared/components/userpool/id.ftl
@@ -31,7 +31,8 @@
         [
             {
                 "Names" : "MFA",
-                "Type" : BOOLEAN_TYPE,
+                "Type" : [ BOOLEAN_TYPE, STRING_TYPE],
+                "Values" : [ "true", true, "false", false, "optional" ],
                 "Default" : false
             },
             {


### PR DESCRIPTION
Adds the ability to specify MFA as optional on a user pool. This can be used to enable MFA after a userpool has been deployed