### PR TITLE
<feature> Add Aurora cluster support

### DIFF
--- a/providers/aws/components/db/setup.ftl
+++ b/providers/aws/components/db/setup.ftl
@@ -457,11 +457,6 @@
                     tags=rdsTags
                     deletionPolicy=deletionPolicy
                     updateReplacePolicy=updateReplacePolicy
-                    enhancedMonitoring=solution.Monitoring.DetailedMetrics.Enabled
-                    enhancedMonitoringInterval=solution.Monitoring.DetailedMetrics.CollectionInterval
-                    enhancedMonitoringRoleId=monitoringRoleId!""
-                    performanceInsights=solution.Monitoring.QueryPerformance.Enabled
-                    performanceInsightsRetention=solution.Monitoring.QueryPerformance.RetentionPeriod
                 /]
 
                 [#list resources["dbInstances"]?values as dbInstance ]
@@ -485,6 +480,11 @@
                         tags=rdsTags
                         deletionPolicy=""
                         updateReplacePolicy=""
+                        enhancedMonitoring=solution.Monitoring.DetailedMetrics.Enabled
+                        enhancedMonitoringInterval=solution.Monitoring.DetailedMetrics.CollectionInterval
+                        enhancedMonitoringRoleId=monitoringRoleId!""
+                        performanceInsights=solution.Monitoring.QueryPerformance.Enabled
+                        performanceInsightsRetention=solution.Monitoring.QueryPerformance.RetentionPeriod
                     /]
                 [/#list]
 
@@ -516,6 +516,11 @@
                         deletionPolicy=deletionPolicy
                         updateReplacePolicy=updateReplacePolicy
                         tags=rdsTags
+                        enhancedMonitoring=solution.Monitoring.DetailedMetrics.Enabled
+                        enhancedMonitoringInterval=solution.Monitoring.DetailedMetrics.CollectionInterval
+                        enhancedMonitoringRoleId=monitoringRoleId!""
+                        performanceInsights=solution.Monitoring.QueryPerformance.Enabled
+                        performanceInsightsRetention=solution.Monitoring.QueryPerformance.RetentionPeriod
                     /]
             [/#if]
         [/#if]

--- a/providers/aws/components/db/state.ftl
+++ b/providers/aws/components/db/state.ftl
@@ -4,50 +4,135 @@
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
-    [#local id = formatResourceId(AWS_RDS_RESOURCE_TYPE, core.Id) ]
-
     [#local engine = occurrence.Configuration.Solution.Engine]
     [#local engineVersion = occurrence.Configuration.Solution.EngineVersion]
+
+    [#local auroraCluster = false ]
 
     [#switch engine]
         [#case "mysql"]
             [#local family = "mysql" + engineVersion]
+            [#local scheme = "mysql" ]
             [#break]
         [#case "postgres" ]
             [#local family = "postgres" + engineVersion]
+            [#local scheme = "postgres" ]
+            [#break]
+        [#case "aurora-postgresql" ]
+            [#local family = "aurora-postgresql" + engineVersion]
+            [#local scheme = "postgres" ]
+            [#local auroraCluster = true ]
             [#break]
         [#default]
             [#local family = engine + engineVersion]
+            [#local scheme = engine ]
     [/#switch]
 
+    [#if auroraCluster ]
+        [#local id = formatResourceId(AWS_RDS_CLUSTER_RESOURCE_TYPE, core.Id) ]
+    [#else]
+        [#local id = formatResourceId(AWS_RDS_RESOURCE_TYPE, core.Id) ]
+    [/#if]
+
     [#local fqdn = getExistingReference(id, DNS_ATTRIBUTE_TYPE)]
+
     [#local port = getExistingReference(id, PORT_ATTRIBUTE_TYPE)]
     [#local name = getExistingReference(id, DATABASENAME_ATTRIBUTE_TYPE)]
     [#local region = getExistingReference(id, REGION_ATTRIBUTE_TYPE)]
     [#local encryptionScheme = (solution.GenerateCredentials.EncryptionScheme)?has_content?then(
                         solution.GenerateCredentials.EncryptionScheme?ensure_ends_with(":"),
                         "" )]
+    [#if auroraCluster ]
+        [#local readfqdn = getExistingReference(id, "read" + DNS_ATTRIBUTE_TYPE )]
+    [/#if]
 
     [#if solution.GenerateCredentials.Enabled ]
         [#local masterUsername = solution.GenerateCredentials.MasterUserName ]
         [#local masterPassword = getExistingReference(id, GENERATEDPASSWORD_ATTRIBUTE_TYPE)?ensure_starts_with(encryptionScheme) ]
         [#local url = getExistingReference(id, URL_ATTRIBUTE_TYPE)?ensure_starts_with(encryptionScheme) ]
+
+        [#if auroraCluster ]
+            [#local readUrl = getExistingReference(id, "read" + URL_ATTRIBUTE_TYPE)?ensure_starts_with(encryptionScheme) ]
+        [/#if]
     [#else]
         [#-- don't flag an error if credentials missing but component is not enabled --]
         [#local masterUsername = getOccurrenceSettingValue(occurrence, "MASTER_USERNAME", !solution.Enabled) ]
         [#local masterPassword = getOccurrenceSettingValue(occurrence, "MASTER_PASSWORD", !solution.Enabled) ]
-        [#local url = engine + "://" + masterUsername + ":" + masterPassword + "@" + fqdn + ":" + port + "/" + name]
+        [#local url = scheme + "://" + masterUsername + ":" + masterPassword + "@" + fqdn + ":" + port + "/" + name]
+
+        [#if auroraCluster ]
+            [#local readUrl = scheme + "://" + masterUsername + ":" + masterPassword + "@" + readfqdn + ":" + port + "/" + name ]
+        [/#if]
     [/#if]
 
-    [#assign componentState =
-        {
-            "Resources" : {
+    [#local dbResources = {}]
+
+    [#if auroraCluster ]
+        [#local dbResources += {
+            "dbCluster" : {
+                "Id" : id,
+                "Name" : core.FullName,
+                "Type" : AWS_RDS_CLUSTER_RESOURCE_TYPE,
+                "Monitored" : true
+            },
+            "dbClusterParamGroup" : {
+                "Id" : formatResourceId(AWS_RDS_CLUSTER_PARAMETER_GROUP_RESOURCE_TYPE, core.Id, replaceAlphaNumericOnly(family, "X") ),
+                "Family" : family,
+                "Type" : AWS_RDS_CLUSTER_PARAMETER_GROUP_RESOURCE_TYPE
+            }
+        }]
+
+        [#if multiAZ!false ]
+            [#local resourceZones = zones ]
+        [#else]
+            [#local resourceZones = [zones[0]] ]
+        [/#if]
+
+        [#local processor = getProcessor(
+                                        occurrence,
+                                        "db",
+                                        solution.ProcessorProfile)]
+        [#if processor.DesiredPerZone?has_content ]
+                [#local instancesPerZone = processor.DesiredPerZone ]
+        [#else]
+            [#local processorCounts = getProcessorCounts(processor, multiAZ ) ]
+            [#local instancesPerZone = (processorCounts.DesiredCount / resourceZones?size)?round ]
+        [/#if]
+
+        [#list resourceZones as resourceZone ]
+            [#list 1..instancesPerZone as instanceId ]
+                [#local dbResources = mergeObjects(
+                    dbResources,
+                    {
+                        "dbInstances" : {
+                            "dbInstance" + resourceZone.Id + instanceId : {
+                                "Id" : formatId( AWS_RDS_RESOURCE_TYPE, core.Id, resourceZone.Id, instanceId),
+                                "Name" : formatName( core.FullName, resourceZone.Name, instanceId ),
+                                "AvailabilityZone" : resourceZone.AWSZone,
+                                "Type" : AWS_RDS_RESOURCE_TYPE
+                            }
+                        }
+                    }
+                )]
+            [/#list]
+        [/#list]
+    [#else]
+        [#local dbResources = mergeObjects(
+            dbResources,
+            {
                 "db" : {
                     "Id" : id,
                     "Name" : core.FullName,
                     "Type" : AWS_RDS_RESOURCE_TYPE,
                     "Monitored" : true
-                },
+                }
+            }
+        )]
+    [/#if]
+
+    [#assign componentState =
+        {
+            "Resources" : {
                 "subnetGroup" : {
                     "Id" : formatResourceId(AWS_RDS_SUBNET_GROUP_RESOURCE_TYPE, core.Id),
                     "Type" : AWS_RDS_SUBNET_GROUP_RESOURCE_TYPE
@@ -76,9 +161,12 @@
                     }
                 },
                 {}
-            ),
+            ) + ,
+            dbResources,
             "Attributes" : {
                 "ENGINE" : engine,
+                "TYPE" : auroraCluster?then("cluster", "instance"),
+                "SCHEME" : scheme,
                 "FQDN" : fqdn,
                 "PORT" : port,
                 "NAME" : name,
@@ -87,7 +175,14 @@
                 "PASSWORD" : masterPassword,
                 "INSTANCEID" : core.FullName,
                 "REGION" : region
-            },
+            } +
+            valueIfTrue(
+                {
+                    "READ_FQDN" : readfqdn!"",
+                    "READ_URL" : readUrl!""
+                },
+                auroraCluster
+            ),
             "Roles" : {
                 "Inbound" : {},
                 "Outbound" : {}

--- a/providers/aws/components/db/state.ftl
+++ b/providers/aws/components/db/state.ftl
@@ -96,7 +96,16 @@
                 [#local instancesPerZone = processor.DesiredPerZone ]
         [#else]
             [#local processorCounts = getProcessorCounts(processor, multiAZ ) ]
-            [#local instancesPerZone = (processorCounts.DesiredCount / resourceZones?size)?round ]
+            [#if processorCounts.DesiredCount?has_content ]
+                [#local instancesPerZone = ( processorCounts.DesiredCount / resourceZones?size)?round ]
+            [#else]
+                [@fatal
+                    message="Invalid Processor Profile for Cluster"
+                    context=processor
+                    detail="Add Autoscaling processing profile"
+                /]
+                [#return]
+            [/#if]
         [/#if]
 
         [#list resourceZones as resourceZone ]
@@ -161,7 +170,7 @@
                     }
                 },
                 {}
-            ) + ,
+            ) +
             dbResources,
             "Attributes" : {
                 "ENGINE" : engine,

--- a/providers/aws/inputsources/shared/masterdata.ftl
+++ b/providers/aws/inputsources/shared/masterdata.ftl
@@ -1251,6 +1251,59 @@
             "Device": "/dev/sdp",
             "Size": "30"
           }
+        },
+        "ECS": {},
+        "ElasticSearch": {},
+        "ComputeCluster": {},
+        "bastion": {}
+      }
+    },
+    "Processors": {
+      "default": {
+        "NAT": {
+          "Processor": "t2.micro"
+        },
+        "bastion": {
+          "Processor": "t2.micro"
+        },
+        "EC2": {
+          "Processor": "t2.micro"
+        },
+        "EMR": {
+          "Processor": "m4.large",
+          "DesiredCorePerZone": 1,
+          "DesiredTaskPerZone": 1
+        },
+        "ComputeCluster": {
+          "Processor": "t2.micro",
+          "MinPerZone": 1,
+          "MaxPerZone": 1,
+          "DesiredPerZone": 1
+        },
+        "ECS": {
+          "Processor": "t2.medium",
+          "MinPerZone": 1,
+          "MaxPerZone": 1,
+          "DesiredPerZone": 1
+        },
+        "ElastiCache": {
+          "Processor": "cache.t2.micro",
+          "CountPerZone": 1
+        },
+        "db": {
+          "Processor": "db.t2.small",
+          "MinPerZone": 1,
+          "MaxPerZone": 1,
+          "DesiredPerZone": 1
+        },
+        "ElasticSearch": {
+          "Processor": "m3.medium.elasticsearch",
+          "CountPerZone": 1
+        },
+        "service" : {
+          "DesiredPerZone" : 1,
+          "MinPerZone" : 1,
+          "MaxPerZone" : 1
         }
       },
       "ECS": {},

--- a/providers/aws/inputsources/shared/masterdata.ftl
+++ b/providers/aws/inputsources/shared/masterdata.ftl
@@ -1257,59 +1257,6 @@
         "ComputeCluster": {},
         "bastion": {}
       }
-    },
-    "Processors": {
-      "default": {
-        "NAT": {
-          "Processor": "t2.micro"
-        },
-        "bastion": {
-          "Processor": "t2.micro"
-        },
-        "EC2": {
-          "Processor": "t2.micro"
-        },
-        "EMR": {
-          "Processor": "m4.large",
-          "DesiredCorePerZone": 1,
-          "DesiredTaskPerZone": 1
-        },
-        "ComputeCluster": {
-          "Processor": "t2.micro",
-          "MinPerZone": 1,
-          "MaxPerZone": 1,
-          "DesiredPerZone": 1
-        },
-        "ECS": {
-          "Processor": "t2.medium",
-          "MinPerZone": 1,
-          "MaxPerZone": 1,
-          "DesiredPerZone": 1
-        },
-        "ElastiCache": {
-          "Processor": "cache.t2.micro",
-          "CountPerZone": 1
-        },
-        "db": {
-          "Processor": "db.t2.small",
-          "MinPerZone": 1,
-          "MaxPerZone": 1,
-          "DesiredPerZone": 1
-        },
-        "ElasticSearch": {
-          "Processor": "m3.medium.elasticsearch",
-          "CountPerZone": 1
-        },
-        "service" : {
-          "DesiredPerZone" : 1,
-          "MinPerZone" : 1,
-          "MaxPerZone" : 1
-        }
-      },
-      "ECS": {},
-      "ElasticSearch": {},
-      "ComputeCluster": {},
-      "bastion": {}
     }
   },
   "Processors": {
@@ -1345,7 +1292,10 @@
         "CountPerZone": 1
       },
       "db": {
-        "Processor": "db.t2.small"
+        "Processor": "db.t2.small",
+        "MinPerZone": 1,
+        "MaxPerZone": 1,
+        "DesiredPerZone": 1
       },
       "ElasticSearch": {
         "Processor": "m3.medium.elasticsearch",

--- a/providers/aws/services/rds/id.ftl
+++ b/providers/aws/services/rds/id.ftl
@@ -7,6 +7,9 @@
 [#assign AWS_RDS_OPTION_GROUP_RESOURCE_TYPE = "rdsOptionGroup" ]
 [#assign AWS_RDS_SNAPSHOT_RESOURCE_TYPE = "rdsSnapShot" ]
 
+[#assign AWS_RDS_CLUSTER_RESOURCE_TYPE = "rdsCluster" ]
+[#assign AWS_RDS_CLUSTER_PARAMETER_GROUP_RESOURCE_TYPE = "rdsClusterParameterGroup" ]
+
 [#function formatDependentRDSSnapshotId resourceId extensions... ]
     [#return formatDependentResourceId(
                 "snapshot",
@@ -20,4 +23,3 @@
                 resourceId,
                 extensions)]
 [/#function]
-

--- a/providers/aws/services/rds/resource.ftl
+++ b/providers/aws/services/rds/resource.ftl
@@ -22,12 +22,43 @@
     mappings=RDS_OUTPUT_MAPPINGS
 /]
 
+[#assign RDS_CLUSTER_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        DNS_ATTRIBUTE_TYPE : {
+            "Attribute" : "Endpoint.Address"
+        },
+        PORT_ATTRIBUTE_TYPE : {
+            "Attribute" : "Endpoint.Port"
+        },
+        "read" + DNS_ATTRIBUTE_TYPE : {
+            "Attribute" : "ReadEndpoint.Address"
+        }
+    }
+
+]
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_RDS_CLUSTER_RESOURCE_TYPE
+    mappings=RDS_CLUSTER_OUTPUT_MAPPINGS
+/]
+
 [#assign metricAttributes +=
     {
         AWS_RDS_RESOURCE_TYPE : {
             "Namespace" : "AWS/RDS",
             "Dimensions" : {
                 "DBInstanceIdentifier" : {
+                    "Output" : ""
+                }
+            }
+        },
+        AWS_RDS_CLUSTER_RESOURCE_TYPE : {
+            "Namespace" : "AWS/RDS",
+            "Dimensions" : {
+                "DBClusterIdentifier" : {
                     "Output" : ""
                 }
             }
@@ -39,32 +70,34 @@
     engine
     engineVersion
     processor
-    size
-    port
-    multiAZ
-    encrypted
-    kmsKeyId
-    masterUsername
-    masterPassword
-    databaseName
-    retentionPeriod
+    availabilityZone
     subnetGroupId
     parameterGroupId
     optionGroupId
-    snapshotId
     securityGroupId
     enhancedMonitoring
     enhancedMonitoringInterval
     performanceInsights
     performanceInsightsRetention
-    enhancedMonitoringRoleId=""
-    tier=""
-    component=""
+    tags
+    clusterMember=false
+    clusterId=""
+    multiAZ=false
+    encrypted=false
+    kmsKeyId=""
+    masterUsername=""
+    masterPassword=""
+    databaseName=""
+    port=""
+    retentionPeriod=""
+    size=""
+    snapshotArn=""
     dependencies=""
     outputId=""
     allowMajorVersionUpgrade=true
     autoMinorVersionUpgrade=true
     deleteAutomatedBackups=true
+    enhancedMonitoringRoleId=""
     deletionPolicy="Snapshot"
     updateReplacePolicy="Snapshot"
 ]
@@ -78,43 +111,74 @@
             "Engine": engine,
             "EngineVersion": engineVersion,
             "DBInstanceClass" : processor,
-            "AllocatedStorage": size,
             "AutoMinorVersionUpgrade": autoMinorVersionUpgrade,
             "AllowMajorVersionUpgrade" : allowMajorVersionUpgrade,
             "DeleteAutomatedBackups" : deleteAutomatedBackups,
-            "StorageType" : "gp2",
-            "Port" : port,
-            "BackupRetentionPeriod" : retentionPeriod,
-            "DBInstanceIdentifier": name,
-            "DBSubnetGroupName": subnetGroupId,
-            "DBParameterGroupName": parameterGroupId,
-            "OptionGroupName": optionGroupId,
-            "VPCSecurityGroups": [securityGroupId]
+            "DBSubnetGroupName": getReference(subnetGroupId),
+            "DBParameterGroupName": getReference(parameterGroupId),
+            "OptionGroupName": getReference(optionGroupId)
         } +
-        multiAZ?then(
+        valueIfTrue(
+            {
+                "AllocatedStorage": size,
+                "StorageType" : "gp2",
+                "BackupRetentionPeriod" : retentionPeriod,
+                "DBInstanceIdentifier": name,
+                "VPCSecurityGroups": asArray( getReference(securityGroupId)),
+                "Port" : port
+            },
+            ( !clusterMember ),
+            {
+                "DBClusterIdentifier" : getReference(clusterId)
+            }
+
+        ) +
+        valueIfTrue(
             {
                 "MultiAZ": true
             },
+            ( multiAZ && !clusterMember ),
             {
-                "AvailabilityZone" : zones[0].AWSZone
+                "AvailabilityZone" : availabilityZone
             }
         ) +
-        (!(snapshotId?has_content) && encrypted)?then(
+        valueIfTrue(
             {
                 "StorageEncrypted" : true,
                 "KmsKeyId" : getReference(kmsKeyId, ARN_ATTRIBUTE_TYPE)
             },
-            {}
+            ( (!(snapshotArn?has_content) && encrypted) && !clusterMember )
         ) +
         [#-- If restoring from a snapshot the database details will be provided by the snapshot --]
-        (snapshotId?has_content)?then(
+        valueIfTrue(
+            valueIfTrue(
+                {
+                    "DBSnapshotIdentifier" : snapshotArn
+                },
+                snapshotArn?has_content,
+                {
+                    "DBName" : databaseName,
+                    "MasterUsername": masterUsername,
+                    "MasterUserPassword": masterPassword
+                }
+            ),
+            !clusterMember
+        )
+    tags=tags
+    outputs=
+        RDS_OUTPUT_MAPPINGS +
+        attributeIfContent(
+            DATABASENAME_ATTRIBUTE_TYPE,
+            databaseName,
             {
-                "DBSnapshotIdentifier" : snapshotId
-            },
+                "Value" : databaseName
+            }
+        ) +
+        attributeIfContent(
+            LASTRESTORE_ATTRIBUTE_TYPE,
+            snapshotArn,
             {
-                "DBName" : databaseName,
-                "MasterUsername": masterUsername,
-                "MasterUserPassword": masterPassword
+                "Value" : snapshotArn
             }
         ) +
         performanceInsights?then(
@@ -152,5 +216,81 @@
             }
         )
     /]
+[/#macro]
 
+[#macro createRDSCluster id name
+    engine
+    engineVersion
+    port
+    encrypted
+    kmsKeyId
+    masterUsername
+    masterPassword
+    databaseName
+    retentionPeriod
+    subnetGroupId
+    parameterGroupId
+    snapshotArn
+    securityGroupId
+    tags
+    dependencies=""
+    outputId=""
+    deletionPolicy="Snapshot"
+    updateReplacePolicy="Snapshot"
+]
+    [#local availabilityZones = []]
+    [#list zones as zone ]
+        [#local availabilityZones += [ zone.AWSZone ] ]
+    [/#list]
+
+    [@cfResource
+        id=id
+        type="AWS::RDS::DBCluster"
+        deletionPolicy=deletionPolicy
+        updateReplacePolicy=updateReplacePolicy
+        properties=
+            {
+                "DBClusterIdentifier" : name,
+                "DBClusterParameterGroupName" : parameterGroupId,
+                "DBSubnetGroupName" : subnetGroupId,
+                "Port" : port,
+                "VpcSecurityGroupIds" : asArray(securityGroupId),
+                "AvailabilityZones" : availabilityZones,
+                "Engine" : engine,
+                "EngineVersion" : engineVersion,
+                "BackupRetentionPeriod" : retentionPeriod
+            } +
+            (!(snapshotArn?has_content) && encrypted)?then(
+                {
+                    "StorageEncrypted" : true,
+                    "KmsKeyId" : getReference(kmsKeyId, ARN_ATTRIBUTE_TYPE)
+                },
+                {}
+            ) +
+            [#-- If restoring from a snapshot the database details will be provided by the snapshot --]
+            (snapshotArn?has_content)?then(
+                {
+                    "DBSnapshotIdentifier" : snapshotArn
+                },
+                {
+                    "DatabaseName" : databaseName,
+                    "MasterUsername": masterUsername,
+                    "MasterUserPassword": masterPassword
+                }
+            )
+        tags=tags
+        outputs=RDS_CLUSTER_OUTPUT_MAPPINGS +
+        {
+            DATABASENAME_ATTRIBUTE_TYPE : {
+                "Value" : databaseName
+            }
+        } +
+        attributeIfContent(
+            LASTRESTORE_ATTRIBUTE_TYPE,
+            snapshotArn,
+            {
+                "Value" : snapshotArn
+            }
+        )
+    /]
 [/#macro]

--- a/providers/aws/services/rds/resource.ftl
+++ b/providers/aws/services/rds/resource.ftl
@@ -163,23 +163,6 @@
                 }
             ),
             !clusterMember
-        )
-    tags=tags
-    outputs=
-        RDS_OUTPUT_MAPPINGS +
-        attributeIfContent(
-            DATABASENAME_ATTRIBUTE_TYPE,
-            databaseName,
-            {
-                "Value" : databaseName
-            }
-        ) +
-        attributeIfContent(
-            LASTRESTORE_ATTRIBUTE_TYPE,
-            snapshotArn,
-            {
-                "Value" : snapshotArn
-            }
         ) +
         performanceInsights?then(
             {
@@ -196,23 +179,21 @@
             },
             {}
         )
-    tags=
-        getCfTemplateCoreTags(
-            name,
-            tier,
-            component)
+    tags=tags
     outputs=
         RDS_OUTPUT_MAPPINGS +
-        {
-            DATABASENAME_ATTRIBUTE_TYPE : {
+        attributeIfContent(
+            DATABASENAME_ATTRIBUTE_TYPE,
+            databaseName,
+            {
                 "Value" : databaseName
             }
-        } +
+        ) +
         attributeIfContent(
             LASTRESTORE_ATTRIBUTE_TYPE,
-            snapshotId,
+            snapshotArn,
             {
-                "Value" : snapshotId
+                "Value" : snapshotArn
             }
         )
     /]

--- a/providers/shared/components/db/id.ftl
+++ b/providers/shared/components/db/id.ftl
@@ -224,6 +224,29 @@
                         ]
                     }
                 ]
+            },
+            {
+                "Names" : "Cluster",
+                "Description" : "Cluster specific configuration when using a clustered database engine",
+                "Children" : [
+                    {
+                        "Names" : "Parameters",
+                        "Description" : "Cluster level database parameters",
+                        "Subobjects" : true,
+                        "Children" : [
+                            {
+                                "Names" : "Name",
+                                "Type" : STRING_TYPE,
+                                "Mandatory" : true
+                            },
+                            {
+                                "Names" : "Value",
+                                "Type" : [ STRING_TYPE, NUMBER_TYPE, BOOLEAN_TYPE],
+                                "Mandatory" : true
+                            }
+                        ]
+                    }
+                ]
             }
         ]
 /]


### PR DESCRIPTION
Adds support for AWS Aurora as a database engine 

Aurora runs as a cluster of db instances with storage managed by the cluster resource and the instances used to manage the compute resources. You can deploy up to 16 database instances across all AZs in a region 

Support has been setup in this PR for postgres based installations, mysql is available as well but has a long list of extra options that can be configured 

Most of the configuration is managed behind the scenes within the framework with the following configuration options added 

- new engine - aurora-postgresql
- An extra configuration section for cluster level database parameters 
- Desired, Max and Min counts on the processor component - Desired is in the initial release, Min and Max can be added for autoscaling the db instances