### PR TITLE
<fix> Lambda policy dependencies if role in same template

### DIFF
--- a/providers/aws/components/lambda/setup.ftl
+++ b/providers/aws/components/lambda/setup.ftl
@@ -185,6 +185,10 @@
 
     [#local linkPolicies = getLinkTargetsOutboundRoles(_context.Links) ]
 
+    [#-- Ensure policies are ignored as dependencies unless created as part of this template --]
+    [#local policyId = ""]
+    [#local linkPolicyId = ""]
+
     [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(roleId)]
 
         [#-- Create a role under which the function will run and attach required policies --]
@@ -215,9 +219,9 @@
         [/#if]
 
         [#if linkPolicies?has_content]
-            [#local policyId = formatDependentPolicyId(fnId, "links")]
+            [#local linkPolicyId = formatDependentPolicyId(fnId, "links")]
             [@createPolicy
-                id=policyId
+                id=linkPolicyId
                 name="links"
                 statements=linkPolicies
                 roles=roleId
@@ -309,7 +313,7 @@
                     []
                 )
             dependencies=
-                [roleId] +
+                [roleId, policyId, linkPolicyId] +
                 valueIfTrue([fnLgId], solution.PredefineLogGroup, [])
         /]
 


### PR DESCRIPTION
If the policies are created in the same stack as the lambda function,
then they must be included as dependencies of the lambda function.

This is because they reference the role they refer to, but don't
directly link to the lambda function. This can cause race conditions
where the role is checked for permissions before the policies are
complete.

This situation arose for a lambda function being used as an
SQS event source, where the source object checks that the lambda
function has permission to read the queue before creating the event
trigger. In this case, it just depends on the function existing, which
in turn was only depending on the role being present.