### PR TITLE
<fix> Seperate ECS Host from Service scaling policy

### DIFF
--- a/providers/aws/components/ecs/setup.ftl
+++ b/providers/aws/components/ecs/setup.ftl
@@ -287,8 +287,8 @@
                 getInitConfigEIPAllocation(allocationIds)]
         [/#if]
 
-        [#if solution.ScalingPolicies?has_content ]
-            [#list solution.ScalingPolicies as name, scalingPolicy ]
+        [#if solution.HostScalingPolicies?has_content ]
+            [#list solution.HostScalingPolicies as name, scalingPolicy ]
                 [#local scalingPolicyId = resources["scalingPolicy" + name].Id ]
 
                 [#local scalingMetricTrigger = scalingPolicy.TrackingResource.MetricTrigger ]

--- a/providers/shared/components/ecs/id.ftl
+++ b/providers/shared/components/ecs/id.ftl
@@ -179,7 +179,7 @@
                 "Children" : autoScalingChildConfiguration
             },
             {
-                "Names" : "ScalingPolicies",
+                "Names" : "HostScalingPolicies",
                 "Subobjects" : true,
                 "Children" : scalingPolicyChildrenConfiguration
             },


### PR DESCRIPTION
Currently ECS Host configuration is merged with the Service configuration. This means that scaling policies overlap and you can't create a policy which only applies to the hosts. 

This workaround allows them to be treated separatley