### PR TITLE
<fix>IAM user managed policy

### DIFF
--- a/providers/aws/components/user/setup.ftl
+++ b/providers/aws/components/user/setup.ftl
@@ -87,30 +87,34 @@
         /]
     [/#if]
 
-    [#if deploymentSubsetRequired(USER_COMPONENT_TYPE, true)]
 
-        [#if _context.Policy?has_content]
-            [#local policyId = formatDependentPolicyId(userId)]
-            [@createPolicy
+    [#if _context.Policy?has_content]
+        [#local policyId = formatDependentPolicyId(userId)]
+        [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(policyId)]
+            [@createManagedPolicy
                 id=policyId
                 name=_context.Name
                 statements=_context.Policy
                 users=userId
             /]
         [/#if]
+    [/#if]
 
-        [#local linkPolicies = getLinkTargetsOutboundRoles(_context.Links) ]
+    [#local linkPolicies = getLinkTargetsOutboundRoles(_context.Links) ]
 
-        [#if linkPolicies?has_content]
-            [#local policyId = formatDependentPolicyId(userId, "links")]
-            [@createPolicy
+    [#if linkPolicies?has_content]
+        [#local linkPolicyId = formatDependentPolicyId(userId, "links")]
+        [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(linkPolicyId)]
+            [@createManagedPolicy
                 id=policyId
                 name="links"
                 statements=linkPolicies
                 users=userId
             /]
-        [/#if]
+         [/#if]
+    [/#if]
 
+    [#if deploymentSubsetRequired(USER_COMPONENT_TYPE, true)]
         [@cfResource
             id=userId
             type="AWS::IAM::User"

--- a/providers/aws/services/iam/resource.ftl
+++ b/providers/aws/services/iam/resource.ftl
@@ -19,60 +19,31 @@
     ]
 [/#function]
 
-[#macro createPolicy id name statements roles="" users="" groups="" dependencies=[] statementGrouping=4 statementLegnthLimit=800 ]
+[#macro createPolicy id name statements roles="" users="" groups="" dependencies=[] ]
+    [@cfResource
+        id=id
+        type="AWS::IAM::Policy"
+        properties=
+            getPolicyDocument(statements, name ) +
+            attributeIfContent("Users", users, getReferences(users)) +
+            attributeIfContent("Roles", roles, getReferences(roles))
+        dependencies=dependencies
+    /]
+[/#macro]
 
-    [#local policyDocuments = []]
-    [#-- IAM has a policy size limit of 2048 characters --]
-    [#-- Need to make sure we break up the polciy document to meet this limit  --]
-    [#-- It also has a limit of 10 policies per role or user so we can't break it up to all statements --]
-
-    [@debug message="TopLevel size" context=getJSON(statements)?length enabled=true /]
-    [#if getJSON(statements)?length gte statementLegnthLimit ]
-        [#list statements?chunk(statementGrouping) as groupStatements ]
-            [#if getJSON(groupStatements)?length gte statementLegnthLimit ]
-                [#list groupStatements?chunk(statementGrouping / 2) as subGroupStatements ]
-                    [#local policyDocuments +=
-                            [
-                                {
-                                    "Id" : formatId( id, groupStatements?index, subGroupStatements?index),
-                                    "Name" : formatName( name, groupStatements?index, subGroupStatements?index) ,
-                                    "Statements" : subGroupStatements
-                                }
-                            ]]
-                [/#list]
-            [#else]
-                [#local policyDocuments +=
-                    [
-                        {
-                            "Id" : formatId(id, groupStatements?index),
-                            "Name" : formatName(name, groupStatements?index ),
-                            "Statements" : groupStatements
-                        }
-                    ]]
-            [/#if]
-        [/#list]
-    [#else]
-        [#local policyDocuments +=
-            [
-                {
-                    "Id" : id,
-                    "Name" : name,
-                    "Statements" : statements
-                }
-            ]]
-    [/#if]
-
-    [#list policyDocuments as policyDocument ]
-        [@cfResource
-            id=policyDocument.Id
-            type="AWS::IAM::Policy"
-            properties=
-                getPolicyDocument(policyDocument.Statements, policyDocument.Name ) +
-                attributeIfContent("Users", users, getReferences(users)) +
-                attributeIfContent("Roles", roles, getReferences(roles))
-            dependencies=dependencies
-        /]
-    [/#list]
+[#macro createManagedPolicy id name statements roles="" users="" groups="" dependencies=[] ]
+    [@cfResource
+        id=id
+        type="AWS::IAM::ManagedPolicy"
+        properties=
+            {
+                "Description" : id
+            } +
+            getPolicyDocument(statements, name ) +
+            attributeIfContent("Users", users, getReferences(users)) +
+            attributeIfContent("Roles", roles, getReferences(roles))
+        dependencies=dependencies
+    /]
 [/#macro]
 
 [#assign ROLE_OUTPUT_MAPPINGS =


### PR DESCRIPTION
A continuation on the user policy limit stuff. It turns out that the character limit isn't per inline policy it as actually all inline polices on a user cannot be above 2048 characters. So however they are grouped it doesn't apply 

This policy limit is different for different IAM types ( groups, roles and users ) with users being the most restricted. 

However managed policies enforce their own limit ( 6000 characters)  rather than being dependent on the IAM type. So for users we should try a managed policy instead of inline 