### PR TITLE
<feature> Disable resource type lookups for alerts

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -968,7 +968,12 @@ behaviour.
 
 [/#function]
 
-[#function getResourceMetricNamespace resourceType ]
+[#function getResourceMetricNamespace resourceType override="" ]
+
+    [#if override?has_content ]
+        [#return override]
+    [/#if]
+
     [#local resourceTypeNameSpace = (metricAttributes[resourceType]).Namespace!"" ]
 
     [#if resourceTypeNameSpace?has_content ]
@@ -1001,14 +1006,19 @@ behaviour.
     [/#switch]
 [/#function]
 
-[#function getMonitoredResources resources, resourceQualifier ]
+[#function getMonitoredResources coreId resources, resourceQualifier ]
     [#local monitoredResources = {} ]
+
+    [#-- allow for a none type which disables dimension lookup --]
+    [#if resourceQualifier.Type?has_content && resourceQualifier.Type == "_none" ]
+        [#return { "_none" : { "Id" : coreId, "Type" : "_none" } }]
+    [/#if]
 
     [#list resources as id,resource ]
 
         [#if !resource["Type"]?has_content && resource?is_hash]
             [#list resource as id,subResource ]
-                [#local monitoredResources += getMonitoredResources({id : subResource}, resourceQualifier)]
+                [#local monitoredResources += getMonitoredResources(coreId, {id : subResource}, resourceQualifier)]
             [/#list]
 
         [#else]

--- a/providers/aws/components/apigateway/setup.ftl
+++ b/providers/aws/components/apigateway/setup.ftl
@@ -468,7 +468,7 @@
 
         [#list solution.Alerts?values as alert ]
 
-            [#local monitoredResources = getMonitoredResources(resources, alert.Resource)]
+            [#local monitoredResources = getMonitoredResources(core.Id, resources, alert.Resource)]
             [#list monitoredResources as name,monitoredResource ]
 
                 [@debug message="Monitored resource" context=monitoredResource enabled=false /]
@@ -482,7 +482,7 @@
                             alertName=alert.Name
                             actions=getCWAlertActions(occurrence, solution.Profiles.Alert, alert.Severity )
                             metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
-                            namespace=getResourceMetricNamespace(monitoredResource.Type)
+                            namespace=getResourceMetricNamespace(monitoredResource.Type, alert.Namespace)
                             description=alert.Description!alert.Name
                             threshold=alert.Threshold
                             statistic=alert.Statistic
@@ -493,7 +493,6 @@
                             unit=alert.Unit
                             missingData=alert.MissingData
                             dimensions=getResourceMetricDimensions(monitoredResource, resources)
-                            dependencies=monitoredResource.Id
                         /]
                     [#break]
                 [/#switch]

--- a/providers/aws/components/cache/setup.ftl
+++ b/providers/aws/components/cache/setup.ftl
@@ -138,7 +138,7 @@
 
             [#list solution.Alerts?values as alert ]
 
-                [#local monitoredResources = getMonitoredResources(resources, alert.Resource)]
+                [#local monitoredResources = getMonitoredResources(core.Id, resources, alert.Resource)]
                 [#list monitoredResources as name,monitoredResource ]
 
                     [@debug message="Monitored resource" context=monitoredResource enabled=false /]
@@ -152,7 +152,7 @@
                                 alertName=alert.Name
                                 actions=getCWAlertActions(occurrence, solution.Profiles.Alert, alert.Severity )
                                 metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
-                                namespace=getResourceMetricNamespace(monitoredResource.Type)
+                                namespace=getResourceMetricNamespace(monitoredResource.Type, alert.Namespace)
                                 description=alert.Description!alert.Name
                                 threshold=alert.Threshold
                                 statistic=alert.Statistic
@@ -163,7 +163,6 @@
                                 unit=alert.Unit
                                 missingData=alert.MissingData
                                 dimensions=getResourceMetricDimensions(monitoredResource, resources)
-                                dependencies=monitoredResource.Id
                             /]
                         [#break]
                     [/#switch]

--- a/providers/aws/components/computecluster/setup.ftl
+++ b/providers/aws/components/computecluster/setup.ftl
@@ -326,10 +326,10 @@
                             [#local scalingTargetResources = resources ]
                         [/#if]
 
-                        [#local monitoredResources = getMonitoredResources(scalingTargetResources, scalingMetricTrigger.Resource)]
+                        [#local monitoredResources = getMonitoredResources(core.Id, scalingTargetResources, scalingMetricTrigger.Resource)]
 
-                        [#if monitoredResources?keys?size > 1 ] 
-                            [@fatal 
+                        [#if monitoredResources?keys?size > 1 ]
+                            [@fatal
                                 message="A scaling policy can only track one metric"
                                 context={ "trackingPolicy" : name, "monitoredResources" : monitoredResources }
                                 detail="Please add an extra resource filter to the metric policy"
@@ -341,7 +341,7 @@
                             [@fatal
                                 message="Could not find monitoring resources"
                                 context={ "scalingPolicy" : scalingPolicy }
-                                detail="Please make sure you have a resource which can be monitored with CloudWatch"    
+                                detail="Please make sure you have a resource which can be monitored with CloudWatch"
                             /]
                             [#continue]
                         [/#if]
@@ -354,7 +354,7 @@
 
                         [#if scalingPolicy.Type?lower_case == "stepped" ]
                             [#if ! isPresent( scalingPolicy.Stepped )]
-                                [@fatal 
+                                [@fatal
                                     message="Stepped Scaling policy not found"
                                     context=scalingPolicy
                                     enabled=true
@@ -397,7 +397,7 @@
                         [#if scalingPolicy.Type?lower_case == "tracked" ]
 
                             [#if ! isPresent( scalingPolicy.Tracked )]
-                                [@fatal 
+                                [@fatal
                                     message="Tracked Scaling policy not found"
                                     context=scalingPolicy
                                     enabled=true
@@ -409,7 +409,7 @@
                                                             getResourceMetricDimensions(monitoredResource, scalingTargetResources ),
                                                             getMetricName(scalingMetricTrigger.Metric, monitoredResource.Type, scalingTargetCore.ShortFullName),
                                                             getResourceMetricNamespace(monitoredResource.Type),
-                                                            scalingMetricTrigger.Statistic 
+                                                            scalingMetricTrigger.Statistic
                                                         )]
 
                             [#local scalingAction = getEc2AutoScalingTrackPolicy(
@@ -429,10 +429,10 @@
                                 minAdjustment=scalingPolicy.Stepped.MinAdjustment
                         /]
                         [#break]
-                    
+
                     [#case "scheduled"]
                         [#if ! isPresent( scalingPolicy.Scheduled )]
-                            [@fatal 
+                            [@fatal
                                 message="Scheduled Scaling policy not found"
                                 context=scalingPolicy
                                 enabled=true
@@ -441,11 +441,11 @@
                         [/#if]
 
                         [#local scheduleProcessor = getProcessor(
-                                                        occurrence, 
-                                                        "ECS", 
+                                                        occurrence,
+                                                        "ECS",
                                                         scalingPolicy.Scheduled.ProcessorProfile)]
                         [#local scheduleProcessorCounts = getProcessorCounts(scheduleProcessor, multiAZ ) ]
-                        [@createEc2AutoScalingSchedule 
+                        [@createEc2AutoScalingSchedule
                             id=scalingPolicyId
                             autoScaleGroupId=computeClusterAutoScaleGroupId
                             schedule=scalingPolicy.Scheduled.Schedule

--- a/providers/aws/components/db/setup.ftl
+++ b/providers/aws/components/db/setup.ftl
@@ -365,7 +365,7 @@
 
         [#list solution.Alerts?values as alert ]
 
-            [#local monitoredResources = getMonitoredResources(resources, alert.Resource)]
+            [#local monitoredResources = getMonitoredResources(core.Id, resources, alert.Resource)]
             [#list monitoredResources as name,monitoredResource ]
 
                 [@debug message="Monitored resource" context=monitoredResource enabled=false /]
@@ -391,7 +391,7 @@
                             alertName=alert.Name
                             actions=getCWAlertActions(occurrence, solution.Profiles.Alert, alert.Severity )
                             metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
-                            namespace=getResourceMetricNamespace(monitoredResource.Type)
+                            namespace=getResourceMetricNamespace(monitoredResource.Type, alert.Namespace)
                             description=alert.Description!alert.Name
                             threshold=alert.Threshold
                             statistic=alert.Statistic

--- a/providers/aws/components/ecs/setup.ftl
+++ b/providers/aws/components/ecs/setup.ftl
@@ -214,7 +214,7 @@
 
         [#list solution.Alerts?values as alert ]
 
-            [#local monitoredResources = getMonitoredResources(resources, alert.Resource)]
+            [#local monitoredResources = getMonitoredResources(core.Id, resources, alert.Resource)]
             [#list monitoredResources as name,monitoredResource ]
 
                 [@debug message="Monitored resource" context=monitoredResource enabled=false /]
@@ -228,7 +228,7 @@
                             alertName=alert.Name
                             actions=getCWAlertActions(occurrence, solution.Profiles.Alert, alert.Severity )
                             metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
-                            namespace=getResourceMetricNamespace(monitoredResource.Type)
+                            namespace=getResourceMetricNamespace(monitoredResource.Type, alert.Namespace)
                             description=alert.Description!alert.Name
                             threshold=alert.Threshold
                             statistic=alert.Statistic
@@ -239,7 +239,6 @@
                             unit=alert.Unit
                             missingData=alert.MissingData
                             dimensions=getResourceMetricDimensions(monitoredResource, resources)
-                            dependencies=monitoredResource.Id
                         /]
                     [#break]
                 [/#switch]
@@ -315,7 +314,7 @@
                             [#local scalingTargetResources = resources ]
                         [/#if]
 
-                        [#local monitoredResources = getMonitoredResources(scalingTargetResources, scalingMetricTrigger.Resource)]
+                        [#local monitoredResources = getMonitoredResources(core.Id, scalingTargetResources, scalingMetricTrigger.Resource)]
 
                         [#if monitoredResources?keys?size > 1 ]
                             [@fatal
@@ -857,7 +856,7 @@
                                     [#local scalingTargetResources = resources + { "cluster" : parentResources["cluster"] }]
                                 [/#if]
 
-                                [#local monitoredResources = getMonitoredResources(scalingTargetResources, scalingMetricTrigger.Resource)]
+                                [#local monitoredResources = getMonitoredResources(core.Id, scalingTargetResources, scalingMetricTrigger.Resource)]
 
                                 [#if monitoredResources?keys?size > 1 ]
                                     [@fatal
@@ -1283,7 +1282,7 @@
 
             [#list solution.Alerts?values as alert ]
 
-                [#local monitoredResources = getMonitoredResources(resources, alert.Resource)]
+                [#local monitoredResources = getMonitoredResources(core.Id, resources, alert.Resource)]
                 [#list monitoredResources as name,monitoredResource ]
 
                     [#switch alert.Comparison ]
@@ -1295,7 +1294,7 @@
                                 alertName=alert.Name
                                 actions=getCWAlertActions(subOccurrence, solution.Profiles.Alert, alert.Severity )
                                 metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
-                                namespace=getResourceMetricNamespace(monitoredResource.Type)
+                                namespace=getResourceMetricNamespace(monitoredResource.Type, alert.Namespace)
                                 description=alert.Description!alert.Name
                                 threshold=alert.Threshold
                                 statistic=alert.Statistic
@@ -1306,7 +1305,6 @@
                                 unit=alert.Unit
                                 missingData=alert.MissingData
                                 dimensions=getResourceMetricDimensions(monitoredResource, ( resources + { "cluster" : parentResources["cluster"] } ) )
-                                dependencies=monitoredResource.Id
                             /]
                         [#break]
                     [/#switch]

--- a/providers/aws/components/es/setup.ftl
+++ b/providers/aws/components/es/setup.ftl
@@ -251,7 +251,7 @@
 
         [#list solution.Alerts?values as alert ]
 
-            [#local monitoredResources = getMonitoredResources(resources, alert.Resource)]
+            [#local monitoredResources = getMonitoredResources(core.Id, resources, alert.Resource)]
             [#list monitoredResources as name,monitoredResource ]
 
                 [@debug message="Monitored resource" context=monitoredResource enabled=false /]
@@ -265,7 +265,7 @@
                             alertName=alert.Name
                             actions=getCWAlertActions(occurrence, solution.Profiles.Alert, alert.Severity )
                             metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
-                            namespace=getResourceMetricNamespace(monitoredResource.Type)
+                            namespace=getResourceMetricNamespace(monitoredResource.Type, alert.Namespace)
                             description=alert.Description!alert.Name
                             threshold=alert.Threshold
                             statistic=alert.Statistic
@@ -276,7 +276,6 @@
                             unit=alert.Unit
                             missingData=alert.MissingData
                             dimensions=getResourceMetricDimensions(monitoredResource, resources)
-                            dependencies=monitoredResource.Id
                         /]
                     [#break]
                 [/#switch]

--- a/providers/aws/components/lambda/setup.ftl
+++ b/providers/aws/components/lambda/setup.ftl
@@ -410,7 +410,7 @@
 
         [#list solution.Alerts?values as alert ]
 
-            [#local monitoredResources = getMonitoredResources(resources, alert.Resource)]
+            [#local monitoredResources = getMonitoredResources(core.Id, resources, alert.Resource)]
             [#list monitoredResources as name,monitoredResource ]
 
                 [#switch alert.Comparison ]
@@ -422,7 +422,7 @@
                             alertName=alert.Name
                             actions=getCWAlertActions(fn, solution.Profiles.Alert, alert.Severity )
                             metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
-                            namespace=getResourceMetricNamespace(monitoredResource.Type)
+                            namespace=getResourceMetricNamespace(monitoredResource.Type, alert.Namespace)
                             description=alert.Description!alert.Name
                             threshold=alert.Threshold
                             statistic=alert.Statistic
@@ -433,7 +433,6 @@
                             unit=alert.Unit
                             missingData=alert.MissingData
                             dimensions=getResourceMetricDimensions(monitoredResource, resources)
-                            dependencies=monitoredResource.Id
                         /]
                     [#break]
                 [/#switch]

--- a/providers/aws/components/lb/setup.ftl
+++ b/providers/aws/components/lb/setup.ftl
@@ -87,7 +87,7 @@
     [#if deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
         [#list solution.Alerts?values as alert ]
 
-            [#local monitoredResources = getMonitoredResources(resources, alert.Resource)]
+            [#local monitoredResources = getMonitoredResources(core.Id, resources, alert.Resource)]
             [#list monitoredResources as name,monitoredResource ]
 
                 [@debug message="Monitored resource" context=monitoredResource enabled=false /]
@@ -101,7 +101,7 @@
                             alertName=alert.Name
                             actions=getCWAlertActions(occurrence, solution.Profiles.Alert, alert.Severity )
                             metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
-                            namespace=getResourceMetricNamespace(monitoredResource.Type)
+                            namespace=getResourceMetricNamespace(monitoredResource.Type, alert.Namespace)
                             description=alert.Description!alert.Name
                             threshold=alert.Threshold
                             statistic=alert.Statistic
@@ -112,7 +112,6 @@
                             unit=alert.Unit
                             missingData=alert.MissingData
                             dimensions=getResourceMetricDimensions(monitoredResource, resources)
-                            dependencies=monitoredResource.Id
                         /]
                     [#break]
                 [/#switch]

--- a/providers/aws/components/mobilenotifier/setup.ftl
+++ b/providers/aws/components/mobilenotifier/setup.ftl
@@ -145,7 +145,7 @@
 
             [#list solution.Alerts?values as alert ]
 
-                [#local monitoredResources = getMonitoredResources(resources, alert.Resource)]
+                [#local monitoredResources = getMonitoredResources(core.Id, resources, alert.Resource)]
                 [#list monitoredResources as name,monitoredResource ]
 
                     [@debug message="Monitored resource" context=monitoredResource enabled=false /]
@@ -159,7 +159,7 @@
                                 alertName=alert.Name
                                 actions=getCWAlertActions(subOccurrence, solution.Profiles.Alert, alert.Severity )
                                 metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
-                                namespace=getResourceMetricNamespace(monitoredResource.Type)
+                                namespace=getResourceMetricNamespace(monitoredResource.Type, alert.Namespace)
                                 description=alert.Description!alert.Name
                                 threshold=alert.Threshold
                                 statistic=alert.Statistic
@@ -170,7 +170,6 @@
                                 unit=alert.Unit
                                 missingData=alert.MissingData
                                 dimensions=getResourceMetricDimensions(monitoredResource, resources)
-                                dependencies=monitoredResource.Id
                             /]
                         [#break]
                     [/#switch]
@@ -221,7 +220,7 @@
                             {
                                 platformAppId : core.Name,
                                 formatId(platformAppId, ARN_ATTRIBUTE_TYPE) : "$\{platform_app_arn}",
-                                formatId(platformAppId, REGION_ATTRIBUTE_TYPE) : regionId 
+                                formatId(platformAppId, REGION_ATTRIBUTE_TYPE) : regionId
                             },
                             core.SubComponent.Id
                         ) +

--- a/providers/aws/components/sqs/setup.ftl
+++ b/providers/aws/components/sqs/setup.ftl
@@ -47,7 +47,7 @@
 
         [#list solution.Alerts?values as alert ]
 
-            [#local monitoredResources = getMonitoredResources(resources, alert.Resource)]
+            [#local monitoredResources = getMonitoredResources(core.Id, resources, alert.Resource)]
             [#list monitoredResources as name,monitoredResource ]
 
                 [#switch alert.Comparison ]
@@ -59,7 +59,7 @@
                             alertName=alert.Name
                             actions=getCWAlertActions(occurrence, solution.Profiles.Alert, alert.Severity )
                             metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
-                            namespace=getResourceMetricNamespace(monitoredResource.Type)
+                            namespace=getResourceMetricNamespace(monitoredResource.Type, alert.Namespace)
                             description=alert.Description!alert.Name
                             threshold=alert.Threshold
                             statistic=alert.Statistic
@@ -70,7 +70,6 @@
                             unit=alert.Unit
                             missingData=alert.MissingData
                             dimensions=getResourceMetricDimensions(monitoredResource, resources)
-                            dependencies=monitoredResource.Id
                         /]
                     [#break]
                 [/#switch]

--- a/providers/aws/components/topic/setup.ftl
+++ b/providers/aws/components/topic/setup.ftl
@@ -33,7 +33,7 @@
     [#if deploymentSubsetRequired(TOPIC_COMPONENT_TYPE) ]
         [#list solution.Alerts?values as alert ]
 
-            [#local monitoredResources = getMonitoredResources(resources, alert.Resource)]
+            [#local monitoredResources = getMonitoredResources(core.Id, resources, alert.Resource)]
             [#list monitoredResources as name,monitoredResource ]
 
                 [@debug message="Monitored resource" context=monitoredResource enabled=false /]
@@ -47,7 +47,7 @@
                             alertName=alert.Name
                             actions=getCWAlertActions(occurrence, solution.Profiles.Alert, alert.Severity )
                             metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
-                            namespace=getResourceMetricNamespace(monitoredResource.Type)
+                            namespace=getResourceMetricNamespace(monitoredResource.Type, alert.Namespace)
                             description=alert.Description!alert.Name
                             threshold=alert.Threshold
                             statistic=alert.Statistic
@@ -58,7 +58,6 @@
                             unit=alert.Unit
                             missingData=alert.MissingData
                             dimensions=getResourceMetricDimensions(monitoredResource, resources)
-                            dependencies=monitoredResource.Id
                         /]
                     [#break]
                 [/#switch]

--- a/providers/aws/services/cw/resource.ftl
+++ b/providers/aws/services/cw/resource.ftl
@@ -11,7 +11,7 @@
     }
 ]
 
-[@addOutputMapping 
+[@addOutputMapping
     provider=AWS_PROVIDER
     resourceType=AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE
     mappings=LOG_GROUP_OUTPUT_MAPPINGS
@@ -105,7 +105,7 @@
     }
 ]
 
-[@addOutputMapping 
+[@addOutputMapping
     provider=AWS_PROVIDER
     resourceType=AWS_CLOUDWATCH_DASHBOARD_RESOURCE_TYPE
     mappings=DASHBOARD_OUTPUT_MAPPINGS
@@ -296,10 +296,13 @@
                 "TreatMissingData" : missingData,
                 "Unit" : unit
             } +
-            attributeIfContent("Dimensions", dimensions) +
+            attributeIfContent(
+                "Dimensions",
+                dimensions
+            ) +
             attributeIfTrue(
-                "OKActions", 
-                reportOK, 
+                "OKActions",
+                reportOK,
                 asArray(actions)
             ) +
             valueIfContent(
@@ -334,7 +337,7 @@
     }
 ]
 
-[@addOutputMapping 
+[@addOutputMapping
     provider=AWS_PROVIDER
     resourceType=AWS_EVENT_RULE_RESOURCE_TYPE
     mappings=EVENT_RULE_OUTPUT_MAPPINGS

--- a/providers/aws/services/resource.ftl
+++ b/providers/aws/services/resource.ftl
@@ -85,7 +85,16 @@
 [/#function]
 
 [#-- Metric Dimensions are extended dynamically by each resouce type --]
-[#assign metricAttributes = {}]
+[#assign metricAttributes = {
+    "_none" : {
+        "Namespace" : "",
+        "Dimensions" : {
+            "None" : {
+                "None" : ""
+            }
+        }
+    }
+}]
 
 [#-- Include a reference to a resource --]
 [#-- Allows resources to share a template or be separated --]


### PR DESCRIPTION
Allows for the resource lookups on alerts to be disabled. 

This is helpful for custom metrics which do not have dimensions that can't be determined by the resources in the component themselves 

Also removes the explicit dependencies on alerts as they aren't required and can cause issues with hibernation