### PR TITLE
Moved the instantiation and assignment of outputMappings 

### DIFF
--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -361,6 +361,35 @@
     [/#list]
 [/#macro]
 
+[#-- Output mappings object is extended dynamically by each resource type --]
+[#assign outputMappings = {} ]
+
+[#macro addOutputMapping provider resourceType mappings]
+    [#assign outputMappings = mergeObjects(
+        outputMappings,
+        {
+            provider : {
+                resourceType : mappings
+            }
+        }
+    )]
+[/#macro]
+
+[#function getOutputMappings provider resourceType="" attributeType=""]
+    [#if resourceType?has_content]
+        [#if attributeType?has_content]
+            [#-- type and attribute provided, return specific attribute --]
+            [#return outputMappings[provider][resourceType][attributeType]!{}]
+        [#else]
+            [#-- type provided, return a specific resource type --]
+            [#return outputMappings[provider][resourceType]!{}]
+        [/#if]
+    [#else]
+        [#-- return all provder resource mappings --]
+        [#return outputMappings[provider]!{}]
+    [/#if]
+[/#function]
+
 [#function getGenPlanStepOutputMapping provider subset ]
     [#if ((genPlanStepOutputMappings[provider][subset])!{})?has_content ]
         [#return genPlanStepOutputMappings[provider][subset]]

--- a/providers/aws/services/acm/resource.ftl
+++ b/providers/aws/services/acm/resource.ftl
@@ -11,11 +11,12 @@
     }
 ]
 
-[#assign outputMappings +=
-    {
-        AWS_CERTIFICATE_RESOURCE_TYPE : CERTIFICATE_OUTPUT_MAPPINGS
-    }
-]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_CERTIFICATE_RESOURCE_TYPE
+    mappings=CERTIFICATE_OUTPUT_MAPPINGS
+/]
+
 
 [#macro createCertificate id domain validationDomain="" outputId=""]
 

--- a/providers/aws/services/apigateway/resource.ftl
+++ b/providers/aws/services/apigateway/resource.ftl
@@ -40,12 +40,18 @@
         }
     }
 ]
-[#assign outputMappings +=
-    {
-        AWS_APIGATEWAY_RESOURCE_TYPE : APIGATEWAY_OUTPUT_MAPPINGS,
-        AWS_APIGATEWAY_APIKEY_RESOURCE_TYPE : APIGATEWAY_APIKEY_OUTPUT_MAPPINGS
-    }
-]
+
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_APIGATEWAY_RESOURCE_TYPE
+    mappings=APIGATEWAY_OUTPUT_MAPPINGS
+/]
+
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_APIGATEWAY_APIKEY_RESOURCE_TYPE
+    mappings=APIGATEWAY_APIKEY_OUTPUT_MAPPINGS
+/]
 
 [#function formatInvokeApiGatewayArn apiId stageName="" account={ "Ref" : "AWS::AccountId" }]
     [#return
@@ -84,11 +90,11 @@
     }
 ]
 
-[#assign outputMappings +=
-    {
-        AWS_APIGATEWAY_USAGEPLAN_RESOURCE_TYPE : APIGATEWAY_USAGEPLAN_OUTPUT_MAPPINGS
-    }
-]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_APIGATEWAY_USAGEPLAN_RESOURCE_TYPE
+    mappings=APIGATEWAY_USAGEPLAN_OUTPUT_MAPPINGS
+/]
 
 [#macro createAPIUsagePlan id name stages=[] dependencies="" ]
     [@cfResource

--- a/providers/aws/services/autoscaling/resource.ftl
+++ b/providers/aws/services/autoscaling/resource.ftl
@@ -33,7 +33,7 @@
 ]
 
 
-[#local mappings =
+[#assign autoScalingMappings =
     {
         AWS_AUTOSCALING_APP_TARGET_RESOURCE_TYPE : AWS_AUTOSCALING_APP_TARGET_OUTPUT_MAPPINGS,
         AWS_AUTOSCALING_APP_POLICY_RESOURCE_TYPE : AWS_AUTOSCALING_APP_POLICY_OUTPUT_MAPPINGS,
@@ -42,7 +42,7 @@
     }
 ]
 
-[#list mappings as type, mappings]
+[#list autoScalingMappings as type, mappings]
     [@addOutputMapping 
         provider=AWS_PROVIDER
         resourceType=type

--- a/providers/aws/services/autoscaling/resource.ftl
+++ b/providers/aws/services/autoscaling/resource.ftl
@@ -33,7 +33,7 @@
 ]
 
 
-[#assign outputMappings +=
+[#local mappings =
     {
         AWS_AUTOSCALING_APP_TARGET_RESOURCE_TYPE : AWS_AUTOSCALING_APP_TARGET_OUTPUT_MAPPINGS,
         AWS_AUTOSCALING_APP_POLICY_RESOURCE_TYPE : AWS_AUTOSCALING_APP_POLICY_OUTPUT_MAPPINGS,
@@ -41,6 +41,14 @@
         AWS_AUTOSCALING_EC2_SCHEDULE_RESOURCE_TYPE : AWS_AUTOSCALING_EC2_SCHEDULE_OUTPUT_MAPPINGS
     }
 ]
+
+[#list mappings as type, mappings]
+    [@addOutputMapping 
+        provider=AWS_PROVIDER
+        resourceType=type
+        mappings=mappings
+    /]
+[/#list]
 
 [#-- Generic AutoScaling functions --]
 [#function getAutoScalingStepAdjustment 

--- a/providers/aws/services/cache/resource.ftl
+++ b/providers/aws/services/cache/resource.ftl
@@ -26,11 +26,12 @@
         }
     }
 ]
-[#assign outputMappings +=
-    {
-        AWS_CACHE_RESOURCE_TYPE : REDIS_OUTPUT_MAPPINGS
-    }
-]
+
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_CACHE_RESOURCE_TYPE
+    mappings=REDIS_OUTPUT_MAPPINGS
+/]
 
 [#assign metricAttributes +=
     {

--- a/providers/aws/services/cf/resource.ftl
+++ b/providers/aws/services/cf/resource.ftl
@@ -22,12 +22,17 @@
     }
 ]
 
-[#assign outputMappings +=
-    {
-        AWS_CLOUDFRONT_DISTRIBUTION_RESOURCE_TYPE : CF_OUTPUT_MAPPINGS,
-        AWS_CLOUDFRONT_ACCESS_ID_RESOURCE_TYPE : CF_ACCESS_ID_OUTPUT_MAPPINGS
-    }
-]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_CLOUDFRONT_DISTRIBUTION_RESOURCE_TYPE
+    mappings=CF_OUTPUT_MAPPINGS
+/]
+
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_CLOUDFRONT_ACCESS_ID_RESOURCE_TYPE
+    mappings=CF_ACCESS_ID_OUTPUT_MAPPINGS
+/]
 
 [#function getCFHTTPHeader name value]
     [#return

--- a/providers/aws/services/cloudmap/resource.ftl
+++ b/providers/aws/services/cloudmap/resource.ftl
@@ -30,7 +30,7 @@
     }
 ]
 
-[#local mappings =
+[#assign cloudmapMappings =
     {
         AWS_CLOUDMAP_DNS_NAMESPACE_RESOURCE_TYPE : CLOUDMAP_DNS_NAMESPACE_OUTPUT_MAPPINGS,
         AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE : CLOUDMAP_SERVICE_OUTPUT_MAPPINGS,
@@ -38,7 +38,7 @@
     }
 ]
 
-[#list mappings as type, mappings]
+[#list cloudmapMappings as type, mappings]
     [@addOutputMapping 
         provider=AWS_PROVIDER
         resourceType=type

--- a/providers/aws/services/cloudmap/resource.ftl
+++ b/providers/aws/services/cloudmap/resource.ftl
@@ -30,13 +30,21 @@
     }
 ]
 
-[#assign outputMappings +=
+[#local mappings =
     {
         AWS_CLOUDMAP_DNS_NAMESPACE_RESOURCE_TYPE : CLOUDMAP_DNS_NAMESPACE_OUTPUT_MAPPINGS,
         AWS_CLOUDMAP_SERVICE_RESOURCE_TYPE : CLOUDMAP_SERVICE_OUTPUT_MAPPINGS,
         AWS_CLOUDMAP_INSTANCE_RESOURCE_TYPE : CLOUDMAP_INSTANCE_OUTPUT_MAPPINGS
     }
 ]
+
+[#list mappings as type, mappings]
+    [@addOutputMapping 
+        provider=AWS_PROVIDER
+        resourceType=type
+        mappings=mappings
+    /]
+[/#list]
 
 [#macro createCloudMapDNSNamespace
     id name

--- a/providers/aws/services/cognito/resource.ftl
+++ b/providers/aws/services/cognito/resource.ftl
@@ -39,7 +39,7 @@
     }
 ]
 
-[#local mappings =
+[#assign cogniitoMappings =
     {
         AWS_COGNITO_USERPOOL_RESOURCE_TYPE : USERPOOL_OUTPUT_MAPPINGS,
         AWS_COGNITO_USERPOOL_CLIENT_RESOURCE_TYPE : USERPOOL_CLIENT_OUTPUT_MAPPINGS,
@@ -47,7 +47,7 @@
     }
 ]
 
-[#list mappings as type, mappings]
+[#list cogniitoMappings as type, mappings]
     [@addOutputMapping 
         provider=AWS_PROVIDER
         resourceType=type

--- a/providers/aws/services/cognito/resource.ftl
+++ b/providers/aws/services/cognito/resource.ftl
@@ -39,13 +39,21 @@
     }
 ]
 
-[#assign outputMappings +=
+[#local mappings =
     {
         AWS_COGNITO_USERPOOL_RESOURCE_TYPE : USERPOOL_OUTPUT_MAPPINGS,
         AWS_COGNITO_USERPOOL_CLIENT_RESOURCE_TYPE : USERPOOL_CLIENT_OUTPUT_MAPPINGS,
         AWS_COGNITO_IDENTITYPOOL_RESOURCE_TYPE : IDENTITYPOOL_OUTPUT_MAPPINGS
     }
 ]
+
+[#list mappings as type, mappings]
+    [@addOutputMapping 
+        provider=AWS_PROVIDER
+        resourceType=type
+        mappings=mappings
+    /]
+[/#list]
 
 [#function getUserPoolPasswordPolicy length="8" lowercase=true uppercase=true numbers=true symbols=true tempPasswordValidity=30 ]
     [#return

--- a/providers/aws/services/cw/resource.ftl
+++ b/providers/aws/services/cw/resource.ftl
@@ -10,11 +10,12 @@
         }
     }
 ]
-[#assign outputMappings +=
-    {
-        AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE : LOG_GROUP_OUTPUT_MAPPINGS
-    }
-]
+
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
+    mappings=LOG_GROUP_OUTPUT_MAPPINGS
+/]
 
 [#-- Dummy metricAttributes to allow for log watchers --]
 [#assign metricAttributes +=
@@ -103,11 +104,12 @@
         }
     }
 ]
-[#assign outputMappings +=
-    {
-        AWS_CLOUDWATCH_DASHBOARD_RESOURCE_TYPE : DASHBOARD_OUTPUT_MAPPINGS
-    }
-]
+
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_CLOUDWATCH_DASHBOARD_RESOURCE_TYPE
+    mappings=DASHBOARD_OUTPUT_MAPPINGS
+/]
 
 [#macro createDashboard id name components ]
 
@@ -332,11 +334,12 @@
     }
 ]
 
-[#assign outputMappings +=
-    {
-        AWS_EVENT_RULE_RESOURCE_TYPE : EVENT_RULE_OUTPUT_MAPPINGS
-    }
-]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_EVENT_RULE_RESOURCE_TYPE
+    mappings=EVENT_RULE_OUTPUT_MAPPINGS
+/]
+
 [#macro createScheduleEventRule id
         enabled
         scheduleExpression

--- a/providers/aws/services/dynamodb/resource.ftl
+++ b/providers/aws/services/dynamodb/resource.ftl
@@ -13,11 +13,12 @@
         }
     }
 ]
-[#assign outputMappings +=
-    {
-        AWS_DYNAMODB_TABLE_RESOURCE_TYPE : DYNAMODB_OUTPUT_MAPPINGS
-    }
-]
+
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_DYNAMODB_TABLE_RESOURCE_TYPE
+    mappings=DYNAMODB_OUTPUT_MAPPINGS
+/]
 
 [#assign metricAttributes +=
     {

--- a/providers/aws/services/ec2/resource.ftl
+++ b/providers/aws/services/ec2/resource.ftl
@@ -16,12 +16,17 @@
     }
 ]
 
-[#assign outputMappings +=
-    {
-        AWS_EC2_AUTO_SCALE_GROUP_RESOURCE_TYPE : AWS_EC2_AUTO_SCALE_GROUP_OUTPUT_MAPPINGS,
-        AWS_EC2_EBS_RESOURCE_TYPE : AWS_EC2_EBS_VOLUME_OUTPUT_MAPPINGS
-    }
-]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_EC2_AUTO_SCALE_GROUP_RESOURCE_TYPE
+    mappings=AWS_EC2_AUTO_SCALE_GROUP_OUTPUT_MAPPINGS
+/]
+
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_EC2_EBS_RESOURCE_TYPE
+    mappings=AWS_EC2_EBS_VOLUME_OUTPUT_MAPPINGS
+/]
 
 [#function getInitConfig configSetName configKeys=[] ]
     [#local configSet = [] ]

--- a/providers/aws/services/ecs/resource.ftl
+++ b/providers/aws/services/ecs/resource.ftl
@@ -41,7 +41,7 @@
         }
     }]
 
-[#local mappings =
+[#assign ecsMappings =
     {
         AWS_ECS_RESOURCE_TYPE : ECS_OUTPUT_MAPPINGS,
         AWS_ECS_SERVICE_RESOURCE_TYPE : ECS_SERVICE_OUTPUT_MAPPINGS,
@@ -49,7 +49,7 @@
     }
 ]
 
-[#list mappings as type, mappings]
+[#list ecsMappings as type, mappings]
     [@addOutputMapping 
         provider=AWS_PROVIDER
         resourceType=type

--- a/providers/aws/services/ecs/resource.ftl
+++ b/providers/aws/services/ecs/resource.ftl
@@ -41,13 +41,21 @@
         }
     }]
 
-[#assign outputMappings +=
+[#local mappings =
     {
         AWS_ECS_RESOURCE_TYPE : ECS_OUTPUT_MAPPINGS,
         AWS_ECS_SERVICE_RESOURCE_TYPE : ECS_SERVICE_OUTPUT_MAPPINGS,
         AWS_ECS_TASK_RESOURCE_TYPE : ECS_TASK_OUTPUT_MAPPINGS
     }
 ]
+
+[#list mappings as type, mappings]
+    [@addOutputMapping 
+        provider=AWS_PROVIDER
+        resourceType=type
+        mappings=mappings
+    /]
+[/#list]
 
 [#assign metricAttributes +=
     {

--- a/providers/aws/services/efs/resource.ftl
+++ b/providers/aws/services/efs/resource.ftl
@@ -22,12 +22,17 @@
     }
 ]
 
-[#assign outputMappings +=
-    {
-        AWS_EFS_RESOURCE_TYPE : EFS_OUTPUT_MAPPINGS,
-        AWS_EFS_MOUNTTARGET_RESOURCE_TYPE : EFS_MOUNTTARGET_MAPPINGS
-    }
-]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_EFS_RESOURCE_TYPE
+    mappings=EFS_OUTPUT_MAPPINGS
+/]
+
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_EFS_MOUNTTARGET_RESOURCE_TYPE
+    mappings=EFS_MOUNTTARGET_MAPPINGS
+/]
 
 [#macro createEFS id name tier component encrypted kmsKeyId]
     [@cfResource

--- a/providers/aws/services/es/resource.ftl
+++ b/providers/aws/services/es/resource.ftl
@@ -16,11 +16,12 @@
         }
     }
 ]
-[#assign outputMappings +=
-    {
-        AWS_ES_RESOURCE_TYPE : ES_OUTPUT_MAPPINGS
-    }
-]
+
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_ES_RESOURCE_TYPE
+    mappings=ES_OUTPUT_MAPPINGS
+/]
 
 [#assign metricAttributes +=
     {

--- a/providers/aws/services/iam/resource.ftl
+++ b/providers/aws/services/iam/resource.ftl
@@ -45,11 +45,11 @@
         }
     }
 ]
-[#assign outputMappings +=
-    {
-        AWS_IAM_ROLE_RESOURCE_TYPE : ROLE_OUTPUT_MAPPINGS
-    }
-]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_IAM_ROLE_RESOURCE_TYPE
+    mappings=ROLE_OUTPUT_MAPPINGS
+/]
 
 [#macro createRole
             id
@@ -118,8 +118,8 @@
         }
     }
 ]
-[#assign outputMappings +=
-    {
-        AWS_IAM_USER_RESOURCE_TYPE : USER_OUTPUT_MAPPINGS
-    }
-]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_IAM_USER_RESOURCE_TYPE
+    mappings=USER_OUTPUT_MAPPINGS
+/]

--- a/providers/aws/services/kinesis/resource.ftl
+++ b/providers/aws/services/kinesis/resource.ftl
@@ -11,11 +11,11 @@
     }
 ]
 
-[#assign outputMappings +=
-    {
-        AWS_KINESIS_FIREHOSE_STREAM_RESOURCE_TYPE : KINESIS_FIREHOSE_STREAM_OUTPUT_MAPPINGS
-    }
-]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_KINESIS_FIREHOSE_STREAM_RESOURCE_TYPE
+    mappings=KINESIS_FIREHOSE_STREAM_OUTPUT_MAPPINGS
+/]
 
 [#assign metricAttributes +=
     {

--- a/providers/aws/services/kms/resource.ftl
+++ b/providers/aws/services/kms/resource.ftl
@@ -13,11 +13,11 @@
         }
     }
 ]
-[#assign outputMappings +=
-    {
-        AWS_CMK_RESOURCE_TYPE : CMK_OUTPUT_MAPPINGS
-    }
-]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_CMK_RESOURCE_TYPE
+    mappings=CMK_OUTPUT_MAPPINGS
+/]
 
 [#macro createCMK id description statements rotateKeys=true outputId=""]
     [@cfResource

--- a/providers/aws/services/lambda/resource.ftl
+++ b/providers/aws/services/lambda/resource.ftl
@@ -54,14 +54,14 @@
     }
 ]
 
-[#local mappings =
+[#assign lambdaMappings =
     {
         AWS_LAMBDA_FUNCTION_RESOURCE_TYPE : LAMBDA_FUNCTION_OUTPUT_MAPPINGS,
         AWS_LAMBDA_PERMISSION_RESOURCE_TYPE : LAMBDA_PERMISSION_OUTPUT_MAPPINGS,
         AWS_LAMBDA_EVENT_SOURCE_TYPE : LAMBDA_EVENT_SOURCE_MAPPINGS
     }
 ]
-[#list mappings as type, mappings]
+[#list lambdaMappings as type, mappings]
     [@addOutputMapping 
         provider=AWS_PROVIDER
         resourceType=type

--- a/providers/aws/services/lambda/resource.ftl
+++ b/providers/aws/services/lambda/resource.ftl
@@ -54,13 +54,21 @@
     }
 ]
 
-[#assign outputMappings +=
+[#local mappings =
     {
         AWS_LAMBDA_FUNCTION_RESOURCE_TYPE : LAMBDA_FUNCTION_OUTPUT_MAPPINGS,
         AWS_LAMBDA_PERMISSION_RESOURCE_TYPE : LAMBDA_PERMISSION_OUTPUT_MAPPINGS,
         AWS_LAMBDA_EVENT_SOURCE_TYPE : LAMBDA_EVENT_SOURCE_MAPPINGS
     }
 ]
+[#list mappings as type, mappings]
+    [@addOutputMapping 
+        provider=AWS_PROVIDER
+        resourceType=type
+        mappings=mappings
+    /]
+[/#list]
+
 [#macro createLambdaFunction id settings roleId securityGroupIds=[] subnetIds=[] dependencies=""]
     [@cfResource
         id=id

--- a/providers/aws/services/lb/resource.ftl
+++ b/providers/aws/services/lb/resource.ftl
@@ -53,7 +53,7 @@
     }
 ]
 
-[#assign outputMappings +=
+[#local mappings =
     {
         AWS_LB_RESOURCE_TYPE : LB_OUTPUT_MAPPINGS,
         AWS_ALB_RESOURCE_TYPE : LB_OUTPUT_MAPPINGS,
@@ -65,6 +65,14 @@
         AWS_ALB_TARGET_GROUP_RESOURCE_TYPE : ALB_TARGET_GROUP_OUTPUT_MAPPINGS
     }
 ]
+
+[#list mappings as type, mappings]
+    [@addOutputMapping 
+        provider=AWS_PROVIDER
+        resourceType=type
+        mappings=mappings
+    /]
+[/#list]
 
 [#assign metricAttributes +=
     {

--- a/providers/aws/services/lb/resource.ftl
+++ b/providers/aws/services/lb/resource.ftl
@@ -53,7 +53,7 @@
     }
 ]
 
-[#local mappings =
+[#local lbMappings =
     {
         AWS_LB_RESOURCE_TYPE : LB_OUTPUT_MAPPINGS,
         AWS_ALB_RESOURCE_TYPE : LB_OUTPUT_MAPPINGS,
@@ -66,7 +66,7 @@
     }
 ]
 
-[#list mappings as type, mappings]
+[#list lbMappings as type, mappings]
     [@addOutputMapping 
         provider=AWS_PROVIDER
         resourceType=type

--- a/providers/aws/services/rds/resource.ftl
+++ b/providers/aws/services/rds/resource.ftl
@@ -16,11 +16,11 @@
         }
     }
 ]
-[#assign outputMappings +=
-    {
-        AWS_RDS_RESOURCE_TYPE : RDS_OUTPUT_MAPPINGS
-    }
-]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_RDS_RESOURCE_TYPE
+    mappings=RDS_OUTPUT_MAPPINGS
+/]
 
 [#assign metricAttributes +=
     {

--- a/providers/aws/services/resource.ftl
+++ b/providers/aws/services/resource.ftl
@@ -112,9 +112,6 @@
         )]
 [/#function]
 
-[#-- Output mappings object is extended dynamically by each resource type --]
-[#assign outputMappings = {} ]
-
 [#-- Metric Dimensions are extended dynamically by each resouce type --]
 [#assign metricAttributes = {}]
 
@@ -154,15 +151,14 @@
         isPartOfCurrentDeploymentUnit(resourceId)]
         [#if attributeType?has_content]
             [#local resourceType = getResourceType(resourceId) ]
-            [#if outputMappings[resourceType]?? ]
-                [#local mapping = outputMappings[getResourceType(resourceId)][attributeType] ]
-                [#if (mapping.Attribute)?has_content]
-                    [#return
-                        {
-                            "Fn::GetAtt" : [resourceId, mapping.Attribute]
-                        }
-                    ]
-                [/#if]
+            [#local mapping = getOutputMappings(AWS_PROVIDER, resourceType, attributeType)]
+            [#if (mapping.Attribute)?has_content]
+                [#return
+                    {
+                        "Fn::GetAtt" : [resourceId, mapping.Attribute]
+                    }
+                ]
+            [/#if]
             [#else]
                 [#return
                     {

--- a/providers/aws/services/s3/resource.ftl
+++ b/providers/aws/services/s3/resource.ftl
@@ -285,11 +285,11 @@
     }
 ]
 
-[#assign outputMappings +=
-    {
-        AWS_S3_RESOURCE_TYPE : S3_OUTPUT_MAPPINGS
-    }
-]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_S3_RESOURCE_TYPE
+    mappings=S3_OUTPUT_MAPPINGS
+/]
 
 [#macro createS3Bucket id name tier="" component=""
                         lifecycleRules=[]

--- a/providers/aws/services/sns/resource.ftl
+++ b/providers/aws/services/sns/resource.ftl
@@ -13,11 +13,11 @@
         }
     }
 ]
-[#assign outputMappings +=
-    {
-        AWS_SNS_TOPIC_RESOURCE_TYPE : SNS_TOPIC_OUTPUT_MAPPINGS
-    }
-]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_SNS_TOPIC_RESOURCE_TYPE
+    mappings=SNS_TOPIC_OUTPUT_MAPPINGS
+/]
 
 [#assign metricAttributes +=
     {

--- a/providers/aws/services/sqs/resource.ftl
+++ b/providers/aws/services/sqs/resource.ftl
@@ -19,11 +19,11 @@
         }
     }
 ]
-[#assign outputMappings +=
-    {
-        AWS_SQS_RESOURCE_TYPE : SQS_OUTPUT_MAPPINGS
-    }
-]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_SQS_RESOURCE_TYPE
+    mappings=SQS_OUTPUT_MAPPINGS
+/]
 
 [#assign metricAttributes +=
     {

--- a/providers/aws/services/ssm/resource.ftl
+++ b/providers/aws/services/ssm/resource.ftl
@@ -15,12 +15,16 @@
         }
     }
 ]
-[#assign outputMappings +=
-    {
-        AWS_SSM_DOCUMENT_RESOURCE_TYPE : AWS_SSM_DOCUMENT_OUTPUT_MAPPINGS,
-        AWS_SSM_MAINTENANCE_WINDOW_RESOURCE_TYPE : AWS_SSM_MAINTENANCE_WINDOW_OUTPUT_MAPPINGS
-    }
-]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_SSM_DOCUMENT_RESOURCE_TYPE
+    mappings=AWS_SSM_DOCUMENT_OUTPUT_MAPPINGS
+/]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_SSM_MAINTENANCE_WINDOW_RESOURCE_TYPE
+    mappings=AWS_SSM_MAINTENANCE_WINDOW_OUTPUT_MAPPINGS
+/]
 
 [#macro createSSMDocument id content tags documentType="" dependencies="" ]
     [@cfResource

--- a/providers/aws/services/vpc/resource.ftl
+++ b/providers/aws/services/vpc/resource.ftl
@@ -295,11 +295,11 @@
         }
     }
 ]
-[#assign outputMappings +=
-    {
-        AWS_EIP_RESOURCE_TYPE : EIP_OUTPUT_MAPPINGS
-    }
-]
+[@addOutputMapping 
+    provider=AWS_PROVIDER
+    resourceType=AWS_EIP_RESOURCE_TYPE
+    mappings=EIP_OUTPUT_MAPPINGS
+/]
 
 [#macro createEIP
             id


### PR DESCRIPTION
This PR addresses the following:
- Output Mappings previously being only instantiated as an empty object within the AWS provider. This prevented other providers from working as they could not merge with an object that didn't exist.
- In order to share the instantiation of the object across providers, this was moved into generation/engine/output.ftl.
- to avoid the potential for conflicting outputMappings between providers, a new macro and function were created to access this object, and incorporate a new object tier for provider.

1. macro - addOutputMapping
2. function - getOutputMappings

The macro will simply add an output mapping to the current providers tier. This has retroactively been applied across AWS resources.

The function is capable of retrieving the mappings for a whole provider, for a whole resource, or a single attribute dependent on the specificity of the function call.

The resultant outputMappings object will look like this:
```
{
  provider : { 
    resource : { 
      Mappings 
    }
  }
}
```
