### PR TITLE
<fix>Add default Security profile for RDS

### DIFF
--- a/providers/aws/inputsources/shared/masterdata.ftl
+++ b/providers/aws/inputsources/shared/masterdata.ftl
@@ -2077,6 +2077,9 @@
           "HTTPSProfile": "TLSv1",
           "WAFProfile": "OWASP2017",
           "WAFValueSet": "default"
+        },
+        "db" : {
+          "SSLCertificateAuthority" : "rds-ca-2019"
         }
       }
     },


### PR DESCRIPTION
Add default rds profile for rds into aws masterdata. Seems to have been lost along the way