### PR TITLE
<feature> Control link attributes included in context

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -222,6 +222,10 @@
                 "Names" : "Enabled",
                 "Type" : BOOLEAN_TYPE,
                 "Default" : true
+            },
+            {
+                "Names" : "IncludeInContext",
+                "Type" : ARRAY_OF_STRING_TYPE
             }
         ]
 ]

--- a/providers/shared/deploymentframeworks/default/legacy.ftl
+++ b/providers/shared/deploymentframeworks/default/legacy.ftl
@@ -106,7 +106,8 @@
             internalCreateOccurrenceFromExternalLink(occurrence, link) +
             {
                 "Direction" : link.Direction!"outbound",
-                "Role" : link.Role!"external"
+                "Role" : link.Role!"external",
+                "IncludeInContext" : link.IncludeInContext![]
             }
         ]
     [/#if]
@@ -200,7 +201,8 @@
                 targetSubOccurrence +
                 {
                     "Direction" : direction,
-                    "Role" : role
+                    "Role" : role,
+                    "IncludeInContext" : link.IncludeInContext![]
                 } ]
         [/#list]
     [/#list]

--- a/providers/shared/deploymentframeworks/default/model.ftl
+++ b/providers/shared/deploymentframeworks/default/model.ftl
@@ -75,7 +75,8 @@
             internalCreateOccurrenceFromContextExternalLink(occurrence, link) +
             {
                 "Direction" : fullLink.Direction,
-                "Role" : fullLink.Role
+                "Role" : fullLink.Role,
+                "IncludeInContext" : fullLink.IncludeInContext![]
             }
         ]
     [/#if]
@@ -131,7 +132,8 @@
             targetOccurrence +
             {
                 "Direction" : fullLink.Direction,
-                "Role" : role
+                "Role" : role,
+                "IncludeInContext" : fullLink.IncludeInContext![]
             } ]
     [/#if]
 


### PR DESCRIPTION
Add the "IncludeInContext" link attribute to permit only a defined set of
attributes to be included in the context as a result of a link. This
permits environment space to be conserved where only one or two
attributes are needed. The default behaviour is all attributes if the
attribute is missing or empty.

Also change the order in which getFinalEnvironment assembles variables
to permit link attributes to be overridden by component attributes (e.g.
link points to an external service with a default timeout value that the
code wants to override). Anything explicitly set via a fragment file
still overrides everything.