### PR TITLE
Update function for multi-provider

### DIFF
--- a/providers/shared/components/baseline/id.ftl
+++ b/providers/shared/components/baseline/id.ftl
@@ -6,7 +6,7 @@
     [#return formatSegmentResourceId(SEED_RESOURCE_TYPE)]
 [/#function]
 
-[#function getBaselineComponentIds links ]
+[#function getBaselineComponentIds links cmk="cmk" ssh="ec2KeyPair" oai="originAccessId"]
     [#local ids = {}]
     [#list links as linkName, linkTarget ]
         [#if !linkTarget?has_content]
@@ -29,13 +29,29 @@
             [#case BASELINE_KEY_COMPONENT_TYPE ]
                 [#switch linkTargetSolution.Engine ]
                     [#case "cmk" ]
-                        [#local ids += { linkName, linkTargetResources["cmk"].Id }]
+                        [#if linkTargetResources[cmk].Id?has_content]
+                            [#local ids += { linkName, linkTargetResources[cmk].Id }]
+                        [#else]
+                            [@fatal
+                                message="CMK resource has not been found. A CMK is a mandatory baseline resource."
+                                context=linkTarget
+                            /]
+                        [/#if]
                         [#break]
                     [#case "ssh" ]
-                        [#local ids += { linkName, linkTargetResources["ec2KeyPair"].Id }]
+                        [#if linkTargetResources[ssh].Id?has_content]
+                            [#local ids += { linkName, linkTargetResources[ssh].Id }]
+                        [#else]
+                            [@fatal
+                                message="SSH resource has not been found. A SSH resource is a mandatory baseline resource."
+                                context=linkTarget
+                            /]
+                        [/#if]
                         [#break]
                     [#case "oai"]
-                        [#local ids += { linkName, linkTargetResources["originAccessId"].Id }]
+                        [#if linkTargetResources[oai].Id?has_content]
+                            [#local ids += { linkName, linkTargetResources[oai].Id }]
+                        [/#if]
                         [#break]
                 [/#switch]
                 [#break]


### PR DESCRIPTION
Update function for multi-provider, which may pass own resource names and not have the same Engines available. Defaults to existing AWS configuration without further amendments.

CMK and SSH are set to be mandatory, whilst oai is optional. If the Engine exists but not the resource, no error will be given.