### PR TITLE
<fix>Show error context in script output

### DIFF
--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -161,10 +161,10 @@
             [#local severity = "[" + message.Severity?right_pad(6) + "]" ]
             [#local comments += [[timestamp, severity, getJSON(message.Message)]?join(" ")] ]
             [#if message.Context?has_content]
-                [#local comments += [" ...." + getJSON(message.Context)] ]
+                [#local comments += [" .... " + severity + " " + getJSON(message.Context)] ]
             [/#if]
             [#if message.Detail?has_content]
-                [#local comments += [" ...." + getJSON(message.Detail)] ]
+                [#local comments += [" .... " + severity + " " + getJSON(message.Detail)] ]
             [/#if]
         [/#list]
         [@addOutputContent


### PR DESCRIPTION
Include severity in script output lines so that error reporting shows the context on generation plan passes which catch the exceptions from configuration validation