### PR TITLE
<Feature> Add external tier for external services

### DIFF
--- a/providers/aws/components/apigateway/state.ftl
+++ b/providers/aws/components/apigateway/state.ftl
@@ -91,7 +91,7 @@ created in either case.
     [#local endpointType       = solution.EndpointType ]
     [#local isEdgeEndpointType = solution.EndpointType == "EDGE" ]
 
-    [#local region = getExistingReference(apiId, REGION_ATTRIBUTE_TYPE)?has_content(
+    [#local region = contentIfContent(
                         getExistingReference(apiId, REGION_ATTRIBUTE_TYPE),
                         regionId
                     )]

--- a/providers/aws/inputsources/shared/masterdata.ftl
+++ b/providers/aws/inputsources/shared/masterdata.ftl
@@ -1381,7 +1381,8 @@
         "ana",
         "mgmt",
         "docs",
-        "gbl"
+        "gbl",
+        "external"
       ]
     }
   },

--- a/providers/aws/masterData.json
+++ b/providers/aws/masterData.json
@@ -1374,7 +1374,8 @@
         "ana",
         "mgmt",
         "docs",
-        "gbl"
+        "gbl",
+        "external"
       ]
     }
   },

--- a/providers/shared/deploymentframeworks/default/legacy.ftl
+++ b/providers/shared/deploymentframeworks/default/legacy.ftl
@@ -91,7 +91,13 @@
         [#return {} ]
     [/#if]
 
-    [#if link.Tier?lower_case == "external"]
+    [#-- Handle external links --]
+    [#-- They are deprecated in favour of an external tier but for now --]
+    [#-- they can still be used, even with an external tier, by explicitly --]
+    [#-- providing the link type --]
+    [#if
+        (link.Tier?lower_case == "external") &&
+        (link.Type?? || (!getTier(link.Tier)?has_content))]
         [#-- If a type is provided, ensure it has been included --]
         [#if link.Type??]
             [@includeComponentConfiguration link.Type /]

--- a/providers/shared/deploymentframeworks/default/model.ftl
+++ b/providers/shared/deploymentframeworks/default/model.ftl
@@ -64,7 +64,9 @@
     [/#if]
 
     [#-- TODO(mfl) remove when external link support superceded by external components --]
-    [#if fullLink.External!false]
+    [#if
+        (fullLink.External!false) &&
+        (fullLink.Type?? || (!getTier(link.Tier)?has_content))]
         [#-- If a type is provided, ensure it has been included --]
         [#if fullLink.Type??]
             [@includeComponentConfiguration fullLink.Type /]


### PR DESCRIPTION
Need to tweak the external link processing to check there isn't actually an external tier. If there is, then assume all external links will be managed via components in the external tier of the solution.

The use of the external tier is now our preferred approach rather than external links. It makes the dependencies much more obvious and the layout of the settings more logical. (Sharing of settings could be done via namespaces but links are a lot more explicit). It also means any generated documentation automatically documents the external dependencies and the values expected for eac external dependency.

We will need to change any components that used to rely on setting the type of the link. They will now need to explicitly look for links to "externalservice" components and check that any required attributes are defined.

For now, if an external link is required even if an external tier is present, set a type on the link.

Also a couple of fixes
- typos for setting namespace management
- a correction to the API gateway logic to manage AWS regions in URLs.