### PR TITLE
<fix> MobileNotifer always mark SMS notifier as deployed

### DIFF
--- a/providers/aws/components/mobilenotifier/state.ftl
+++ b/providers/aws/components/mobilenotifier/state.ftl
@@ -80,7 +80,12 @@
                     "Engine" : engine,
                     "Type" : AWS_SNS_PLATFORMAPPLICATION_RESOURCE_TYPE,
                     "Monitored" : true
-                },
+                } + 
+                attributeIfTrue(
+                    "Deployed",
+                    ( engine == MOBILENOTIFIER_SMS_ENGINE),
+                    true
+                ),
                 "lg" : {
                     "Id" : lgId,
                     "Name" : lgName,


### PR DESCRIPTION
The SMS mobile notifier isn't  real component in AWS so instead we just need to fake it to get the policy details