### PR TITLE
<feature> distinctInstance placement constraint for ECS Tasks

### DIFF
--- a/providers/aws/services/ecs/resource.ftl
+++ b/providers/aws/services/ecs/resource.ftl
@@ -284,6 +284,15 @@
             dependencies=""
     ]
 
+    [#-- define an array of constraints --]
+    [#-- for potential support of "memberOf" type placement constraint --]
+    [#local placementConstraints = [] ]
+    [#if placement.DistinctInstance]
+        [#local placementConstraints += [{
+            "Type" : "distinctInstance"
+        }]]
+    [/#if]
+
     [@cfResource
         id=id
         type="AWS::ECS::Service"
@@ -329,6 +338,11 @@
             attributeIfContent(
                 "NetworkConfiguration",
                 networkConfiguration
+            ) +
+            attributeIfTrue(
+                "PlacementConstraints",
+                placementConstraints?size > 0,
+                placementConstraints
             )
         dependencies=dependencies
         outputs=ECS_SERVICE_OUTPUT_MAPPINGS

--- a/providers/shared/components/ecs/id.ftl
+++ b/providers/shared/components/ecs/id.ftl
@@ -336,6 +336,12 @@
                         "Values" : [ "", "daemon"],
                         "Description" : "How to place containers on the cluster",
                         "Default" : ""
+                    },
+                    {
+                        "Names" : "DistinctInstance",
+                        "Type" : BOOLEAN_TYPE,
+                        "Description" : "Each task is running on a different container instance when true",
+                        "Default" : true
                     }
                 ]
             },


### PR DESCRIPTION
Set a placement constraint with type `distinctInstance` to a ECS services when MultiAZ is enabled so each task is running on a different container instance.