### PR TITLE
<fix> Autoscaling rolling update policy

### DIFF
--- a/providers/aws/services/ec2/resource.ftl
+++ b/providers/aws/services/ec2/resource.ftl
@@ -792,10 +792,12 @@
                     processorProfile.DesiredPerZone
     )]
 
+    [#assign autoscalingMinUpdateInstances = autoScalingConfig.MinUpdateInstances ]
     [#if hibernate ]
         [#assign minSize = 0 ]
         [#assign desiredCapacity = 0 ]
         [#assign maxSize = 1]
+        [#assign autoscalingMinUpdateInstances = 0 ]
     [/#if]
 
     [@cfResource
@@ -854,7 +856,7 @@
             {
                 "AutoScalingRollingUpdate" : {
                     "WaitOnResourceSignals" : autoScalingConfig.WaitForSignal,
-                    "MinInstancesInService" : autoScalingConfig.MinUpdateInstances,
+                    "MinInstancesInService" : autoscalingMinUpdateInstances,
                     "PauseTime" : "PT" + autoScalingConfig.UpdatePauseTime
                 }
             }


### PR DESCRIPTION
Fix for ec2 autoscaling groups with rolling updates enabled. 

You can't set the maxCount to the same or below the MinInstancesInService for rolling updates, Since we want to set it to 1 and the minCount to 0 we need to make sure no instances need to be in service during the updaet 

See https://forums.aws.amazon.com/thread.jspa?threadID=141982 from AWS