### PR TITLE
Service Provider Registration

### DIFF
--- a/aws/manageDeployment.sh
+++ b/aws/manageDeployment.sh
@@ -95,17 +95,19 @@ function register_resource_providers() {
 
   providers=$(cat ${1} | jq -c --raw-output '.resources | map(.type | split("/")[0] ) | unique | .[]')
   
+  return_result=0
+
   for ((i=0; i<${#providers[@]}; i++)); do
     result=$(az provider register --namespace ${providers[i]})
     if [[ -z "${result}" ]]; then
       info "$(succeed_or_fail "succeed") ${providers[i]}"
     else 
       info "$(succeed_or_fail "fail") ${providers[i]}"
-      return 1
+      return_result=1
     fi
   done
 
-  return 0
+  return ${return_result}
 }
 
 function construct_parameter_inputs() {


### PR DESCRIPTION
* Separated out Resource Group and Deployment Group during deployment. Using the same value limits the deployments to 1 resource group per deployment. Specifying the resource group in this way allows you to create or utilise existing resource groups as necessary.

* Removed DEPLOYMENT_GROUP_NAME (-n) as a script option and replaced it with a concatenated value (DEPLOYMENT_NAME) that will make the deployments easily navigated. Specifying both resource group and deployment group is unnecessary.

*Added Service Provider registration during deployment with pretty terminal output.