### PR TITLE
<fix> rds alarm on replace

### DIFF
--- a/providers/aws/components/db/setup.ftl
+++ b/providers/aws/components/db/setup.ftl
@@ -370,6 +370,18 @@
 
                 [@debug message="Monitored resource" context=monitoredResource enabled=false /]
 
+                [#-- when replacing the instance the database is removed so we need to override refrences to keep the alarms around --]
+                [#if monitoredResource.Id == rdsId && (commandLineOptions.Deployment.Unit.Alternative!"") == "replace1" ]
+                    [#local resourceDimensions = [
+                        {
+                            "Name": "DBInstanceIdentifier",
+                            "Value": getExistingReference(rdsId)
+                        }
+                    ]]
+                [#else]
+                    [#local resourceDimensions = getResourceMetricDimensions(monitoredResource, resources) ]
+                [/#if]
+
                 [#switch alert.Comparison ]
                     [#case "Threshold" ]
                         [@createAlarm
@@ -389,8 +401,7 @@
                             reportOK=alert.ReportOk
                             unit=alert.Unit
                             missingData=alert.MissingData
-                            dimensions=getResourceMetricDimensions(monitoredResource, resources)
-                            dependencies=monitoredResource.Id
+                            dimensions=resourceDimensions
                         /]
                     [#break]
                 [/#switch]


### PR DESCRIPTION
As part of #1088 the alarm configuration was moved out of the hibernate so that the alarms weren't recreated which trigged a false trigger 

But this means that during the replace template jobs when the database is removed the reference look ups fail. So we need to do a getExistingReference to get the actual value during a replace1 template generation so that the template can deploy without touching the alarms. 

Also removes the unnecessary dependency on the resource which the REf function provides anyway