### PR TITLE
<fix> SNS subscriptions to SQS

### DIFF
--- a/providers/aws/components/sqs/id.ftl
+++ b/providers/aws/components/sqs/id.ftl
@@ -7,6 +7,8 @@
     services=
         [
             AWS_SIMPLE_QUEUEING_SERVICE,
-            AWS_CLOUDWATCH_SERVICE
+            AWS_CLOUDWATCH_SERVICE,
+            AWS_IDENTITY_SERVICE
+
         ]
 /]

--- a/providers/aws/components/topic/setup.ftl
+++ b/providers/aws/components/topic/setup.ftl
@@ -121,27 +121,6 @@
                             [#break]
 
                         [#case SQS_COMPONENT_TYPE]
-
-                            [#local resourceId = linkTargetResources["queue"].Id ]
-                            [#local policyId =
-                                    formatDependentPolicyId(
-                                        subscriptionId,
-                                        resourceId) ]
-
-                            [#local subscriptionDependencies += [policyId] ]
-
-                            [@createSQSPolicy
-                                id=policyId
-                                queues=resourceId
-                                statements=sqsWritePermission(
-                                                resourceId,
-                                                "*",
-                                                {
-                                                    "ArnEquals" : {
-                                                        "aws:sourceArn" : getReference(topicId)
-                                                    }
-                                                })
-                            /]
                             [#local endpoint = linkTargetAttributes["ARN"] ]
                             [#local protocol = "sqs" ]
                             [#break]

--- a/providers/shared/components/sqs/id.ftl
+++ b/providers/shared/components/sqs/id.ftl
@@ -55,6 +55,11 @@
                 "Children" : alertChildrenConfiguration
             },
             {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
                 "Names" : "Profiles",
                 "Children" :
                     [


### PR DESCRIPTION
Move the permission to be on the queue side - means the solution needs an inbound link to the queue as well as an outbound subscription from the topic.

Add the necessary configuration for SQS to support inbound links.