### PR TITLE
<fix> IAM remove default output for policy

### DIFF
--- a/engine/inputdata/stackOutput.ftl
+++ b/engine/inputdata/stackOutput.ftl
@@ -16,7 +16,7 @@
     "Attributes" : [
         {
             "Names" : "Account",
-            "Type" : STRING_TYPE       
+            "Type" : STRING_TYPE
         },
         {
             "Names" : "Region",
@@ -49,20 +49,20 @@
 
 [#function getStackOutputObject provider id deploymentUnit="" region="" account="" ]
     [#-- Build the stack outputs list --]
-    [#local outputMacroOptions = 
+    [#local outputMacroOptions =
         [
             [ provider, "input", commandLineOptions.Input.Source, "stackoutput" ],
             [ SHARED_PROVIDER, "input", commandLineOptions.Input.Source, "stackoutput" ]
         ]]
-    
+
     [#local outputMacro = getFirstDefinedDirective(outputMacroOptions)]
     [#if outputMacro?has_content ]
-        [@(.vars[outputMacro]) 
-            id=id 
-            deploymentUnit=deploymentUnit 
-            region=region 
-            account=account 
-            level=level 
+        [@(.vars[outputMacro])
+            id=id
+            deploymentUnit=deploymentUnit
+            region=region
+            account=account
+            level=level
         /]
     [#else]
         [@debug
@@ -73,13 +73,13 @@
     [/#if]
 
     [#-- Apply default filters based on provider --]
-    [#local filterFunctionOptions = 
+    [#local filterFunctionOptions =
         [
             [ provider, "input", commandLineOptions.Input.Source, "stackoutput", "filter" ],
             [ SHARED_PROVIDER, "input", commandLineOptions.Input.Source, "stackoutput", "filter" ]
         ]
-    ] 
-    
+    ]
+
     [#local outputFilter = {
             "Account" : account,
             "Region" : region,
@@ -152,7 +152,7 @@
 [#macro internalMergeStackOutputs data ]
     [#if data?has_content ]
         [#list data as content ]
-            [#assign stackOutputsList = 
+            [#assign stackOutputsList =
                 combineEntities(
                     stackOutputsList,
                     [ getCompositeObject( stackOutputConfiguration.Attributes, content) ],

--- a/providers/aws/services/iam/resource.ftl
+++ b/providers/aws/services/iam/resource.ftl
@@ -28,6 +28,7 @@
             attributeIfContent("Users", users, getReferences(users)) +
             attributeIfContent("Roles", roles, getReferences(roles))
         dependencies=dependencies
+        outputs={}
     /]
 [/#macro]
 

--- a/providers/shared/services/resource.ftl
+++ b/providers/shared/services/resource.ftl
@@ -3,7 +3,7 @@
 [#-- Is a resource part of a deployment unit --]
 [#function isPartOfDeploymentUnit resourceId deploymentUnit deploymentUnitSubset]
   [#local resourceObject = getStackOutputObject(commandLineOptions.Deployment.Provider.Name, resourceId)]
-  [#local 
+  [#local
     currentDeploymentUnit =
       deploymentUnit +
       deploymentUnitSubset?has_content?then(


### PR DESCRIPTION
Don't use the default stack output mappings for IAM policy. Policy should always be deployed with a role