### PR TITLE
<fix> Ecs task dependencies

### DIFF
--- a/providers/aws/components/ecs/setup.ftl
+++ b/providers/aws/components/ecs/setup.ftl
@@ -1164,13 +1164,14 @@
                         "RoleArn" : getReference(scheduleTaskRoleId, ARN_ATTRIBUTE_TYPE)
                     }]
 
-                    [@createScheduleEventRule
-                        id=scheduleRuleId
-                        enabled=scheduleEnabled
-                        scheduleExpression=schedule.Expression
-                        targetParameters=targetParameters
-                        dependencies=fnId
-                    /]
+                    [#if deploymentSubsetRequired("ecs", true) ]
+                        [@createScheduleEventRule
+                            id=scheduleRuleId
+                            enabled=scheduleEnabled
+                            scheduleExpression=schedule.Expression
+                            targetParameters=targetParameters
+                        /]
+                    [/#if]
 
                     [#local ruleCleanupScript += [
                         "       delete_cloudwatch_event" +


### PR DESCRIPTION
Scheduled task doesn't need depedents as they are implied.
Make sure the schdeduled event resource is only deployed for the subset