### PR TITLE
<Feature> Component type wildcard support in profiles

### DIFF
--- a/providers/shared/deploymentframeworks/default/legacy.ftl
+++ b/providers/shared/deploymentframeworks/default/legacy.ftl
@@ -374,6 +374,7 @@
                     [#-- Apply deployment profile overrides --]
                     [#local occurrenceContexts +=
                         [
+                            (getDeploymentProfile(profiles.Deployment, commandLineOptions.Deployment.Mode)["*"])!{},
                             (getDeploymentProfile(profiles.Deployment, commandLineOptions.Deployment.Mode)[type])!{}
                         ]
                     ]

--- a/providers/shared/deploymentframeworks/default/model.ftl
+++ b/providers/shared/deploymentframeworks/default/model.ftl
@@ -642,6 +642,7 @@
                         attributes,
                         [
                             content,
+                            (getDeploymentProfile(profiles.Deployment, commandLineOptions.Deployment.Mode)["*"])!{},
                             (getDeploymentProfile(profiles.Deployment, commandLineOptions.Deployment.Mode)[type])!{}
                         ])
             }


### PR DESCRIPTION
In a same way that a deployment profile can be made to apply to all
modes via the use of a mode of "\*", add the ability for a deployment
profile to apply to all component types by the user of "\*". This allows
configuration applying to all components sharing a deployment profile to
be separate from that specific to the component type.