### PR TITLE
<fix> EIP remove tags on gateway components

### DIFF
--- a/providers/aws/components/gateway/setup.ftl
+++ b/providers/aws/components/gateway/setup.ftl
@@ -54,10 +54,7 @@
 
                     [@createEIP
                         id=eipId
-                        tags=getOccurrenceCoreTags(
-                            occurrence,
-                            eipName
-                        )
+                        tags=[]
                     /]
 
                 [/#if]

--- a/providers/aws/services/vpc/resource.ftl
+++ b/providers/aws/services/vpc/resource.ftl
@@ -303,7 +303,7 @@
 
 [#macro createEIP
             id
-            tags
+            tags=[]
             dependencies=""]
     [@cfResource
         id=id


### PR DESCRIPTION
Once a NAT Gateway has been assinged to an EIP you can't make updates to the EIP, including tagging unless you replace the NAT Gateway 

This disables tags on gatway components for the time being