### PR TITLE
<fix> Remove extra chars from genplan

### DIFF
--- a/providers/shared/deploymentframeworks/default/legacy.ftl
+++ b/providers/shared/deploymentframeworks/default/legacy.ftl
@@ -41,7 +41,7 @@
 
                     [#list occurrence.State.ResourceGroups as key,value]
                         [#switch commandLineOptions.Deployment.Unit.Subset ]
-                            [#case "genplan" ]/]
+                            [#case "genplan" ]
                                 [#if invokeGenPlanMacro(occurrence, key, [ level ] ) ]
                                     [@debug
                                         message="Genplan Processing key:" + key + "..."


### PR DESCRIPTION
Remove a couple of spurious chars when processing genplans.