### PR TITLE
<fix> ECS task schedules and useRef lookup

### DIFF
--- a/providers/aws/services/resource.ftl
+++ b/providers/aws/services/resource.ftl
@@ -158,7 +158,7 @@
                         "Fn::GetAtt" : [resourceId, mapping.Attribute]
                     }
                 ]
-            [#else]
+            [#elseif !(mapping.UseRef)!false ]
                 [#return
                     {
                         "Mapping" : "COTFatal: Unknown Resource Type",


### PR DESCRIPTION
A couple of minor fixes 

- Add ECS task schedule Role back in 
- Move subnet lookup to handle scheduled tasks which don't use aws vpc 
- Fix for getOutputMappings when use Ref is set on an output which isn't the REF_ATTRIBUTE_TYPE