### PR TITLE
<feature> Null stripping for freemarker

### DIFF
--- a/aws/contextTree.sh
+++ b/aws/contextTree.sh
@@ -129,7 +129,8 @@ function getFilesAsJSON() {
     done
 
     # Slurp all of the standardised files and put them into a single file as an array
-    runJQ --indent 2 -s '.' "${file_array[@]}" > "${result_file}"; return_status=$?
+    # Freemarker doesn't support the null json value in ?eval so we need to remove any null values
+    runJQ --indent 2 -s -f "${GENERATION_DIR}/nullStrip.jq" "${file_array[@]}" > "${result_file}"; return_status=$?
   else
     echo "[]" > "${result_file}"; return_status=0
   fi
@@ -334,7 +335,7 @@ function assemble_composite_stack_outputs() {
   getFilesAsJSON "${COMPOSITE_STACK_OUTPUTS}" "${stack_array[@]}"; return_status=$?
 
   popTempDir
-  return 0
+  return ${return_status}
 }
 
 function getBluePrintParameter() {

--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -176,7 +176,7 @@ function options() {
             ("${GENERATION_USE_SETTINGS_CACHE}" != "true")) ||
         (! -f "${COMPOSITE_SETTINGS}") ]]; then
         debug "Generating composite settings ..."
-        assemble_settings "${GENERATION_DATA_DIR}" "${COMPOSITE_SETTINGS}"
+        assemble_settings "${GENERATION_DATA_DIR}" "${COMPOSITE_SETTINGS}" || return $?
     fi
 
     # Create the composite definitions
@@ -184,7 +184,7 @@ function options() {
     if [[ (("${GENERATION_USE_CACHE}" != "true") &&
             ("${GENERATION_USE_DEFINITIONS_CACHE}" != "true")) ||
         (! -f "${COMPOSITE_DEFINITIONS}") ]]; then
-        assemble_composite_definitions
+        assemble_composite_definitions || return $?
     fi
 
     # Create the composite stack outputs
@@ -192,7 +192,7 @@ function options() {
     if [[ (("${GENERATION_USE_CACHE}" != "true") &&
             ("${GENERATION_USE_STACK_OUTPUTS_CACHE}" != "true")) ||
         (! -f "${COMPOSITE_STACK_OUTPUTS}") ]]; then
-        assemble_composite_stack_outputs
+        assemble_composite_stack_outputs || return $?
     fi
 
   fi

--- a/aws/nullStrip.jq
+++ b/aws/nullStrip.jq
@@ -1,0 +1,11 @@
+# Apply f to composite entities recursively, and to atoms
+def walk(f):
+  . as $in
+  | if type == "object" then
+      reduce keys[] as $key
+        ( {}; . + { ($key):  ($in[$key] | walk(f)) } ) | f
+  elif type == "array" then map( walk(f) ) | f
+  else f
+  end;
+
+walk( if type == "array" then map(select(. != null)) elif type == "object" then with_entries( select( .value != null ) ) else . end )


### PR DESCRIPTION
Replacement PR for #1123  which aligns with the changes introduced in #1121 

Now whenever we load collcetion of files via getFilesAsJSON we pass them through a null strip jq function. 

This also supports cleaning out array null values 