### PR TITLE
Added Linking to Shared Network Component

### DIFF
--- a/providers/shared/components/network/id.ftl
+++ b/providers/shared/components/network/id.ftl
@@ -58,6 +58,11 @@
                         "Default" : "10.0.0.0/16"
                     }
                 ]
+            },            
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
             }
         ]
 /]


### PR DESCRIPTION
Azure requires a link between Network and Gateway components. This PR implements the capability to add links to the Network configuration.