### PR TITLE
migrated shared resources functions to the shared provider.

### DIFF
--- a/providers/aws/services/resource.ftl
+++ b/providers/aws/services/resource.ftl
@@ -84,34 +84,6 @@
     ]
 [/#function]
 
-[#-- Is a resource part of a deployment unit --]
-[#function isPartOfDeploymentUnit resourceId deploymentUnit deploymentUnitSubset]
-    [#local resourceObject = getStackOutputObject(AWS_PROVIDER, resourceId)]
-    [#local
-        currentDeploymentUnit =
-            deploymentUnit +
-            deploymentUnitSubset?has_content?then(
-                "-" + deploymentUnitSubset?lower_case,
-                ""
-            )
-    ]
-    [#return !(resourceObject?has_content &&
-                (resourceObject.DeploymentUnit != currentDeploymentUnit))]
-[/#function]
-
-[#-- Is a resource part of the current deployment unit --]
-[#function isPartOfCurrentDeploymentUnit resourceId]
-    [#return
-        isPartOfDeploymentUnit(
-            resourceId,
-            commandLineOptions.Deployment.Unit.Name,
-            (ignoreDeploymentUnitSubsetInOutputs!false)?then(
-                "",
-                commandLineOptions.Deployment.Unit.Subset!""
-            )
-        )]
-[/#function]
-
 [#-- Metric Dimensions are extended dynamically by each resouce type --]
 [#assign metricAttributes = {}]
 

--- a/providers/shared/services/resource.ftl
+++ b/providers/shared/services/resource.ftl
@@ -1,0 +1,30 @@
+[#ftl]
+
+[#-- Is a resource part of a deployment unit --]
+[#function isPartOfDeploymentUnit resourceId deploymentUnit deploymentUnitSubset]
+  [#local resourceObject = getStackOutputObject(commandLineOptions.Deployment.Provider, resourceId)]
+  [#local 
+    currentDeploymentUnit =
+      deploymentUnit +
+      deploymentUnitSubset?has_content?then(
+        "-" + deploymentUnitSubset?lower_case,
+        ""
+      )
+  ]
+  [#return !(resourceObject?has_content &&
+    (resourceObject.DeploymentUnit != currentDeploymentUnit))]
+[/#function]
+
+[#-- Is a resource part of the current deployment unit --]
+[#function isPartOfCurrentDeploymentUnit resourceId]
+  [#return
+    isPartOfDeploymentUnit(
+      resourceId,
+      commandLineOptions.Deployment.Unit.Name,
+      (ignoreDeploymentUnitSubsetInOutputs!false)?then(
+        "",
+        commandLineOptions.Deployment.Unit.Subset!""
+      )
+    )
+  ]
+[/#function]

--- a/providers/shared/services/resource.ftl
+++ b/providers/shared/services/resource.ftl
@@ -2,7 +2,7 @@
 
 [#-- Is a resource part of a deployment unit --]
 [#function isPartOfDeploymentUnit resourceId deploymentUnit deploymentUnitSubset]
-  [#local resourceObject = getStackOutputObject(commandLineOptions.Deployment.Provider, resourceId)]
+  [#local resourceObject = getStackOutputObject(commandLineOptions.Deployment.Provider.Name, resourceId)]
   [#local 
     currentDeploymentUnit =
       deploymentUnit +


### PR DESCRIPTION
This PR addresses the need for any provider to be able to check to see if a given resource is apart of the current deployment. Previously these functions were within the AWS provider, however with a small change to use a provider lookup instead of a hardcoded value, this can be used for any provider.