### PR TITLE
<fix>support array and single element master exports formats

### DIFF
--- a/aws/runExpoAppPublish.sh
+++ b/aws/runExpoAppPublish.sh
@@ -339,25 +339,25 @@ function main() {
 
     if [[ "${EXPO_ID_OVERRIDE}" != "null" && -n "${EXPO_ID_OVERRIDE}" ]]; then
 
-        jq -c --arg EXPO_ID_OVERRIDE "${EXPO_ID_OVERRIDE}" '[ .[] | .id=$EXPO_ID_OVERRIDE ]' < "${SRC_PATH}/app/dist/master/ios-index.json" > "${tmpdir}/ios-master-expo-override.json"
+        jq -c --arg EXPO_ID_OVERRIDE "${EXPO_ID_OVERRIDE}" '[ if type=="array" then .[] | .id=$EXPO_ID_OVERRIDE else .id=$EXPO_ID_OVERRIDE end ]' < "${SRC_PATH}/app/dist/master/ios-index.json" > "${tmpdir}/ios-master-expo-override.json"
         mv "${tmpdir}/ios-master-expo-override.json" "${SRC_PATH}/app/dist/master/ios-index.json"
 
-        jq -c --arg EXPO_ID_OVERRIDE "${EXPO_ID_OVERRIDE}" '[ .[] | .id=$EXPO_ID_OVERRIDE ]' < "${SRC_PATH}/app/dist/master/android-index.json" > "${tmpdir}/android-master-expo-override.json"
+        jq -c --arg EXPO_ID_OVERRIDE "${EXPO_ID_OVERRIDE}" '[ if type=="array" then .[] | .id=$EXPO_ID_OVERRIDE else .id=$EXPO_ID_OVERRIDE end ]' < "${SRC_PATH}/app/dist/master/android-index.json" > "${tmpdir}/android-master-expo-override.json"
         mv "${tmpdir}/android-master-expo-override.json" "${SRC_PATH}/app/dist/master/android-index.json"
 
     fi
 
     if [[ -n "${SENTRY_RELEASE_NAME}" ]]; then
       info "Override revisionId in master export to match the corresponding sentry release name ${SENTRY_RELEASE_NAME}"
-      jq -c --arg REVISION_ID "${SENTRY_RELEASE_NAME}" '[ .[] | .revisionId=$REVISION_ID ]' < "${SRC_PATH}/app/dist/master/ios-index.json" > "${tmpdir}/ios-expo-override.json"
+      jq -c --arg REVISION_ID "${SENTRY_RELEASE_NAME}" '[ if type=="array" then .[] | .revisionId=$REVISION_ID else .revisionId=$REVISION_ID end ]' < "${SRC_PATH}/app/dist/master/ios-index.json" > "${tmpdir}/ios-expo-override.json"
       mv "${tmpdir}/ios-expo-override.json" "${SRC_PATH}/app/dist/master/ios-index.json"
 
-      jq -c --arg REVISION_ID "${SENTRY_RELEASE_NAME}" '[ .[] | .revisionId=$REVISION_ID ]' < "${SRC_PATH}/app/dist/master/android-index.json" > "${tmpdir}/android-expo-override.json"
+      jq -c --arg REVISION_ID "${SENTRY_RELEASE_NAME}" '[ if type=="array" then .[] | .revisionId=$REVISION_ID else .revisionId=$REVISION_ID end ]' < "${SRC_PATH}/app/dist/master/android-index.json" > "${tmpdir}/android-expo-override.json"
       mv "${tmpdir}/android-expo-override.json" "${SRC_PATH}/app/dist/master/android-index.json"
 
     fi
 
-    aws --region "${AWS_REGION}" s3 sync "${SRC_PATH}/app/dist/master/" "s3://${PUBLIC_BUCKET}/${PUBLIC_PREFIX}" || return $? 
+    aws --region "${AWS_REGION}" s3 sync "${SRC_PATH}/app/dist/master/" "s3://${PUBLIC_BUCKET}/${PUBLIC_PREFIX}" || return $?
   fi
 
    DETAILED_HTML_QR_MESSAGE="<h4>Expo Client App QR Codes</h4> <p>Use these codes to load the app through the Expo Client</p>"

--- a/aws/runExpoAppPublish.sh
+++ b/aws/runExpoAppPublish.sh
@@ -339,20 +339,20 @@ function main() {
 
     if [[ "${EXPO_ID_OVERRIDE}" != "null" && -n "${EXPO_ID_OVERRIDE}" ]]; then
 
-        jq -c --arg EXPO_ID_OVERRIDE "${EXPO_ID_OVERRIDE}" '[ if type=="array" then .[] | .id=$EXPO_ID_OVERRIDE else .id=$EXPO_ID_OVERRIDE end ]' < "${SRC_PATH}/app/dist/master/ios-index.json" > "${tmpdir}/ios-master-expo-override.json"
+        jq -c --arg EXPO_ID_OVERRIDE "${EXPO_ID_OVERRIDE}" 'if type=="array" then [ .[] | .id=$EXPO_ID_OVERRIDE ] else .id=$EXPO_ID_OVERRIDE end' < "${SRC_PATH}/app/dist/master/ios-index.json" > "${tmpdir}/ios-master-expo-override.json"
         mv "${tmpdir}/ios-master-expo-override.json" "${SRC_PATH}/app/dist/master/ios-index.json"
 
-        jq -c --arg EXPO_ID_OVERRIDE "${EXPO_ID_OVERRIDE}" '[ if type=="array" then .[] | .id=$EXPO_ID_OVERRIDE else .id=$EXPO_ID_OVERRIDE end ]' < "${SRC_PATH}/app/dist/master/android-index.json" > "${tmpdir}/android-master-expo-override.json"
+        jq -c --arg EXPO_ID_OVERRIDE "${EXPO_ID_OVERRIDE}" 'if type=="array" then [ .[] | .id=$EXPO_ID_OVERRIDE ] else .id=$EXPO_ID_OVERRIDE end' < "${SRC_PATH}/app/dist/master/android-index.json" > "${tmpdir}/android-master-expo-override.json"
         mv "${tmpdir}/android-master-expo-override.json" "${SRC_PATH}/app/dist/master/android-index.json"
 
     fi
 
     if [[ -n "${SENTRY_RELEASE_NAME}" ]]; then
       info "Override revisionId in master export to match the corresponding sentry release name ${SENTRY_RELEASE_NAME}"
-      jq -c --arg REVISION_ID "${SENTRY_RELEASE_NAME}" '[ if type=="array" then .[] | .revisionId=$REVISION_ID else .revisionId=$REVISION_ID end ]' < "${SRC_PATH}/app/dist/master/ios-index.json" > "${tmpdir}/ios-expo-override.json"
+      jq -c --arg REVISION_ID "${SENTRY_RELEASE_NAME}" 'if type=="array" then [ .[] | .revisionId=$REVISION_ID ] else .revisionId=$REVISION_ID end' < "${SRC_PATH}/app/dist/master/ios-index.json" > "${tmpdir}/ios-expo-override.json"
       mv "${tmpdir}/ios-expo-override.json" "${SRC_PATH}/app/dist/master/ios-index.json"
 
-      jq -c --arg REVISION_ID "${SENTRY_RELEASE_NAME}" '[ if type=="array" then .[] | .revisionId=$REVISION_ID else .revisionId=$REVISION_ID end ]' < "${SRC_PATH}/app/dist/master/android-index.json" > "${tmpdir}/android-expo-override.json"
+      jq -c --arg REVISION_ID "${SENTRY_RELEASE_NAME}" 'if type=="array" then [ .[] | .revisionId=$REVISION_ID ] else .revisionId=$REVISION_ID end' < "${SRC_PATH}/app/dist/master/android-index.json" > "${tmpdir}/android-expo-override.json"
       mv "${tmpdir}/android-expo-override.json" "${SRC_PATH}/app/dist/master/android-index.json"
 
     fi


### PR DESCRIPTION
This PR introduce a fix for overrides in expo master export. Depends on a number of SDK export file might be an array or a single element.