### PR TITLE
<fix> move source maps uploads configuration to CMDB

### DIFF
--- a/aws/runExpoAppPublish.sh
+++ b/aws/runExpoAppPublish.sh
@@ -269,10 +269,8 @@ function main() {
   fi
 
   # variable for sentry source map upload
-  SENTRY_RELEASE_NAME="${BUILD_REFERENCE}"
   SENTRY_SOURCE_MAP_S3_URL="s3://${PUBLIC_BUCKET}/${PUBLIC_PREFIX}/packages/${EXPO_SDK_VERSION}"
   echo "SENTRY_SOURCE_MAP_S3_URL=${SENTRY_SOURCE_MAP_S3_URL}" >> ${AUTOMATION_DATA_DIR}/chain.properties
-  echo "SENTRY_RELEASE_NAME=${SENTRY_RELEASE_NAME}" >> ${AUTOMATION_DATA_DIR}/chain.properties
   echo "SENTRY_URL_PREFIX=~/${PUBLIC_PREFIX}" >> ${AUTOMATION_DATA_DIR}/chain.properties
 
   # Update the app.json with build context information - Also ensure we always have a unique IOS build number
@@ -314,12 +312,12 @@ function main() {
 
   if [[ "${DISABLE_OTA}" == "false" ]]; then
 
-    if [[ -n "${SENTRY_RELEASE_NAME}" ]]; then
-      info "Override revisionId to match the corresponding sentry release name ${SENTRY_RELEASE_NAME}"
-      jq -c --arg REVISION_ID "${SENTRY_RELEASE_NAME}" '.revisionId=$REVISION_ID' < "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}/ios-index.json" > "${tmpdir}/ios-expo-override.json"
+    if [[ -n "${BUILD_REFERENCE}" ]]; then
+      info "Override revisionId to match the build reference ${BUILD_REFERENCE}"
+      jq -c --arg REVISION_ID "${BUILD_REFERENCE}" '.revisionId=$REVISION_ID' < "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}/ios-index.json" > "${tmpdir}/ios-expo-override.json"
       mv "${tmpdir}/ios-expo-override.json" "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}/ios-index.json"
 
-      jq -c --arg REVISION_ID "${SENTRY_RELEASE_NAME}" '.revisionId=$REVISION_ID' < "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}/android-index.json" > "${tmpdir}/android-expo-override.json"
+      jq -c --arg REVISION_ID "${BUILD_REFERENCE}" '.revisionId=$REVISION_ID' < "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}/android-index.json" > "${tmpdir}/android-expo-override.json"
       mv "${tmpdir}/android-expo-override.json" "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}/android-index.json"
 
     fi
@@ -348,12 +346,12 @@ function main() {
 
     fi
 
-    if [[ -n "${SENTRY_RELEASE_NAME}" ]]; then
-      info "Override revisionId in master export to match the corresponding sentry release name ${SENTRY_RELEASE_NAME}"
-      jq -c --arg REVISION_ID "${SENTRY_RELEASE_NAME}" 'if type=="array" then [ .[] | .revisionId=$REVISION_ID ] else .revisionId=$REVISION_ID end' < "${SRC_PATH}/app/dist/master/ios-index.json" > "${tmpdir}/ios-expo-override.json"
+    if [[ -n "${BUILD_REFERENCE}" ]]; then
+      info "Override revisionId in master export to match the build reference ${BUILD_REFERENCE}"
+      jq -c --arg REVISION_ID "${BUILD_REFERENCE}" 'if type=="array" then [ .[] | .revisionId=$REVISION_ID ] else .revisionId=$REVISION_ID end' < "${SRC_PATH}/app/dist/master/ios-index.json" > "${tmpdir}/ios-expo-override.json"
       mv "${tmpdir}/ios-expo-override.json" "${SRC_PATH}/app/dist/master/ios-index.json"
 
-      jq -c --arg REVISION_ID "${SENTRY_RELEASE_NAME}" 'if type=="array" then [ .[] | .revisionId=$REVISION_ID ] else .revisionId=$REVISION_ID end' < "${SRC_PATH}/app/dist/master/android-index.json" > "${tmpdir}/android-expo-override.json"
+      jq -c --arg REVISION_ID "${BUILD_REFERENCE}" 'if type=="array" then [ .[] | .revisionId=$REVISION_ID ] else .revisionId=$REVISION_ID end' < "${SRC_PATH}/app/dist/master/android-index.json" > "${tmpdir}/android-expo-override.json"
       mv "${tmpdir}/android-expo-override.json" "${SRC_PATH}/app/dist/master/android-index.json"
 
     fi

--- a/aws/runSentryRelease.sh
+++ b/aws/runSentryRelease.sh
@@ -25,17 +25,20 @@ function env_setup() {
 function usage() {
     cat <<EOF
 
-Upload sourcemap files to sentry for a specific release
+Upload sourcemap files to sentry for a specific release for SPA and mobile apps. DEPLOYMENT_UNIT is required to build a blueprint
+to get the configuration file location. Sentry cli configuration is read from the configuration file, but for the expo
+SENTRY_SOURCE_MAP_S3_URL and SENTRY_URL_PREFIX are set in the runExpoPublish script and passed as chain properties.
 
-Usage: $(basename $0) -m SENTRY_SOURCE_MAP_S3_URL -r SENTRY_RELEASE -s
+Usage: $(basename $0) -m SENTRY_SOURCE_MAP_S3_URL -r SENTRY_RELEASE -s -d DEPLOYMENT_UNIT
 
 where
 
+(m) -d DEPLOYMENT_UNIT              deployment unit for a build blueprint
     -h                              shows this text
-(m) -m SENTRY_SOURCE_MAP_S3_URL     s3 link to sourcemap files
-(o) -p SENTRY_URL_PREFIX                prefix for sourcemap files
-(m) -r SENTRY_RELEASE_NAME          sentry release name
-(o) -s RUN_SETUP              		run setup installation to prepare
+(o) -m SENTRY_SOURCE_MAP_S3_URL     s3 link to sourcemap files
+(o) -p SENTRY_URL_PREFIX            prefix for sourcemap files
+(o) -r SENTRY_RELEASE               sentry release name
+(o) -s RUN_SETUP              		  run setup installation to prepare
 
 (m) mandatory, (o) optional, (d) deprecated
 
@@ -50,8 +53,11 @@ EOF
 function options() { 
 
     # Parse options
-    while getopts ":hm:p:r:s" opt; do
+    while getopts ":d:hm:p:r:s" opt; do
         case $opt in
+            m)
+                DEPLOYMENT_UNIT="${OPTARG}"
+                ;;
             h)
                 usage
                 ;;
@@ -62,7 +68,7 @@ function options() {
                 SENTRY_URL_PREFIX="${OPTARG}"
                 ;;
             r)
-                SENTRY_RELEASE_NAME="${OPTARG}"
+                SENTRY_RELEASE="${OPTARG}"
                 ;;
             s)
                 RUN_SETUP="true"
@@ -93,20 +99,63 @@ function main() {
   fi
 
   # Ensure mandatory arguments have been provided
-  [[ -z "${SENTRY_SOURCE_MAP_S3_URL}" || -z "${SENTRY_RELEASE_NAME}" ]] && fatalMandatory
+  [[ -z "${DEPLOYMENT_UNIT}" ]] && fatalMandatory
+
+  # Create build blueprint
+  info "Generating build blueprint..."
+  "${GENERATION_DIR}/createBuildblueprint.sh" -u "${DEPLOYMENT_UNIT}" -o "${AUTOMATION_DATA_DIR}" >/dev/null || return $?
+
+  BUILD_BLUEPRINT="${AUTOMATION_DATA_DIR}/build_blueprint-${DEPLOYMENT_UNIT}-.json"
 
   SOURCE_MAP_PATH="${AUTOMATION_DATA_DIR}/source_map"
+  OPS_PATH="${AUTOMATION_DATA_DIR}/ops"
 
   mkdir -p "${SOURCE_MAP_PATH}"
+  mkdir -p "${OPS_PATH}"
+
+  # get config file
+  CONFIG_BUCKET="$( jq -r '.Occurrence.State.Attributes.CONFIG_BUCKET' < "${BUILD_BLUEPRINT}" )"
+  CONFIG_KEY="$( jq -r '.Occurrence.State.Attributes.CONFIG_FILE' < "${BUILD_BLUEPRINT}" )"
+  CONFIG_FILE="${OPS_PATH}/config.json"
+
+  info "Gettting configuration file from s3://${CONFIG_BUCKET}/${CONFIG_KEY}"
+  aws --region "${AWS_REGION}" s3 cp "s3://${CONFIG_BUCKET}/${CONFIG_KEY}" "${CONFIG_FILE}" || return $?
+
+  # attempting to read sentry configuration parameter from the configuration file if it is not passed as an argument
+  # configuration file for expo builds contains .AppConfig element
+  # Note: for the expo builds SENTRY_SOURCE_MAP_S3_URL and SENTRY_URL_PREFIX are passed as arguments
+  # because the sources and maps are uploaded to the OTA_ARTEFACT_BUCKET considering expo sdk version, which is set in app.json
+  # there is no point duplicate expo sdk version as a setting in CMDB and it doesn't make sense to checkout the code to read it at this stage
+  [[ -z "${SENTRY_SOURCE_MAP_S3_URL}" ]] && SENTRY_SOURCE_MAP_S3_URL="$( jq -r '.SENTRY_SOURCE_MAP_S3_URL' <"${CONFIG_FILE}" )"
+  [[ -z "${SENTRY_URL_PREFIX}" ]] && SENTRY_URL_PREFIX="$( jq -r '.SENTRY_URL_PREFIX' <"${CONFIG_FILE}" )"
+  [[ -z "${SENTRY_RELEASE}" ]] && SENTRY_RELEASE="$( jq -r 'if .AppConfig? then .AppConfig.SENTRY_RELEASE else .SENTRY_RELEASE end' <"${CONFIG_FILE}" )"
+  [[ -z "${SENTRY_PROJECT}" ]] && SENTRY_PROJECT="$( jq -r 'if .AppConfig? then .AppConfig.SENTRY_PROJECT else .SENTRY_PROJECT end' <"${CONFIG_FILE}" )"
+  [[ -z "${SENTRY_URL}" ]] && SENTRY_URL="$( jq -r 'if .AppConfig? then .AppConfig.SENTRY_URL else .SENTRY_URL end' <"${CONFIG_FILE}" )"
+  [[ -z "${SENTRY_ORG}" ]] && SENTRY_ORG="$( jq -r 'if .AppConfig? then .AppConfig.SENTRY_ORG else .SENTRY_ORG end' <"${CONFIG_FILE}" )"
+
+  [[ "${SENTRY_SOURCE_MAP_S3_URL}" == "null" || -z "${SENTRY_SOURCE_MAP_S3_URL}" ]] && fatal "SENTRY_SOURCE_MAP_S3_URL is required but was not defined"
+  [[ "${SENTRY_RELEASE}" == "null" || -z "${SENTRY_RELEASE}" ]] &&  fatal "SENTRY_RELEASE is required but was not defined"
+  [[ "${SENTRY_URL_PREFIX}" == "null" || -z "${SENTRY_URL_PREFIX}" ]] &&  fatal "SENTRY_URL_PREFIX is required but was not defined"
+  [[ "${SENTRY_PROJECT}" == "null" || -z "${SENTRY_PROJECT}" ]] &&  fatal "SENTRY_PROJECT is required but was not defined"
+  [[ "${SENTRY_URL}" == "null" || -z "${SENTRY_URL}" ]] &&  fatal "SENTRY_URL is required but was not defined"
+  [[ "${SENTRY_ORG}" == "null" || -z "${SENTRY_ORG}" ]] &&  fatal "SENTRY_ORG is required but was not defined"
+
+  #making sure sentry config is available to sentry cli
+  export SENTRY_PROJECT=$SENTRY_PROJECT
+  export SENTRY_URL=$SENTRY_URL
+  export SENTRY_ORG=$SENTRY_ORG
 
   info "Getting source code from from ${SENTRY_SOURCE_MAP_S3_URL}"
   aws --region "${AWS_REGION}" s3 cp --recursive "${SENTRY_SOURCE_MAP_S3_URL}" "${SOURCE_MAP_PATH}" || return $?
 
-  sentry-cli releases files "${SENTRY_RELEASE_NAME}" upload-sourcemaps "${SOURCE_MAP_PATH}" --rewrite --url-prefix "${SENTRY_URL_PREFIX}"
-  info "exit code form sentry-cli releases files $?"
+  info "Creating a new release ${SENTRY_RELEASE}"
+  sentry-cli releases new "${SENTRY_RELEASE}" || return $?
+  info "Uploading source maps for the release ${SENTRY_RELEASE}"
+  sentry-cli releases files "${SENTRY_RELEASE}" upload-sourcemaps "${SOURCE_MAP_PATH}" --rewrite --url-prefix "${SENTRY_URL_PREFIX}" || return $?
+  info "Finalising the release ${SENTRY_RELEASE}"
+  sentry-cli releases finalize "${SENTRY_RELEASE}" || return $?
 
-  DETAIL_MESSAGE="${DETAIL_MESSAGE} Source map files uploaded for the release ${SENTRY_RELEASE_NAME}."
-
+  DETAIL_MESSAGE="${DETAIL_MESSAGE} Source map files uploaded for the release ${SENTRY_RELEASE}."
   echo "DETAIL_MESSAGE=${DETAIL_MESSAGE}" >> ${AUTOMATION_DATA_DIR}/context.properties
 
   # All good

--- a/providers/aws/components/spa/state.ftl
+++ b/providers/aws/components/spa/state.ftl
@@ -6,6 +6,17 @@
 
     [#local cfId  = formatComponentCFDistributionId(core.Tier, core.Component, occurrence)]
 
+    [#-- Baseline component lookup --]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+
+    [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
+
+    [#local configFilePath = formatRelativePath(
+                                getOccurrenceSettingValue(occurrence, "SETTINGS_PREFIX"),
+                                "config" )]
+    [#local configFileName = "config.json" ]
+
     [#assign componentState =
         {
             "Resources" : {
@@ -25,7 +36,12 @@
                 {}
             ),
             "Attributes" : {
-                "CONFIG_PATH_PATTERN" : solution.ConfigPathPattern
+                "CONFIG_PATH_PATTERN" : solution.ConfigPathPattern,
+                "CONFIG_BUCKET" : operationsBucket,
+                "CONFIG_FILE" : formatRelativePath(
+                                    configFilePath,
+                                    configFileName
+                                )
             },
             "Roles" : {
                 "Inbound" : {},


### PR DESCRIPTION
This PR separates the configuration and process of source maps uploads.
Source maps upload process:

1. create a release using a build reference as a name (`SENTRY_RELEASE`)
2. download sources and map files from the specified path (`SENTRY_SOURCE_MAP_S3_URL`)
3. upload sources and maps files specifying a prefix (`SENTRY_URL_PREFIX`)
4. finalize the release 

Initially source maps uploads were added for expo builds, and all configuration was calculated at expo publish stage. For SPA there is only deploy, so the configuration needs to be read from the config file.  `CONFIG_BUCKET`/`CONFIG_FILE` already are added to a build blueprint for `mobileapp` and now for `spa` application type as well. `DEPLOYMENT_UNIT` is added as a mandatory argument to generate a build blueprint and read the configuration location from it. 

Order of lookup:

1. local environment
2. configuration file

This gives the flexibility either pass the settings from another build (mobileapp), define as Jenkins job environment variable or read it from the config.

For expo builds source map location depends on expo sdk version and OTA configuration, and as these settings are already accessed at the publish phase, `SENTRY_SOURCE_MAP_S3_URL` and `SENTRY_URL_PREFIX` are defined there as well and passed as chain properties to the sentry release job. 
`SENTRY_PROJECT`, `SENTRY_URL` and `SENTRY_ORG` are the default Sentry cli configuration variables.