### PR TITLE
<fix> SNS subscriptions to SQS

### DIFF
--- a/providers/aws/components/topic/setup.ftl
+++ b/providers/aws/components/topic/setup.ftl
@@ -121,27 +121,6 @@
                             [#break]
 
                         [#case SQS_COMPONENT_TYPE]
-
-                            [#local resourceId = linkTargetResources["queue"].Id ]
-                            [#local policyId =
-                                    formatDependentPolicyId(
-                                        subscriptionId,
-                                        resourceId) ]
-
-                            [#local subscriptionDependencies += [policyId] ]
-
-                            [@createSQSPolicy
-                                id=policyId
-                                queues=resourceId
-                                statements=sqsWritePermission(
-                                                resourceId,
-                                                "*",
-                                                {
-                                                    "ArnEquals" : {
-                                                        "aws:sourceArn" : getReference(topicId)
-                                                    }
-                                                })
-                            /]
                             [#local endpoint = linkTargetAttributes["ARN"] ]
                             [#local protocol = "sqs" ]
                             [#break]


### PR DESCRIPTION
Move the permission to be on the queue side - means the solution needs an inbound link to the queue as well as an outbound subscription from the topic.