### PR TITLE
<fix> SNS Subscription to SQS

### DIFF
--- a/providers/aws/components/sqs/setup.ftl
+++ b/providers/aws/components/sqs/setup.ftl
@@ -110,12 +110,13 @@
                                         queues=sqsId
                                         statements=sqsWritePermission(
                                                         sqsId,
-                                                        linkTargetRoles.Inbound["invoke"].Principal,
+                                                        {"Service" : linkTargetRoles.Inbound["invoke"].Principal},
                                                         {
                                                             "ArnEquals" : {
                                                                 "aws:sourceArn" : linkTargetRoles.Inbound["invoke"].SourceArn
                                                             }
-                                                        })
+                                                        },
+                                                        true)
                                     /]
                                     [#break]
                             [/#switch]

--- a/providers/aws/services/sqs/policy.ftl
+++ b/providers/aws/services/sqs/policy.ftl
@@ -68,10 +68,15 @@
         sqsListQueuesPermission() ]
 [/#function]
 
-[#function sqsWritePermission id principals="*" conditions=""]
+[#function sqsWritePermission id principals="*" conditions="" resourcePolicy=false]
+    [#-- SQS resource policies don't support wildcards --]
     [#return
         getSqsStatement(
-            "sqs:SendMessage*",
+            valueIfTrue(
+                "sqs:SendMessage",
+                resourcePolicy,
+                "sqs:SendMessage*"
+            ),
             id,
             principals,
             conditions


### PR DESCRIPTION
Correct the format of the resource policy for a service based principal.

Don't include action wildcards as they are not supported on SQS resource
policies (advice from AWS Support Desk).