### PR TITLE
<refactor> Terminate findDir on first match

### DIFF
--- a/aws/utility.sh
+++ b/aws/utility.sh
@@ -262,6 +262,9 @@ function findDir() {
   local matches=()
   for pattern in "${patterns[@]}"; do
     matches+=("${root_dir}"/**/${pattern})
+    if [[ "${#matches[@]}" -gt 0 ]]; then
+      break
+    fi
   done
 
   ${restore_nullglob}


### PR DESCRIPTION
As soon as a match is found, stop looping through the provided patterns.