### PR TITLE
<refactor> v2.0.0 restructure of CMDB

### DIFF
--- a/aws/createBlueprint.sh
+++ b/aws/createBlueprint.sh
@@ -29,7 +29,7 @@ where
 
 (o) -i GENERATION_INPUT_SOURCE is the source of input data to use when generating the template
     -h                         shows this text
-(o) -o OUTPUT_DIR              is the directory where the outputs will be saved - defaults to the PRODUCT_INFRASTRUCTURE_DIR
+(o) -o OUTPUT_DIR              is the directory where the outputs will be saved - defaults to the PRODUCT_STATE_DIR
 (o) -p GENERATION_PROVIDER     is the provider to for template generation
 (o) -f GENERATION_FRAMEWORK    is the output framework to use for template generation
 (o) -t GENERATION_TESTCASE     is the test case you would like to generate a template for

--- a/aws/createBuildblueprint.sh
+++ b/aws/createBuildblueprint.sh
@@ -29,7 +29,7 @@ where
 
 (o) -i GENERATION_INPUT_SOURCE is the source of input data to use when generating the template
     -h                         shows this text
-(o) -o OUTPUT_DIR              is the directory where the outputs will be saved - defaults to the PRODUCT_INFRASTRUCTURE_DIR
+(o) -o OUTPUT_DIR              is the directory where the outputs will be saved - defaults to the PRODUCT_STATE_DIR
 (o) -p GENERATION_PROVIDER     is the provider to for template generation
 (o) -f GENERATION_FRAMEWORK    is the output framework to use for template generation
 (o) -s GENERATION_SCENARIOS    is a comma seperated list of framework scenarios to load

--- a/aws/createReference.sh
+++ b/aws/createReference.sh
@@ -75,7 +75,7 @@ function process_template() {
 
   case "${type}" in
     component)
-      cf_dir="${PRODUCT_INFRASTRUCTURE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
+      cf_dir="${PRODUCT_STATE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
       passes=("reference")
 
       pass_level_prefix["reference"]="component-reference"

--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -26,7 +26,7 @@ where
 (o) -i GENERATION_INPUT_SOURCE is the source of input data to use when generating the template - "composite", "mock"
     -h                         shows this text
 (m) -l LEVEL                   is the template level - "blueprint", "account", "segment", "solution" or "application"
-(o) -o OUTPUT_DIR              is the directory where the outputs will be saved - defaults to the PRODUCT_INFRASTRUCTURE_DIR
+(o) -o OUTPUT_DIR              is the directory where the outputs will be saved - defaults to the PRODUCT_STATE_DIR
 (o) -q REQUEST_REFERENCE       is an opaque value to link this template to a triggering request management system
 (o) -r REGION                  is the AWS region identifier
 (m) -u DEPLOYMENT_UNIT         is the deployment unit to be included in the template
@@ -117,7 +117,7 @@ function options() {
   fi
 
   # Contextual Defaults
-  OUTPUT_DIR_DEFAULT="${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
+  OUTPUT_DIR_DEFAULT="${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
   OUTPUT_DIR="${OUTPUT_DIR:-${OUTPUT_DIR_DEFAULT}}"
 
   return 0
@@ -575,23 +575,23 @@ function process_template() {
   # Defaults
   local passes=("template")
   local template_alternatives=("primary")
-  local cf_dir_default="${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
+  local cf_dir_default="${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
   local cf_dir="${OUTPUT_DIR:-${cf_dir_default}}"
 
   case "${level}" in
     blueprint)
-      cf_dir_default="${PRODUCT_INFRASTRUCTURE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
+      cf_dir_default="${PRODUCT_STATE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
       cf_dir="${OUTPUT_DIR:-${cf_dir_default}}"
       ;;
 
     buildblueprint)
       # this is expected to run from an automation context
-      cf_dir_default="${AUTOMATION_DATA_DIR:-"${PRODUCT_INFRASTRUCTURE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"}"
+      cf_dir_default="${AUTOMATION_DATA_DIR:-"${PRODUCT_STATE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"}"
       cf_dir="${OUTPUT_DIR:-${cf_dir_default}}"
       ;;
 
     account)
-      cf_dir_default="${ACCOUNT_INFRASTRUCTURE_DIR}/cf/shared"
+      cf_dir_default="${ACCOUNT_STATE_DIR}/cf/shared"
       cf_dir="${OUTPUT_DIR:-${cf_dir_default}}"
       ;;
 

--- a/aws/runLambda.sh
+++ b/aws/runLambda.sh
@@ -87,7 +87,7 @@ function main() {
     # Create build blueprint
     ${GENERATION_DIR}/createBuildblueprint.sh -u "${DEPLOYMENT_UNIT}"  -o "${AUTOMATION_DATA_DIR}" >/dev/null || return $?
 
-    COT_TEMPLATE_DIR="${PRODUCT_INFRASTRUCTURE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
+    COT_TEMPLATE_DIR="${PRODUCT_STATE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
     BUILD_BLUEPRINT="${COT_TEMPLATE_DIR}/build_blueprint-${DEPLOYMENT_UNIT}-.json"
 
     DEPLOYMENT_UNIT_TYPE="$(jq -r '.Type' < "${BUILD_BLUEPRINT}" )"

--- a/aws/runTask.sh
+++ b/aws/runTask.sh
@@ -120,7 +120,7 @@ checkInSegmentDirectory
 # Generate a blueprint that we can use to find hosting details
 info "Generating blueprint to find details..."
 ${GENERATION_DIR}/createBlueprint.sh >/dev/null || exit $?
-ENV_BLUEPRINT="${PRODUCT_INFRASTRUCTURE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}/blueprint.json"
+ENV_BLUEPRINT="${PRODUCT_STATE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}/blueprint.json"
 
 # allow for undefined instance and versions
 if [[ -n "${COMPONENT_INSTANCE}" ]]; then

--- a/aws/setStackContext.sh
+++ b/aws/setStackContext.sh
@@ -45,7 +45,7 @@ if [[ -n "${DEPLOYMENT_UNIT_SUBSET}" ]]; then
 fi
 case $LEVEL in
     account)
-        CF_DIR="${ACCOUNT_INFRASTRUCTURE_DIR}/cf/shared"
+        CF_DIR="${ACCOUNT_STATE_DIR}/cf/shared"
         PRODUCT_PREFIX="${ACCOUNT}"
         REGION="${ACCOUNT_REGION}"
         REGION_PREFIX="${ACCOUNT_REGION}-"
@@ -59,7 +59,7 @@ case $LEVEL in
                 DEPLOYMENT_UNIT_SUFFIX=""
             fi
         fi
-        
+
         # Simplify stack naming if stack doesn't already exist
         if [[ ! -f "${CF_DIR}/${LEVEL_PREFIX}${DEPLOYMENT_UNIT_PREFIX}${REGION_PREFIX}stack.json" ]]; then
             PRODUCT_PREFIX=""
@@ -70,7 +70,7 @@ case $LEVEL in
         ;;
 
     product)
-        CF_DIR="${PRODUCT_INFRASTRUCTURE_DIR}/cf/shared"
+        CF_DIR="${PRODUCT_STATE_DIR}/cf/shared"
         ENVIRONMENT_SUFFIX=""
         SEGMENT_SUFFIX=""
 
@@ -84,7 +84,7 @@ case $LEVEL in
         ;;
 
     solution)
-        CF_DIR="${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
+        CF_DIR="${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
         LEVEL_PREFIX="soln-"
         LEVEL_SUFFIX="-soln"
         if [[ -f "${CF_DIR}/solution-${REGION}-template.json" ]]; then
@@ -96,11 +96,11 @@ case $LEVEL in
         ;;
 
     segment)
-        CF_DIR="${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
+        CF_DIR="${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
         LEVEL_PREFIX="seg-"
         LEVEL_SUFFIX="-seg"
 
-        # LEGACY: Support old formats for existing stacks so they can be updated 
+        # LEGACY: Support old formats for existing stacks so they can be updated
         if [[ !("${DEPLOYMENT_UNIT}" =~ cmk|cert|dns ) ]]; then
             if [[ -f "${CF_DIR}/cont-${DEPLOYMENT_UNIT_PREFIX}${REGION_PREFIX}template.json" ]]; then
                 LEVEL_PREFIX="cont-"
@@ -130,13 +130,13 @@ case $LEVEL in
         ;;
 
     application)
-        CF_DIR="${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
+        CF_DIR="${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
         LEVEL_PREFIX="app-"
         LEVEL_SUFFIX="-app"
         ;;
 
     multiple)
-        CF_DIR="${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
+        CF_DIR="${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
         LEVEL_PREFIX="multi-"
         LEVEL_SUFFIX="-multi"
         ;;


### PR DESCRIPTION
Reorganise cmdb to make it easier to manage via branches and dynamic cmdbs

- State is now in its own directory at the same level as config and infrastructure
- Solutions is now under infrastructure
- Builds are separated from settings and are now under infrastructure
- Operations are now in their own directory at same level as config and infrastructure. For consistency with config, a settings subdirectory has been added.

With this layout,
- infrastructure should be the same across environments assuming no builds are being promoted
- product and operations settings are managed consistently
- all the state info is cleanly separated (so potentially in its own repo)

/config/settings
/operations/settings
/infrastructure/solutions
/infrastructure/builds
/state/cf
/state/cot

If config and infrastructure are not in the one repo, then the upgrade must be performed manually and the cmdb version manually updated.

Functions for context tree access now support the pre and post v2.0.0 cmdb directory formats.

Previously defined global variables have been redefined to permit support for pre and post v2.0.0 cmdbs.

NOTE: 
v2.0.0 has not been included in the update list, so switching to v2.0.0 will be done via a separate PR. For now, the aim is to test the changes do not cause issues for pre v2.0.0 cmdbs. Manual testing of v2.0.0 upgrades can also be performed.