### PR TITLE
<refactor> Move composite processing into freemarker

### DIFF
--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -106,7 +106,7 @@ function options() {
   if [[ "${GENERATION_INPUT_SOURCE}" == "composite" ]]; then
 
 
-    info "Building composite inputs for engine..."
+    debug "Building composite inputs for engine..."
     # Set up the context
     . "${GENERATION_DIR}/setContext.sh"
 

--- a/providers/shared/inputsources/composite/setting.ftl
+++ b/providers/shared/inputsources/composite/setting.ftl
@@ -1,28 +1,159 @@
 [#ftl]
 
-[#-- Intial seeding of settings data based on input data --]
+[#-- Initial seeding of settings data based on input data --]
 [#macro shared_input_composite_setting_seed ]
-    [@addSettings 
-        type="Settings" 
-        scope="Accounts" 
-        settings=(commandLineOptions.Composites.Settings.Settings.Accounts)!{}
+    [@addSettings
+        type="Settings"
+        scope="Accounts"
+        settings=
+            internalReformatSettings(
+                (commandLineOptions.Composites.Settings.Accounts.Settings)!{}
+            )
     /]
 
-    [@addSettings 
-        type="Settings" 
-        scope="Products" 
-        settings=(commandLineOptions.Composites.Settings.Settings.Products)!{}
+    [#-- (?! ) negates the remaining expression --]
+    [@addSettings
+        type="Settings"
+        scope="Products"
+        settings=
+            mergeObjects(
+                internalReformatSettings(
+                    (commandLineOptions.Composites.Settings.Products.Settings)!{},
+                    r"^(?!.*build\.json|.*credentials\.json|.*sensitive\.json$).*$"
+                ),
+                internalReformatSettings(
+                    (commandLineOptions.Composites.Settings.Products.Operations)!{},
+                    r"^(?!.*build\.json|.*credentials\.json|.*sensitive\.json$).*$"
+                )
+            )
     /]
 
-    [@addSettings 
-        type="Builds" 
-        scope="Products" 
-        settings=(commandLineOptions.Composites.Settings.Builds.Products)!{}
+    [@addSettings
+        type="Builds"
+        scope="Products"
+        settings=
+            mergeObjects(
+                internalReformatSettings(
+                    (commandLineOptions.Composites.Settings.Products.Settings)!{},
+                    r"^.*build\.json$"
+                ),
+                internalReformatSettings(
+                    (commandLineOptions.Composites.Settings.Products.Builds)!{},
+                    r"^.*build\.json$"
+                )
+            )
     /]
 
     [@addSettings
         type="Sensitive"
         scope="Products"
-        settings=(commandLineOptions.Composites.Settings.Sensitive.Products)!{}
+        settings=
+            mergeObjects(
+                internalReformatSettings(
+                    (commandLineOptions.Composites.Settings.Products.Settings)!{},
+                    r"^.*credentials\.json|.*sensitive\.json$"
+                ),
+                internalReformatSettings(
+                    (commandLineOptions.Composites.Settings.Products.Operations)!{},
+                    r"^.*credentials\.json|.*sensitive\.json$"
+                )
+            )
     /]
 [/#macro]
+
+[#---------------------------------------------------------------
+-- Internal support functions for composite setting processing --
+-----------------------------------------------------------------]
+
+[#function internalReformatSettings objects fileRegex=".*"]
+    [#local result = {}]
+    [#list objects!{} as key,value]
+        [#local result =
+            mergeObjects(
+                result,
+                internalReformatFiles(key, value!{}, fileRegex)
+            )]
+    [/#list]
+    [#return result]
+[/#function]
+
+[#function internalReformatFiles key settingsFiles fileRegex]
+    [#local result = {} ]
+    [#list settingsFiles.Files![] as file ]
+        [#-- Ignore the file if it doesn't match the desired regex --]
+        [#if ! file.FileName?lower_case?trim?matches(fileRegex)]
+            [#continue]
+        [/#if]
+
+        [#-- Locate files reative to the CMDB root --]
+        [#local relativeFile =
+            concatenate(
+                [
+                    file.FilePath?remove_beginning(settingsFiles.RootDirectory)?remove_beginning("/"),
+                    file.FileName
+                ],
+                "/"
+            ) ]
+
+        [#-- The namespace starts with the key, followed by any parts of the file path --]
+        [#-- relative to the base directory --]
+        [#local extension = file.FileName?keep_after_last(".")]
+        [#local base = file.FileName?remove_ending("." + extension)]
+        [#local namespace =
+            concatenate(
+                [
+                    key,
+                    file.FilePath?remove_beginning(settingsFiles.BaseDirectory)?lower_case?replace("/", " ")?trim?split(" ")
+                ],
+                "-"
+            ) ]
+
+        [#-- Attribute for file contents --]
+        [#local attribute = base?replace("-","_")?upper_case]
+
+        [#-- asFile --]
+        [#if file.FilePath?lower_case?contains("asfile")]
+            [#local result =
+                mergeObjects(
+                    result,
+                    {
+                        namespace : {
+                            attribute : {
+                                "Value" : file.FileName,
+                                "AsFile" : relativeFile
+                            }
+                        }
+                    }
+                 ) ]
+            [#continue]
+        [/#if]
+
+        [#-- Settings format depends on file extension --]
+        [#switch extension?lower_case]
+            [#case "json"]
+                [#local result =
+                    mergeObjects(
+                        result,
+                        {
+                            namespace : file.Content[0]
+                        }
+                     ) ]
+                [#break]
+            [#default]
+                [#local result =
+                    mergeObjects(
+                        result,
+                        {
+                            namespace : {
+                                attribute : {
+                                    "Value" : file.Content[0],
+                                    "FromFile" : relativeFile
+                                }
+                            }
+                        }
+                    ) ]
+                [#break]
+        [/#switch]
+    [/#list]
+    [#return result]
+[/#function]


### PR DESCRIPTION
In preparation for direct file querying from freemarker, move much of the logic to differentiate between cmdb files into freemarker.

The bash scripts now mainly ignore "dot" files and leave the processing based on filenames to freemarker.

While removing a number of directory scans, most of the time in assembly is spent in running jq on each file, which hasn't altered with the commit.

However, by moving the actual processing into freemarker, we are ready to bypass the file scanning in bash and do it directly from the freemarker wrapper.