### PR TITLE
<refactor> move genplan to a dedicated invoke macro

### DIFF
--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -203,7 +203,7 @@
             [@debug
                 message="Unable to invoke any of the macro options"
                 context=macroOptions
-                enabled=true
+                enabled=false
             /]
         [/#if]
     [/#if]

--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -167,19 +167,26 @@
     [#return profile[key]!{} ]
 [/#function]
 
-[#function invokeComponentMacro occurrence resourceGroup levels=[] parent={} baseState={} ]
+[#function invokeComponentMacro occurrence resourceGroup type qualifiers=[] parent={} baseState={} ]
     [#local placement = (occurrence.State.ResourceGroups[resourceGroup].Placement)!{} ]
     [#if placement?has_content]
         [#local macroOptions = [] ]
-            [#list asArray(levels) as level]
-                [#-- An empty level is assumed to be ignored --]
-                [#local macroOptions +=
-                    [
-                        [placement.Provider, occurrence.Core.Type, resourceGroup, placement.DeploymentFramework, level],
-                        [placement.Provider, occurrence.Core.Type, placement.DeploymentFramework, level],
-                        [placement.Provider, resourceGroup, placement.DeploymentFramework, level]
-                    ]]
-            [/#list]
+        [#list asArray(qualifiers) as qualifier]
+            [#-- An empty level is assumed to be ignored --]
+            [#local macroOptions +=
+                [
+                    [placement.Provider, occurrence.Core.Type, resourceGroup, placement.DeploymentFramework, type, qualifier],
+                    [placement.Provider, occurrence.Core.Type, placement.DeploymentFramework, type, qualifier],
+                    [placement.Provider, resourceGroup, placement.DeploymentFramework, type, qualifier]
+                ]]
+        [/#list]
+
+        [#local macroOptions +=
+            [
+                [placement.Provider, occurrence.Core.Type, resourceGroup, placement.DeploymentFramework, type],
+                [placement.Provider, occurrence.Core.Type, placement.DeploymentFramework, type],
+                [placement.Provider, resourceGroup, placement.DeploymentFramework, type]
+            ]]
         [#local macro = getFirstDefinedDirective(macroOptions)]
         [#if macro?has_content]
             [#if parent?has_content || baseState?has_content]
@@ -196,22 +203,35 @@
             [@debug
                 message="Unable to invoke any of the macro options"
                 context=macroOptions
-                enabled=false
+                enabled=true
             /]
         [/#if]
     [/#if]
     [#return false]
 [/#function]
 
-[#function invokeSetupMacro occurrence resourceGroup levels=[] ]
+[#function invokeSetupMacro occurrence resourceGroup qualifiers=[] ]
     [#return
         invokeComponentMacro(
             occurrence,
             resourceGroup,
-            levels,
+            "setup",
+            qualifiers,
             {},
             {}
-        ) ]
+        )]
+[/#function]
+
+[#function invokeGenPlanMacro occurrence resourceGroup qualifiers=[] ]
+    [#return
+        invokeComponentMacro(
+            occurrence,
+            resourceGroup,
+            "genplan",
+            qualifiers,
+            {},
+            {}
+        )]
 [/#function]
 
 [#function invokeStateMacro occurrence resourceGroup parent={} baseState={} ]
@@ -220,9 +240,10 @@
             occurrence,
             resourceGroup,
             "state",
+            [],
             parent,
             baseState
-        ) ]
+        )]
 [/#function]
 
 [#-- Tiers --]

--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -172,7 +172,6 @@
     [#if placement?has_content]
         [#local macroOptions = [] ]
         [#list asArray(qualifiers) as qualifier]
-            [#-- An empty level is assumed to be ignored --]
             [#local macroOptions +=
                 [
                     [placement.Provider, occurrence.Core.Type, resourceGroup, placement.DeploymentFramework, type, qualifier],

--- a/providers/aws/components/apigateway/setup.ftl
+++ b/providers/aws/components/apigateway/setup.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_apigateway_cf_genplan_application ]
+[#macro aws_apigateway_cf_genplan_application occurrence ]
     [@addDefaultGenerationPlan subsets=["pregeneration", "prologue", "template", "epilogue", "config"] /]
 [/#macro]
 

--- a/providers/aws/components/apigateway/setup.ftl
+++ b/providers/aws/components/apigateway/setup.ftl
@@ -1,11 +1,11 @@
 [#ftl]
-[#macro aws_apigateway_cf_application occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=["pregeneration", "prologue", "template", "epilogue", "config"] /]
-        [#return]
-    [/#if]
+[#macro aws_apigateway_cf_genplan_application ]
+    [@addDefaultGenerationPlan subsets=["pregeneration", "prologue", "template", "epilogue", "config"] /]
+[/#macro]
+
+[#macro aws_apigateway_cf_setup_application occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]

--- a/providers/aws/components/apiusageplan/setup.ftl
+++ b/providers/aws/components/apiusageplan/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_apiusageplan_cf_application occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_apiusageplan_cf_genplan_application occurrence ]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_apiusageplan_cf_setup_application occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]

--- a/providers/aws/components/baseline/setup.ftl
+++ b/providers/aws/components/baseline/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_baseline_cf_segment occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_baseline_cf_genplan_segment occurrence ]
+    [@addDefaultGenerationPlan subsets=["prologue", "template", "epilogue"] /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=["prologue", "template", "epilogue"] /]
-        [#return]
-    [/#if]
+[#macro aws_baseline_cf_setup_segment occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]

--- a/providers/aws/components/bastion/setup.ftl
+++ b/providers/aws/components/bastion/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_bastion_cf_segment occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_bastion_cf_genplan_segment occurrence ]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_bastion_cf_setup_segment occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]

--- a/providers/aws/components/cache/setup.ftl
+++ b/providers/aws/components/cache/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_cache_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_cache_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_cache_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]

--- a/providers/aws/components/cdn/setup.ftl
+++ b/providers/aws/components/cdn/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_cdn_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_cdn_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets=["template", "epilogue"] /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=["template", "epilogue"] /]
-        [#return]
-    [/#if]
+[#macro aws_cdn_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local resources = occurrence.State.Resources]
@@ -365,7 +364,7 @@
 
         [#local errorResponses = []]
         [#if solution.Pages.NotFound?has_content || solution.Pages.Error?has_content ]
-            [#local errorResponses += 
+            [#local errorResponses +=
                 getErrorResponse(
                         404,
                         200,
@@ -377,7 +376,7 @@
         [/#if]
 
         [#if solution.Pages.Denied?has_content || solution.Pages.Error?has_content ]
-            [#local errorResponses += 
+            [#local errorResponses +=
                 getErrorResponse(
                         403,
                         200,
@@ -389,14 +388,14 @@
         [/#if]
 
         [#list solution.ErrorResponseOverrides as key,errorResponseOverride ]
-            [#local errorResponses += 
+            [#local errorResponses +=
                 getErrorResponse(
                         errorResponseOverride.ErrorCode,
                         errorResponseOverride.ResponseCode,
                         errorResponseOverride.ResponsePagePath
                 )
             ]
-        [/#list] 
+        [/#list]
 
         [@createCFDistribution
             id=cfId

--- a/providers/aws/components/computecluster/setup.ftl
+++ b/providers/aws/components/computecluster/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_computecluster_cf_application occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_computecluster_cf_genplan_application occurrence ]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_computecluster_cf_setup_application occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]

--- a/providers/aws/components/configstore/setup.ftl
+++ b/providers/aws/components/configstore/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_configstore_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_configstore_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets=["template", "epilogue", "cli"] /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=["template", "epilogue", "cli"] /]
-        [#return]
-    [/#if]
+[#macro aws_configstore_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local parentCore = occurrence.Core]
     [#local parentSolution = occurrence.Configuration.Solution]

--- a/providers/aws/components/contenthub/setup.ftl
+++ b/providers/aws/components/contenthub/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_contenthub_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_contenthub_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets="prologue" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="prologue" /]
-        [#return]
-    [/#if]
+[#macro aws_contenthub_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution ]

--- a/providers/aws/components/contentnode/setup.ftl
+++ b/providers/aws/components/contentnode/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_contentnode_cf_application occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_contentnode_cf_genplan_application occurrence ]
+    [@addDefaultGenerationPlan subsets="prologue" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="prologue" /]
-        [#return]
-    [/#if]
+[#macro aws_contentnode_cf_setup_application occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
@@ -62,7 +61,7 @@
                                         "\"" +    linkTargetAttributes.REPOSITORY + "\" " +
                                         "\"" +    linkTargetAttributes.PREFIX + "\" " +
                                         "\"" +    pathObject + "\" " +
-                                        "\"" +    linkTargetAttributes.BRANCH + "\" " + 
+                                        "\"" +    linkTargetAttributes.BRANCH + "\" " +
                                         "\"replace\" || return $? ",
                                 "}",
                                 "#",

--- a/providers/aws/components/datafeed/setup.ftl
+++ b/providers/aws/components/datafeed/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_datafeed_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_datafeed_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_datafeed_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]

--- a/providers/aws/components/datapipeline/setup.ftl
+++ b/providers/aws/components/datapipeline/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_datapipeline_cf_application occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_datapipeline_cf_genplan_application occurrence ]
+    [@addDefaultGenerationPlan subsets=["prologue", "template", "epilogue", "cli", "config"] /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=["prologue", "template", "epilogue", "cli", "config"] /]
-        [#return]
-    [/#if]
+[#macro aws_datapipeline_cf_setup_application occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]

--- a/providers/aws/components/dataset/setup.ftl
+++ b/providers/aws/components/dataset/setup.ftl
@@ -1,10 +1,9 @@
 [#ftl]
-[#macro aws_dataset_cf_application occurrence ]
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=[ "prologue" ] /]
-        [#return]
-    [/#if]
+[#macro aws_dataset_cf_genplan_application occurrence ]
+    [@addDefaultGenerationPlan subsets=[ "prologue" ] /]
+[#/macro]
 
+[#macro aws_dataset_cf_setup_application occurrence ]
     [#if deploymentSubsetRequired("prologue", false)]
         [@addToDefaultBashScriptOutput
             [

--- a/providers/aws/components/datavolume/setup.ftl
+++ b/providers/aws/components/datavolume/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_datavolume_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_datavolume_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets=["template", "epilogue"] /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=["template", "epilogue"] /]
-        [#return]
-    [/#if]
+[#macro aws_datavolume_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]

--- a/providers/aws/components/db/setup.ftl
+++ b/providers/aws/components/db/setup.ftl
@@ -1,14 +1,13 @@
 [#ftl]
-[#macro aws_db_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_db_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan
+        subsets=["prologue", "template", "epilogue"]
+        alternatives=["primary", "replace1", "replace2"]
+    /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan
-            subsets=["prologue", "template", "epilogue"]
-            alternatives=["primary", "replace1", "replace2"]
-        /]
-        [#return]
-    [/#if]
+[#macro aws_db_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]

--- a/providers/aws/components/ec2/setup.ftl
+++ b/providers/aws/components/ec2/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
 [#macro aws_ec2_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_ec2_cf_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]

--- a/providers/aws/components/ecs/setup.ftl
+++ b/providers/aws/components/ecs/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_ecs_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_ecs_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_ecs_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
@@ -479,13 +478,12 @@
     [/#if]
 [/#macro]
 
-[#macro aws_ecs_cf_application occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_ecs_cf_genplan_application occurrence ]
+    [@addDefaultGenerationPlan subsets=["prologue", "template", "epilogue", "cli"] /]å
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=["prologue", "template", "epilogue", "cli"] /]
-        [#return]
-    [/#if]
+[#macro aws_ecs_cf_setup_application occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local parentResources = occurrence.State.Resources]
     [#local parentSolution = occurrence.Configuration.Solution ]

--- a/providers/aws/components/efs/setup.ftl
+++ b/providers/aws/components/efs/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_efs_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_efs_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_efs_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]

--- a/providers/aws/components/es/setup.ftl
+++ b/providers/aws/components/es/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_es_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_es_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets=["template", "epilogue", "cli"] /]å
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=["template", "epilogue", "cli"] /]
-        [#return]
-    [/#if]
+[#macro aws_es_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]

--- a/providers/aws/components/federatedrole/setup.ftl
+++ b/providers/aws/components/federatedrole/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_federatedrole_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_federatedrole_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_federatedrole_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
@@ -48,7 +47,7 @@
             [#switch linkTargetCore.Type]
                 [#case USERPOOL_CLIENT_COMPONENT_TYPE ]
                 [#case USERPOOL_COMPONENT_TYPE ]
-        
+
                     [#local userPoolName = linkTargetAttributes["USERPOOL_NAME"]!"" ]
                     [#local userPoolClient = linkTargetAttributes["USERPOOL_CLIENTID"]!"" ]
 
@@ -274,5 +273,3 @@
         /]
     [/#if]
 [/#macro]
-
-

--- a/providers/aws/components/gateway/setup.ftl
+++ b/providers/aws/components/gateway/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_gateway_cf_segment occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_gateway_cf_genplan_segment occurrence ]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_gateway_cf_setup_segment occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local gwCore = occurrence.Core ]
     [#local gwSolution = occurrence.Configuration.Solution ]

--- a/providers/aws/components/lambda/setup.ftl
+++ b/providers/aws/components/lambda/setup.ftl
@@ -1,12 +1,11 @@
 [#ftl]
+[#macro aws_lambda_cf_genplan_application occurrence ]
+    [@addDefaultGenerationPlan subsets=["prologue", "template", "config"] /]
+[/#macro]
 
-[#macro aws_lambda_cf_application occurrence ]
+[#macro aws_lambda_cf_setup_application occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=["prologue", "template", "config"] /]
-        [#return]
-    [/#if]
     [#list occurrence.Occurrences as fn]
         [@internalProcessFunction fn /]
     [/#list]

--- a/providers/aws/components/lb/setup.ftl
+++ b/providers/aws/components/lb/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_lb_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_lb_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets=["prologue", "template"] /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=["prologue", "template"] /]
-        [#return]
-    [/#if]
+[#macro aws_lb_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]

--- a/providers/aws/components/mobileapp/setup.ftl
+++ b/providers/aws/components/mobileapp/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_mobileapp_cf_application occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_mobileapp_cf_genplan_application occurrence ]
+    [@addDefaultGenerationPlan subsets=["prologue", "config"] /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=["prologue", "config"] /]
-        [#return]
-    [/#if]
+[#macro aws_mobileapp_cf_setup_application occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]

--- a/providers/aws/components/mobilenotifier/setup.ftl
+++ b/providers/aws/components/mobilenotifier/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_mobilenotifier_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_mobilenotifier_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets=["prologue", "template", "epilogue", "cli"] /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=["prologue", "template", "epilogue", "cli"] /]
-        [#return]
-    [/#if]
+[#macro aws_mobilenotifier_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]

--- a/providers/aws/components/network/setup.ftl
+++ b/providers/aws/components/network/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_network_cf_segment occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_network_cf_genplan_segment occurrence ]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_network_cf_setup_segment occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]

--- a/providers/aws/components/s3/setup.ftl
+++ b/providers/aws/components/s3/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_s3_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_s3_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_s3_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
@@ -81,7 +80,7 @@
                                     formatS3NotificationPolicyId(
                                         s3Id,
                                         resourceId) ]
-                                
+
                                 [#local dependencies += [policyId] ]
 
                                 [#if deploymentSubsetRequired("s3", true)]
@@ -102,7 +101,7 @@
                                     formatS3NotificationPolicyId(
                                         s3Id,
                                         resourceId) ]
-                                        
+
                                 [#local dependencies += [ policyId ]]
 
                                 [#if deploymentSubsetRequired("s3", true )]
@@ -115,8 +114,8 @@
                         [/#switch]
 
                         [#list notification.Events as event ]
-                            [#local notifications += 
-                                    getS3Notification(resourceId, resourceType, event, notification.Prefix, notification.Suffix) ]     
+                            [#local notifications +=
+                                    getS3Notification(resourceId, resourceType, event, notification.Prefix, notification.Suffix) ]
                         [/#list]
                     [/#if]
                 [/#if]
@@ -184,7 +183,7 @@
 
                     [#local originPath = (linkTargetConfiguration.Solution.Origin.BasePath)?remove_ending("/") ]
                     [#if linkDirection == "inbound" ]
-                        [#local policyStatements += 
+                        [#local policyStatements +=
                                 s3ReadPermission(
                                     s3Name,
                                     originPath,

--- a/providers/aws/components/segment/segment_cert.ftl
+++ b/providers/aws/components/segment/segment_cert.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_cert_cf_segment occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_cert_cf_genplan_segment occurrence ]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_cert_cf_setup_segment occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#if deploymentSubsetRequired("cert", true)]
         [#local certificateId = formatCertificateId(segmentDomainCertificateId)]
@@ -18,4 +17,3 @@
         /]
     [/#if]
 [/#macro]
-

--- a/providers/aws/components/segment/segment_dashboard.ftl
+++ b/providers/aws/components/segment/segment_dashboard.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_dashboard_cf_segment occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_dashboard_cf_genplan_segment occurrence ]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_dashboard_cf_setup_segment occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#if deploymentSubsetRequired("dashboard", true)]
         [@createDashboard
@@ -15,5 +14,3 @@
         /]
     [/#if]
 [/#macro]
-
-

--- a/providers/aws/components/segment/segment_dns.ftl
+++ b/providers/aws/components/segment/segment_dns.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_dns_cf_segment occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_dns_cf_genplan_segment occurrence ]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_dns_cf_setup_segment occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#if deploymentSubsetRequired("dns", true)]
         [@cfResource

--- a/providers/aws/components/serviceregistry/setup.ftl
+++ b/providers/aws/components/serviceregistry/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_serviceregistry_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_serviceregistry_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_serviceregistry_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]

--- a/providers/aws/components/solution/solution_lg.ftl
+++ b/providers/aws/components/solution/solution_lg.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_lg_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_lg_cf_genplan_solution occurrence ]
+     [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_lg_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local componentLogGroupId = formatComponentLogGroupId(tier, component)]
     [#if deploymentSubsetRequired("lg", true) &&

--- a/providers/aws/components/spa/setup.ftl
+++ b/providers/aws/components/spa/setup.ftl
@@ -1,26 +1,18 @@
 [#ftl]
-[#macro aws_spa_cf_solution occurrence ]
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=["prologue" ] /]
-        [#return]
-    [/#if]
-
-    [#if deploymentSubsetRequired("prologue", false)]
-        [@addToDefaultBashScriptOutput
-            [
-                "warning \"solution level spa components have been deprecated. Please remove this component\""
-            ]
-        /]
-    [/#if]
+[#macro aws_spa_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets=[] /]
+    [@error
+        message="Solution SPA Deprecation"
+        context="Solution SPA has been replaced with the CDN component - please remove this unit from you solution level units"
+    /]
 [/#macro]
 
-[#macro aws_spa_cf_application occurrence  ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_spa_cf_genplan_application occurrence  ]
+    [@addDefaultGenerationPlan subsets=["prologue", "config", "epilogue" ] /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=["prologue", "config", "epilogue" ] /]
-        [#return]
-    [/#if]
+[#macro aws_spa_cf_setup_application occurrence  ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]

--- a/providers/aws/components/sqs/setup.ftl
+++ b/providers/aws/components/sqs/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_sqs_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_sqs_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_sqs_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#if deploymentSubsetRequired("sqs", true)]
 

--- a/providers/aws/components/topic/setup.ftl
+++ b/providers/aws/components/topic/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
 [#macro aws_topic_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+    [@addDefaultGenerationPlan subsets="template" /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets="template" /]
-        [#return]
-    [/#if]
+[#macro aws_topic_cf_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]

--- a/providers/aws/components/user/setup.ftl
+++ b/providers/aws/components/user/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_user_cf_application occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_user_cf_genplan_application occurrence ]
+    [@addDefaultGenerationPlan subsets=["prologue", "template", "epilogue"] /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=["prologue", "template", "epilogue"] /]
-        [#return]
-    [/#if]
+[#macro aws_user_cf_setup_application occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
     [#local resources = occurrence.State.Resources]

--- a/providers/aws/components/userpool/setup.ftl
+++ b/providers/aws/components/userpool/setup.ftl
@@ -1,11 +1,10 @@
 [#ftl]
-[#macro aws_userpool_cf_solution occurrence ]
-    [@debug message="Entering" context=occurrence enabled=false /]
+[#macro aws_userpool_cf_genplan_solution occurrence ]
+    [@addDefaultGenerationPlan subsets=["prologue", "template", "epilogue", "cli"] /]
+[/#macro]
 
-    [#if deploymentSubsetRequired("genplan", false)]
-        [@addDefaultGenerationPlan subsets=["prologue", "template", "epilogue", "cli"] /]
-        [#return]
-    [/#if]
+[#macro aws_userpool_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
@@ -25,7 +24,7 @@
         [#local userPoolCustomDomainCertArn = resources["customdomain"].CertificateArn]
 
         [#if ! userPoolCustomDomainCertArn?has_content ]
-            [@fatal 
+            [@fatal
                 message="ACM Certificate required in us-east-1"
                 context=resources
                 enabled=true
@@ -342,7 +341,7 @@
                                             )]
                     [#local samlIDPSignout = (environment[settingsPrefix + "SAML_IDP_SIGNOUT"])?has_content?then(
                                                     (environment[settingsPrefix + "SAML_IDP_SIGNOUT"]),
-                                                    subSolution.SAML.EnableIDPSignOut?c 
+                                                    subSolution.SAML.EnableIDPSignOut?c
                                             )]
 
                     [#local providerDetails = {
@@ -365,7 +364,7 @@
                                                 subSolution.OIDC.Scopes?join(","),
                                                 (environment[settingsPrefix + "OIDC_SCOPES"])!"COTFatal: Scopes not defined"
                                             )]
-                    
+
                     [#local oidcAttributesMethod = subSolution.OIDC.AttributesHttpMethod?has_content?then(
                                                 subSolution.OIDC.AttributesHttpMethod,
                                                 (environment[settingsPrefix + "OIDC_ATTRIBUTES_HTTP_METHOD"])!"COTFatal: AttributesHttpMethod not defined"
@@ -375,7 +374,7 @@
                                                 subSolution.OIDC.Issuer,
                                                 (environment[settingsPrefix + "OIDC_ISSUER"])!"COTFatal: Issuer not defined"
                                             )]
-                    
+
                     [#local oidcAuthorizeUrl = subSolution.OIDC.AuthorizeUrl?has_content?then(
                                                 subSolution.OIDC.AuthorizeUrl,
                                                 (environment[settingsPrefix + "OIDC_AUTHORIZE_URL"])!"COTFatal: AuthorizeUrl not defined"
@@ -385,7 +384,7 @@
                                                 subSolution.OIDC.TokenUrl,
                                                 (environment[settingsPrefix + "OIDC_TOKEN_URL"])!"COTFatal: TokenUrl not defined"
                                             )]
-                    
+
                     [#local oidcAttributesUrl = subSolution.OIDC.AttributesUrl?has_content?then(
                                                 subSolution.OIDC.AttributesUrl,
                                                 (environment[settingsPrefix + "OIDC_ATTRIBUTES_URL"])!"COTFatal: AttributesUrl not defined"
@@ -435,7 +434,7 @@
                         "       \"" + region + "\" " +
                         "       \"$\{userPoolId}\" " +
                         "       \"" + authProviderName + "\" " +
-                        "       \"" + authProviderEngine + "\" " + 
+                        "       \"" + authProviderEngine + "\" " +
                         (authProviderEngine == "OIDC" )?then(
                             "       \"" + subSolution.EncryptionScheme + "\" \"" + (oidcClientSecret!"") + "\" ",
                             "       \"\" \"\" "

--- a/providers/shared/deploymentframeworks/default/legacy.ftl
+++ b/providers/shared/deploymentframeworks/default/legacy.ftl
@@ -42,18 +42,18 @@
                     [#list occurrence.State.ResourceGroups as key,value]
                         [#switch commandLineOptions.Deployment.Unit.Subset ]
                             [#case "genplan" ]/]
-                                [#if invokeGenPlanMacro(occurrence, key, ["genplan", level] ) ]
+                                [#if invokeGenPlanMacro(occurrence, key, [ level ] ) ]
                                     [@debug
-                                        message="GenPlan Processing key:" + key + "level:" + level + "..."
+                                        message="Genplan Processing key:" + key + "..."
                                         enabled=false
                                     /]
                                 [/#if]
                                 [#break]
 
                             [#default]
-                                [#if invokeSetupMacro(occurrence, key, ["setup", level]) ]
+                                [#if invokeSetupMacro(occurrence, key, [ level ] ) ]
                                     [@debug
-                                        message="Processing " + key + " ..."
+                                        message="Setup Processing " + key + " ..."
                                         enabled=false
                                     /]
                                 [/#if]

--- a/providers/shared/deploymentframeworks/default/legacy.ftl
+++ b/providers/shared/deploymentframeworks/default/legacy.ftl
@@ -39,15 +39,25 @@
                             }
                     /]
 
-                    [@debug message=occurrence enabled=false /]
-
                     [#list occurrence.State.ResourceGroups as key,value]
-                        [#if invokeSetupMacro(occurrence, key, ["setup", level]) ]
-                            [@debug
-                                message="Processing " + key + " ..."
-                                enabled=false
-                            /]
-                        [/#if]
+                        [#switch commandLineOptions.Deployment.Unit.Subset ]
+                            [#case "genplan" ]/]
+                                [#if invokeGenPlanMacro(occurrence, key, ["genplan", level] ) ]
+                                    [@debug
+                                        message="GenPlan Processing key:" + key + "level:" + level + "..."
+                                        enabled=false
+                                    /]
+                                [/#if]
+                                [#break]
+
+                            [#default]
+                                [#if invokeSetupMacro(occurrence, key, ["setup", level]) ]
+                                    [@debug
+                                        message="Processing " + key + " ..."
+                                        enabled=false
+                                    /]
+                                [/#if]
+                        [/#switch]
                     [/#list]
                     [#local processingEnd = .now]
                     [@timing


### PR DESCRIPTION
Moves the genplan to a dedicated component macro which is invoked dynamically 

This is inline with the idea of introducing other plans which don't need to load the setup routine to generate what they need 

