### PR TITLE
<feature> Lambda Create new version on deploy

### DIFF
--- a/providers/aws/components/lambda/state.ftl
+++ b/providers/aws/components/lambda/state.ftl
@@ -26,7 +26,14 @@
     [#local solution = occurrence.Configuration.Solution ]
 
     [#local id = formatResourceId(AWS_LAMBDA_FUNCTION_RESOURCE_TYPE, core.Id)]
-    [#local versionId = formatResourceId(AWS_LAMBDA_VERSION_RESOURCE_TYPE, core.Id )]
+
+    [#local versionOutputId = formatResourceId(AWS_LAMBDA_VERSION_RESOURCE_TYPE, core.Id) ]
+
+    [#if solution.FixedCodeVersion.NewVersionOnDeploy ]
+        [#local versionId = formatId(versionOutputId, runId )]
+    [#else]
+        [#local versionId = versionOutputId]
+    [/#if]
 
     [#local region = getExistingReference(id, REGION_ATTRIBUTE_TYPE)!regionId]
 
@@ -70,14 +77,15 @@
                 "version",
                 fixedCodeVersion,
                 {
-                    "Id" : versionId,
+                    "Id" : versionOutputId,
+                    "ResourceId" : versionId,
                     "Type" : AWS_LAMBDA_VERSION_RESOURCE_TYPE
                 }
             ),
             "Attributes" : {
                 "REGION" : region,
                 "ARN" : valueIfTrue(
-                            getExistingReference( versionId ),
+                            getExistingReference(versionOutputId),
                             fixedCodeVersion
                             formatArn(
                                 regionObject.Partition,

--- a/providers/aws/services/lambda/resource.ftl
+++ b/providers/aws/services/lambda/resource.ftl
@@ -62,7 +62,7 @@
     }
 ]
 [#list lambdaMappings as type, mappings]
-    [@addOutputMapping 
+    [@addOutputMapping
         provider=AWS_PROVIDER
         resourceType=type
         mappings=mappings
@@ -114,7 +114,8 @@
             targetId
             codeHash=""
             description=""
-            dependencies="" ]
+            dependencies=""
+            outputId="" ]
     [@cfResource
         id=id
         type="AWS::Lambda::Version"
@@ -131,6 +132,7 @@
                 codeHash
             )
         outputs=LAMBDA_VERSION_OUTPUT_MAPPINGS
+        outputId=outputId
         dependencies=dependencies
     /]
 [/#macro]

--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -162,6 +162,11 @@
                 "Names" : "FixedCodeVersion",
                 "Children" : [
                     {
+                        "Names" : "NewVersionOnDeploy",
+                        "Description" : "Create a new version on each deployment",
+                        "Default" : false
+                    },
+                    {
                         "Names" : "CodeHash",
                         "Description" : "A sha256 hash of the code zip file",
                         "Default" : ""


### PR DESCRIPTION
When using Lambda@Edge you can only use versions of lambda functions. You can't use the $LATEST version which is normally implied 

This PR adds a configuration option on Lambda functions which creates a new version of a lambda function on each deployment. This is useful when you have fragment based lambda functions which have been updated 