### PR TITLE
<Feature> Make API Gateway viewer policy configurable

### DIFF
--- a/providers/aws/components/apigateway/setup.ftl
+++ b/providers/aws/components/apigateway/setup.ftl
@@ -375,7 +375,8 @@
                             endpointType == "REGIONAL",
                             []
                         ),
-                    solution.CloudFront.Compress) ]
+                    solution.CloudFront.Compress,
+                    securityProfile.ProtocolPolicy) ]
             [#local restrictions = {} ]
             [#if solution.CloudFront.CountryGroups?has_content]
                 [#list asArray(solution.CloudFront.CountryGroups) as countryGroup]

--- a/providers/aws/inputsources/shared/masterdata.ftl
+++ b/providers/aws/inputsources/shared/masterdata.ftl
@@ -2068,6 +2068,7 @@
         },
         "apigateway": {
           "HTTPSProfile": "TLSv1",
+          "ProtocolPolicy" : "redirect-to-https",
           "WAFProfile": "OWASP2017",
           "WAFValueSet": "default"
         },

--- a/providers/aws/masterData.json
+++ b/providers/aws/masterData.json
@@ -2111,6 +2111,7 @@
       },
       "apigateway": {
         "HTTPSProfile": "TLSv1",
+        "ProtocolPolicy" : "redirect-to-https",
         "WAFProfile": "OWASP2017",
         "WAFValueSet": "default"
       },

--- a/providers/aws/services/cf/resource.ftl
+++ b/providers/aws/services/cf/resource.ftl
@@ -22,13 +22,13 @@
     }
 ]
 
-[@addOutputMapping 
+[@addOutputMapping
     provider=AWS_PROVIDER
     resourceType=AWS_CLOUDFRONT_DISTRIBUTION_RESOURCE_TYPE
     mappings=CF_OUTPUT_MAPPINGS
 /]
 
-[@addOutputMapping 
+[@addOutputMapping
     provider=AWS_PROVIDER
     resourceType=AWS_CLOUDFRONT_ACCESS_ID_RESOURCE_TYPE
     mappings=CF_ACCESS_ID_OUTPUT_MAPPINGS
@@ -183,7 +183,8 @@
     ]
 [/#function]
 
-[#function getCFAPIGatewayCacheBehaviour origin customHeaders=[] compress=true]
+[#function getCFAPIGatewayCacheBehaviour origin customHeaders=[] compress=true viewerProtocolPolicy="redirect-to-https"
+]
     [#return
         getCFCacheBehaviour(
             origin,
@@ -223,7 +224,9 @@
                 ] + customHeaders,
                 "QueryString" : true
             },
-            compress
+            compress,
+            [],
+            viewerProtocolPolicy
         )
     ]
 [/#function]


### PR DESCRIPTION
Add viewer protocol policy configured via the security profile, with the
default being redirect (via the master data).