### PR TITLE
<fix> APIGateway Occurrence Naming

### DIFF
--- a/providers/aws/components/apigateway/state.ftl
+++ b/providers/aws/components/apigateway/state.ftl
@@ -70,7 +70,14 @@ created in either case.
     [#local apiName = formatComponentFullName(core.Tier, core.Component, occurrence)]
 
     [#local stageId = formatResourceId(AWS_APIGATEWAY_STAGE_RESOURCE_TYPE, core.Id)]
-    [#local stageName = core.Version.Name]
+    [#local stageName = valueIfContent(
+                            core.Version.Name,
+                            core.Version.Name,
+                            valueIfContent(
+                                core.Instance.Name,
+                                core.Instance.Name,
+                                core.Name
+                            ))]
 
     [#local serviceName = "execute-api" ]
 


### PR DESCRIPTION
With the ability to not include the stage in custom Domain names on API Gateways the stage might not been seen on an APIGateway

This gets around an issue at the moment where you have to set a version on an APIGateway to get the stage name to be populated. 
