### PR TITLE
<fix> Remove analyzeCIDR usage

### DIFF
--- a/providers/aws/services/waf/resource.ftl
+++ b/providers/aws/services/waf/resource.ftl
@@ -91,18 +91,18 @@
     [#return result]
 [/#function]
 
+[#-- TODO(mfl) Make this work for IPv6 as well --]
+[#-- For now always assume IPv4                --]
 [#function formatWAFIPMatchTuples filter={} valueSet={} ]
     [#local result= [] ]
     [#list getWAFValueList(filter.Targets, valueSet) as target]
-        [#local analyzedCIDR = analyzeCIDR(target) ]
-        [#if analyzedCIDR?has_content]
-            [#local result += [
-                    {
-                        "Type" : analyzedCIDR.Type,
-                        "Value" : target
-                    }
-                ] ]
-        [/#if]
+        [#local result += [
+                {
+                    "Type" : "IPV4",
+                    "Value" : target
+                }
+            ]
+        ]
     [/#list]
     [#return result]
 [/#function]


### PR DESCRIPTION
https://github.com/codeontap/gen3/pull/1082 removed the analyzeCIDR function without remediating its use in the WAF configuration management.

It was used to determine the type of an IP address range (v4 vs v6).

For now, hard code to IPv4.
