### PR TITLE
Added IPAddressGroups attribute to Baseline Keys

### DIFF
--- a/providers/shared/components/baseline/id.ftl
+++ b/providers/shared/components/baseline/id.ftl
@@ -249,6 +249,11 @@
                 "Mandatory" : true
             },
             {
+                "Names" : "IPAddressGroups",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : ["_global"]
+            },
+            {
                 "Names" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration


### PR DESCRIPTION
for use in assigning the network access policies on keyvault. Defaults to global, which would leave the keyvault relying on permission-based access only. Setting it this way ensures that the COT user who is implementing the infrastructure can access the keyvault during setup. Less open configuration will need to account for the given network that the admins reside on.