### PR TITLE
<feature> Provider switch

### DIFF
--- a/providers/aws/deploymentframeworks/cf/output.ftl
+++ b/providers/aws/deploymentframeworks/cf/output.ftl
@@ -212,6 +212,15 @@
     [@initialiseJsonOutput name="resources" /]
     [@initialiseJsonOutput name="outputs" /]
 
+    [@addGenPlanStepOutputMapping 
+        provider=AWS_PROVIDER
+        subsets=[
+            "template"
+        ]
+        outputType=AWS_OUTPUT_RESOURCE_TYPE
+        outputFormat=""
+    /]
+
     [#-- Resources --]
     [#if include?has_content]
         [#include include?ensure_starts_with("/")]


### PR DESCRIPTION
Adds the ability to switch provider and framework as a command line option/env var 

This is a workaround for the work we are doing with resource groups which allow for multiple providers to be used in the same template and instead makes it possible to switch between single providers for a given template

It also adds the ability for providers to add output step mappings for generation plans so that providers can customise the outputs generated for different subnets
