### PR TITLE
<fix> lb updates from lint testing

### DIFF
--- a/providers/aws/components/lb/setup.ftl
+++ b/providers/aws/components/lb/setup.ftl
@@ -434,7 +434,9 @@
                         name=securityGroupName
                         occurrence=occurrence
                         ingressRules=[ {"Port" : sourcePort.Port, "CIDR" : cidrs} ]
-                        vpcId=vpcId/]
+                        egressRules=[ { "Port" : "any",  "CIDR" : "0.0.0.0/0" }]
+                        vpcId=vpcId
+                    /]
 
                 [/#if]
                 [#break]

--- a/providers/aws/services/lb/resource.ftl
+++ b/providers/aws/services/lb/resource.ftl
@@ -67,7 +67,7 @@
 ]
 
 [#list lbMappings as type, mappings]
-    [@addOutputMapping 
+    [@addOutputMapping
         provider=AWS_PROVIDER
         resourceType=type
         mappings=mappings
@@ -237,8 +237,8 @@
             {
                 "HealthCheckPort" : (destination.HealthCheck.Port)!"traffic-port",
                 "HealthCheckProtocol" : healthCheckProtocol,
-                "HealthCheckIntervalSeconds" : destination.HealthCheck.Interval,
-                "HealthyThresholdCount" : destination.HealthCheck.HealthyThreshold,
+                "HealthCheckIntervalSeconds" : destination.HealthCheck.Interval?number,
+                "HealthyThresholdCount" : destination.HealthCheck.HealthyThreshold?number,
                 "Port" : destination.Port,
                 "Protocol" : (destination.Protocol)?upper_case,
                 "VpcId": getReference(vpcId),
@@ -263,11 +263,11 @@
             ) +
             (healthCheckProtocol != "TCP")?then(
                 {
-                    "HealthCheckTimeoutSeconds" : destination.HealthCheck.Timeout,
-                    "UnhealthyThresholdCount" : destination.HealthCheck.UnhealthyThreshold
+                    "HealthCheckTimeoutSeconds" : destination.HealthCheck.Timeout?number,
+                    "UnhealthyThresholdCount" : destination.HealthCheck.UnhealthyThreshold?number
                 },
                 {
-                    "UnhealthyThresholdCount" : destination.HealthCheck.HealthyThreshold
+                    "UnhealthyThresholdCount" : destination.HealthCheck.HealthyThreshold?number
                 }
 
             )

--- a/providers/aws/services/vpc/resource.ftl
+++ b/providers/aws/services/vpc/resource.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#function getSecurityGroupIngressRules port cidr groupId=""]
+[#function getSecurityGroupRules port cidr groupId=""]
     [#local rules = [] ]
     [#list asArray(cidr) as cidrBlock]
         [#local rule =
@@ -89,19 +89,29 @@
                 )
             type="AWS::EC2::SecurityGroupIngress"
             properties=
-                getSecurityGroupIngressRules(port, cidrBlock, groupId)[0]
+                getSecurityGroupRules(port, cidrBlock, groupId)[0]
         /]
     [/#list]
 [/#macro]
 
-[#macro createSecurityGroup id name vpcId tier={} component={} occurrence={} description="" ingressRules=[] ]
+[#macro createSecurityGroup id name vpcId tier={} component={} occurrence={} description="" ingressRules=[] egressRules=[] ]
     [#local nonemptyIngressRules = [] ]
     [#list asFlattenedArray(ingressRules) as ingressRule]
         [#if ingressRule.CIDR?has_content]
             [#local nonemptyIngressRules +=
-                        getSecurityGroupIngressRules(
+                        getSecurityGroupRules(
                             ingressRule.Port,
                             ingressRule.CIDR) ]
+        [/#if]
+    [/#list]
+
+    [#local nonemptyEgressRules = [] ]
+    [#list asFlattenedArray(egressRules) as egressRule]
+        [#if egressRule.CIDR?has_content]
+            [#local nonemptyEgressRules +=
+                        getSecurityGroupRules(
+                            egressRule.Port,
+                            egressRule.CIDR) ]
         [/#if]
     [/#list]
 
@@ -116,6 +126,10 @@
         attributeIfContent(
             "SecurityGroupIngress",
             nonemptyIngressRules
+        ) +
+        attributeIfContent(
+            "SecurityGroupEgress",
+            nonemptyEgressRules
         )
     ]
 


### PR DESCRIPTION
Some minor fixes to lb rules based on the testing results in #1145 

- Change the type of value for target groups - cfn-lint 
- Make the egress security rule an explicit rather than implicit - cfn_nag F1000  