### PR TITLE
<feature> Optimise cmdb version checks

### DIFF
--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -1697,6 +1697,13 @@ function process_cmdb() {
 
     [[ -z "${current_version}" ]] && current_version="v0.0.0"
 
+    # Most of the time we expect no upgrade to be required
+    local last_check="$(semver_compare "${current_version}" "${versions[-1]}")"
+    if [[ "${last_check}" != "-1" ]]; then
+      debug "${action^} of repo "${cmdb_repo}" to ${versions[-1]} is not required - skipping all version checks"
+      continue
+    fi
+
     for version in "${versions[@]}"; do
       # Nothing to do if not less than version being checked
       local semver_check="$(semver_compare "${current_version}" "${version}")"

--- a/aws/setContext.sh
+++ b/aws/setContext.sh
@@ -81,8 +81,8 @@ done
 current_dir="$(pwd)"
 pushd "${current_dir}" >/dev/null
 
-local solutions_ancestor_dir="$(findAncestorDir "solutions" "${current_dir}")"
-local solutionsv2_ancestor_dir="$(findAncestorDir "solutionsv2" "${current_dir}")"
+solutions_ancestor_dir="$(findAncestorDir "solutions" "${current_dir}")"
+solutionsv2_ancestor_dir="$(findAncestorDir "solutionsv2" "${current_dir}")"
 if [[ (-z "${solutions_ancestor_dir}") && (-z "${solutionsv2_ancestor_dir}") ]]; then
     # We are not in the solutions part of the tree
     # Assume we are in the >=v2.0.0 cmdb config or operations trees


### PR DESCRIPTION
Mostly there are no cmdb upgrades to be done. On this basis, check the
last version to be checked first and only check the full set of versions
if an upgrade to the last version is required. This assumes the version
lists are ordered, which they are to ensure an upgrade can assume the
cmdb is in the state expected as a result of the previous version
upgrade.

Also fix a minor syntax error with local vs global variables in a bash
script.