### PR TITLE
<feature> RDS Advanced Monitoring

### DIFF
--- a/providers/aws/components/db/id.ftl
+++ b/providers/aws/components/db/id.ftl
@@ -6,6 +6,7 @@
     resourceGroup=DEFAULT_RESOURCE_GROUP
     services=
         [
+            AWS_IDENTITY_SERVICE,
             AWS_CLOUDWATCH_SERVICE,
             AWS_KEY_MANAGEMENT_SERVICE,
             AWS_RELATIONAL_DATABASE_SERVICE,

--- a/providers/aws/components/db/state.ftl
+++ b/providers/aws/components/db/state.ftl
@@ -66,7 +66,17 @@
                     "Name" : core.FullName,
                     "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
                 }
-            },
+            } +
+            solution.Monitoring.DetailedMetrics.Enabled?then(
+                {
+                    "monitoringRole" : {
+                        "Id" : formatResourceId(AWS_IAM_ROLE_RESOURCE_TYPE, core.Id, "monitoring" ),
+                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                        "IncludeInDeploymentState" : false
+                    }
+                },
+                {}
+            ),
             "Attributes" : {
                 "ENGINE" : engine,
                 "FQDN" : fqdn,

--- a/providers/aws/services/rds/resource.ftl
+++ b/providers/aws/services/rds/resource.ftl
@@ -16,7 +16,7 @@
         }
     }
 ]
-[@addOutputMapping 
+[@addOutputMapping
     provider=AWS_PROVIDER
     resourceType=AWS_RDS_RESOURCE_TYPE
     mappings=RDS_OUTPUT_MAPPINGS
@@ -53,6 +53,11 @@
     optionGroupId
     snapshotId
     securityGroupId
+    enhancedMonitoring
+    enhancedMonitoringInterval
+    performanceInsights
+    performanceInsightsRetention
+    enhancedMonitoringRoleId=""
     tier=""
     component=""
     dependencies=""
@@ -111,26 +116,41 @@
                 "MasterUsername": masterUsername,
                 "MasterUserPassword": masterPassword
             }
+        ) +
+        performanceInsights?then(
+            {
+                "EnablePerformanceInsights" : performanceInsights,
+                "PerformanceInsightsRetentionPeriod" : performanceInsightsRetention,
+                "PerformanceInsightsKMSKeyId" : getReference(kmsKeyId, ARN_ATTRIBUTE_TYPE)
+            },
+            {}
+        ) +
+        enhancedMonitoring?then(
+            {
+                "MonitoringInterval" : enhancedMonitoringInterval,
+                "MonitoringRoleArn" : getReference(enhancedMonitoringRoleId, ARN_ATTRIBUTE_TYPE)
+            },
+            {}
         )
-tags=
-    getCfTemplateCoreTags(
-        name,
-        tier,
-        component)
-outputs=
-    RDS_OUTPUT_MAPPINGS +
-    {
-        DATABASENAME_ATTRIBUTE_TYPE : {
-            "Value" : databaseName
-        }
-    } +
-    attributeIfContent(
-        LASTRESTORE_ATTRIBUTE_TYPE,
-        snapshotId,
+    tags=
+        getCfTemplateCoreTags(
+            name,
+            tier,
+            component)
+    outputs=
+        RDS_OUTPUT_MAPPINGS +
         {
-            "Value" : snapshotId
-        }
-    )
-/]
+            DATABASENAME_ATTRIBUTE_TYPE : {
+                "Value" : databaseName
+            }
+        } +
+        attributeIfContent(
+            LASTRESTORE_ATTRIBUTE_TYPE,
+            snapshotId,
+            {
+                "Value" : snapshotId
+            }
+        )
+    /]
 
 [/#macro]

--- a/providers/shared/components/db/id.ftl
+++ b/providers/shared/components/db/id.ftl
@@ -182,6 +182,48 @@
                 "Description" : "Always create the database from a snapshot",
                 "Type" : BOOLEAN_TYPE,
                 "Default" : false
+            },
+            {
+                "Names" : "Monitoring",
+                "Description" : "Monitoring configuration options",
+                "Children" : [
+                    {
+                        "Names" : "QueryPerformance",
+                        "Description" : "Enable monitoring database query performance",
+                        "Children" : [
+                            {
+                                "Names" : "Enabled",
+                                "Type" : BOOLEAN_TYPE,
+                                "Default" : false
+                            },
+                            {
+                                "Names" : "RetentionPeriod",
+                                "Description" : "How long to keep data for ( days )",
+                                "Values" : [ 7, 731 ],
+                                "Type" : NUMBER_TYPE,
+                                "Default" : 7
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "DetailedMetrics",
+                        "Description" : "Enables detailed metric collection from the database host",
+                        "Children" : [
+                            {
+                                "Names" : "Enabled",
+                                "Type" : BOOLEAN_TYPE,
+                                "Default" : false
+                            },
+                            {
+                                "Names" : "CollectionInterval",
+                                "Description" : "Metric Collection interval ( seconds )",
+                                "Type" : NUMBER_TYPE,
+                                "Values" : [ 0, 1, 5, 10, 15, 30, 60 ],
+                                "Default" : 60
+                            }
+                        ]
+                    }
+                ]
             }
         ]
 /]


### PR DESCRIPTION
Adds the ability to enable the advanced monitoring features for RDS
- QueryPerformance - Enables RDS Performance Insights which provide monitoring details on query impact
- DetailedMetrics - Enables more detailed metrics collection based on an agent installed on the RDS host rather than using the host

Both are disabled by default due to cost restrictions and QueryPerformance is only available on select instance families

QueryPerformance encrypts its data by default so we use the baseline key all the time