### PR TITLE
<fix> Region lookup for attribtues

### DIFF
--- a/providers/aws/components/apigateway/state.ftl
+++ b/providers/aws/components/apigateway/state.ftl
@@ -84,12 +84,13 @@ created in either case.
     [#local endpointType       = solution.EndpointType ]
     [#local isEdgeEndpointType = solution.EndpointType == "EDGE" ]
 
+    [#local region = getExistingReference(apiId, REGION_ATTRIBUTE_TYPE)!regionId ]
     [#-- The AWS assigned domain for the API --]
     [#local internalFqdn =
         formatDomainName(
             getExistingReference(apiId),
             serviceName,
-            regionId,
+            region,
             "amazonaws.com") ]
 
     [#-- Preferred domain to use when accessing the API --]

--- a/providers/aws/components/ecs/state.ftl
+++ b/providers/aws/components/ecs/state.ftl
@@ -156,6 +156,8 @@
     [#local lgId = formatDependentLogGroupId(taskId) ]
     [#local lgName = core.FullAbsolutePath ]
 
+    [#local region = getExistingReference(serviceId, REGION_ATTRIBUTE_TYPE )!regionId ]
+
     [#local logMetrics = {} ]
     [#list solution.LogMetrics as name,logMetric ]
         [#local logMetrics += {
@@ -256,7 +258,7 @@
             "Roles" : {
                 "Inbound" : {
                     "logwatch" : {
-                        "Principal" : "logs." + regionId + ".amazonaws.com",
+                        "Principal" : "logs." + region + ".amazonaws.com",
                         "LogGroupIds" : [ lgId ]
                     }
                 },
@@ -279,6 +281,8 @@
 
     [#local lgId = formatDependentLogGroupId(taskId) ]
     [#local lgName = core.FullAbsolutePath ]
+
+    [#local region = getExistingReference(taskId, REGION_ATTRIBUTE_TYPE )]
 
     [#local logMetrics = {} ]
     [#list solution.LogMetrics as name,logMetric ]
@@ -360,7 +364,7 @@
             "Roles" : {
                 "Inbound" : {
                     "logwatch" : {
-                        "Principal" : "logs." + regionId + ".amazonaws.com",
+                        "Principal" : "logs." + region + ".amazonaws.com",
                         "LogGroupIds" : [ lgId ]
                     }
                 },

--- a/providers/aws/components/es/state.ftl
+++ b/providers/aws/components/es/state.ftl
@@ -53,7 +53,7 @@
                     }
                 },
                 "Attributes" : {
-                    "REGION" : regionId,
+                    "REGION" : getExistingReference(esId, REGION_ATTRIBUTE_TYPE)!regionId,
                     "AUTH" : solution.Authentication,
                     "FQDN" : esHostName,
                     "URL" : "https://" + esHostName,

--- a/providers/aws/components/lambda/state.ftl
+++ b/providers/aws/components/lambda/state.ftl
@@ -12,9 +12,7 @@
                     "Type" : AWS_LAMBDA_RESOURCE_TYPE
                 }
             },
-            "Attributes" : {
-                "REGION" : regionId
-            },
+            "Attributes" : {},
             "Roles" : {
                 "Inbound" : {},
                 "Outbound" : {}
@@ -29,6 +27,8 @@
 
     [#local id = formatResourceId(AWS_LAMBDA_FUNCTION_RESOURCE_TYPE, core.Id)]
     [#local versionId = formatResourceId(AWS_LAMBDA_VERSION_RESOURCE_TYPE, core.Id )]
+
+    [#local region = getExistingReference(id, REGION_ATTRIBUTE_TYPE)!regionId]
 
     [#local lgId = formatLogGroupId(core.Id)]
     [#local lgName = formatAbsolutePath("aws", "lambda", core.FullName)]
@@ -75,14 +75,14 @@
                 }
             ),
             "Attributes" : {
-                "REGION" : regionId,
+                "REGION" : region,
                 "ARN" : valueIfTrue(
                             getExistingReference( versionId ),
                             fixedCodeVersion
                             formatArn(
                                 regionObject.Partition,
                                 "lambda",
-                                regionId,
+                                region,
                                 accountObject.AWSId,
                                 "function:" + core.FullName,
                                 true)
@@ -93,7 +93,7 @@
             "Roles" : {
                 "Inbound" : {
                     "logwatch" : {
-                        "Principal" : "logs." + regionId + ".amazonaws.com",
+                        "Principal" : "logs." + region + ".amazonaws.com",
                         "LogGroupIds" : [ lgId ]
                     }
                 },

--- a/providers/aws/components/mobilenotifier/setup.ftl
+++ b/providers/aws/components/mobilenotifier/setup.ftl
@@ -220,7 +220,8 @@
                             "SNS Platform App",
                             {
                                 formatId(platformAppId, "arn") : "$\{platform_app_arn}",
-                                platformAppId : core.Name
+                                platformAppId : core.Name,
+                                formatId(platformAppId, "region) : regionId 
                             },
                             core.SubComponent.Id
                         ) +

--- a/providers/aws/components/mobilenotifier/state.ftl
+++ b/providers/aws/components/mobilenotifier/state.ftl
@@ -47,6 +47,8 @@
     [#local lgFailureId = formatMobileNotifierLogGroupId(engine, name, true) ]
     [#local lgFailureName = formatMobileNotifierLogGroupName(engine, name, true)]
 
+    [#local region = getExistingReference(id, REGION_ATTRIBUTE_TYPE)!regionId ]
+
     [#local logMetrics = {} ]
     [#list solution.LogMetrics as name,logMetric ]
         [#local logMetrics += {
@@ -98,7 +100,7 @@
                             formatArn(
                                 regionObject.Partition,
                                 "sns",
-                                regionId,
+                                region,
                                 accountObject.AWSId,
                                 "smsPlaceHolder"
                             ),
@@ -110,7 +112,7 @@
             "Roles" : {
                 "Inbound" : {
                     "logwatch" : {
-                        "Principal" : "logs." + regionId + ".amazonaws.com",
+                        "Principal" : "logs." + region + ".amazonaws.com",
                         "LogGroupIds" : [ lgId, lgFailureId ]
                     }
                 },

--- a/providers/aws/components/sqs/state.ftl
+++ b/providers/aws/components/sqs/state.ftl
@@ -67,7 +67,7 @@
                     "URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE),
                     "PRODUCT_URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE)?replace("https://", "sqs://"),
                     "ARN" : getExistingReference(id, ARN_ATTRIBUTE_TYPE),
-                    "REGION" : regionId
+                    "REGION" : getExistingReference(esId, REGION_ATTRIBUTE_TYPE)!regionId
                 },
                 "Roles" : {
                     "Inbound" : {},

--- a/providers/aws/services/apigateway/resource.ftl
+++ b/providers/aws/services/apigateway/resource.ftl
@@ -7,6 +7,9 @@
         },
         ROOT_ATTRIBUTE_TYPE : {
             "Attribute" : "RootResourceId"
+        },
+        REGION_ATTRIBUTE_TYPE: {
+            "Value" : { "Ref" : "AWS::Region" }
         }
     }
 ]

--- a/providers/aws/services/ecs/resource.ftl
+++ b/providers/aws/services/ecs/resource.ftl
@@ -10,6 +10,9 @@
         },
         NAME_ATTRIBUTE_TYPE : {
             "Attribute" : "Name"
+        },
+        REGION_ATTRIBUTE_TYPE: {
+            "Value" : { "Ref" : "AWS::Region" }
         }
     }
 ]
@@ -21,6 +24,9 @@
         },
         ARN_ATTRIBUTE_TYPE : {
             "UseRef" : true
+        },
+        REGION_ATTRIBUTE_TYPE: {
+            "Value" : { "Ref" : "AWS::Region" }
         }
     }
 ]

--- a/providers/aws/services/es/resource.ftl
+++ b/providers/aws/services/es/resource.ftl
@@ -10,6 +10,9 @@
         },
         DNS_ATTRIBUTE_TYPE : {
             "Attribute" : "DomainEndpoint"
+        },
+        REGION_ATTRIBUTE_TYPE: {
+            "Value" : { "Ref" : "AWS::Region" }
         }
     }
 ]

--- a/providers/aws/services/lambda/resource.ftl
+++ b/providers/aws/services/lambda/resource.ftl
@@ -7,6 +7,9 @@
         },
         ARN_ATTRIBUTE_TYPE : {
             "Attribute" : "Arn"
+        },
+        REGION_ATTRIBUTE_TYPE: {
+            "Value" : { "Ref" : "AWS::Region" }
         }
     }
 ]

--- a/providers/aws/services/sqs/resource.ftl
+++ b/providers/aws/services/sqs/resource.ftl
@@ -13,6 +13,9 @@
         },
         URL_ATTRIBUTE_TYPE : {
             "UseRef" : true
+        },
+        REGION_ATTRIBUTE_TYPE: {
+            "Value" : { "Ref" : "AWS::Region" }
         }
     }
 ]


### PR DESCRIPTION
Fixes #100  
Adds the region output to resources where required. 
Updates state routines with region specified to use the new output and fall back to the default region until the output is available