### PR TITLE
created VM Image reference type

### DIFF
--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -111,6 +111,11 @@
 [@addReferenceData type=NETWORKENDPOINTGROUP_REFERENCE_TYPE data=blueprintObject.NetworkEndpointGroups /]
 [#assign networkEndpointGroups = referenceData.NetworkEndpointGroups ]
 
+[#-- Virtual Machine Image Profiles --]
+[@includeSharedReferenceConfiguration referenceType=VIRTUAL_MACHINE_IMAGE_REFERENCE_TYPE /]
+[@addReferenceData type=VIRTUAL_MACHINE_IMAGE_REFERENCE_TYPE data=blueprintObject.VMImageProfiles /]
+[#assign vmImageProfiles = referenceData.VMImageProfiles]
+
 [#-- Regions --]
 [#if commandLineOptions.Regions.Segment?has_content]
     [#assign regionId = commandLineOptions.Regions.Segment]

--- a/providers/shared/inputsources/shared/masterdata.ftl
+++ b/providers/shared/inputsources/shared/masterdata.ftl
@@ -984,7 +984,7 @@
             "Rules" : [ "All" ]
           }
         },
-        "OSProfiles": {},
+        "VMImageProfiles": {},
         "PlacementProfiles": {
           "external": {
             "default": {

--- a/providers/shared/inputsources/shared/masterdata.ftl
+++ b/providers/shared/inputsources/shared/masterdata.ftl
@@ -984,6 +984,7 @@
             "Rules" : [ "All" ]
           }
         },
+        "OSProfiles": {},
         "PlacementProfiles": {
           "external": {
             "default": {

--- a/providers/shared/references/VMImageProfile/id.ftl
+++ b/providers/shared/references/VMImageProfile/id.ftl
@@ -1,0 +1,34 @@
+[#ftl]
+
+[@addReference 
+    type=VIRTUAL_MACHINE_IMAGE_REFERENCE_TYPE
+    pluralType="VMImageProfiles"
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "A virtual machine operating system configuration" 
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "Publisher",
+            "Type" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "Offering",
+            "Type" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "SKU",
+            "Type" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "LicenseType",
+            "Type" : STRING_TYPE,
+            "Mandatory" : false
+        }
+    ]
+/]

--- a/providers/shared/references/reference.ftl
+++ b/providers/shared/references/reference.ftl
@@ -19,6 +19,7 @@
 [#assign LOGFILTER_REFERENCE_TYPE = "LogFilter" ]
 
 [#-- Compute Reference Types --]
+[#assign VIRTUAL_MACHINE_IMAGE_REFERENCE_TYPE = "VMImageProfile"]
 [#assign PROCESSOR_REFERENCE_TYPE = "Processor" ]
 [#assign STORAGE_REFERENCE_TYPE = "Storage" ]
 


### PR DESCRIPTION
New reference type for creating profiles for virtual machine images.

New profiles can now be created as necessary in each providers masterData.ftl.

```
"VMImageProfiles" : {
  "bastion" : {
    "Publisher" : "Canonical",
    "Offering" : "UbuntuServer",
    "SKU" : "18.04-LTS"
  }
}
```

These profiles can then be referenced in component setup easily through the global var vmImageProfiles:

```
[#local vmssVMImageProfile = vmImageProfiles[BASTION_COMPONENT_TYPE]]
```