### PR TITLE
Allow for loading of a plugin utility script.

### DIFF
--- a/aws/common.sh
+++ b/aws/common.sh
@@ -7,6 +7,11 @@
 . ${GENERATION_DIR}/utility.sh
 . ${GENERATION_DIR}/contextTree.sh
 
+# Load plugin utilities if they exist
+if [[ -f ${GENERATION_PLUGIN_DIR}/utility.sh]]; then
+  . ${GENERATION_PLUGIN_DIR}/utility.sh
+fi
+
 function getLogLevel() {
   checkLogLevel "${GENERATION_LOG_LEVEL}"
 }


### PR DESCRIPTION
As a part of the Azure plugin baseline component, I need to utilise the pki/ssh utilities within the generation\aws\utilities.sh - however in their current state they are specific to AWS.

Rather than update them to allow for a new provider (which would then have to happen for every possible plugin) this will allow dynamic loading of a second utility.sh that is specific to the provider. The "shared" provider utility.sh will load first and provide the bulk of the functions whilst anything provider specific can come from the plugin directly.

One thing to note is that plugin function names should include their provider, both for debugging (knowing where the function originated) and also to avoid naming conflicts between both utility scripts. 