### PR TITLE
<feature> Deployment Unit list

### DIFF
--- a/aws/templates/createUnitlist.ftl
+++ b/aws/templates/createUnitlist.ftl
@@ -1,0 +1,61 @@
+[#ftl]
+[#include "/bootstrap.ftl" ]
+
+[#function getDeploymentUnits ]
+  [#local deploymentUnits=[] ]
+  [#list tiers as tier]
+    [#list tier.Components!{} as id, value]
+      [#local component =
+        {
+            "Id" : id,
+            "Name" : id
+        } + value ]
+
+      [#if component?is_hash]
+        [#local occurrences = getOccurrences(tier, component) ]
+
+        [#list occurrences as occurrence ]
+          [#local deploymentUnits =
+                    combineEntities(
+                      deploymentUnits,
+                      asArray((occurrence.Configuration.Solution.DeploymentUnits)![]),
+                      UNIQUE_COMBINE_BEHAVIOUR
+                    )]
+        [/#list]
+      [/#if]
+    [/#list]
+  [/#list]
+  [#return deploymentUnits ]
+[/#function]
+
+[#-- Redefine the core processing macro --]
+[#macro processComponents level]
+  [#if (commandLineOptions.Deployment.Unit.Subset!"") == "config" ]
+    [@addToDefaultJsonOutput
+      content={ "DeploymentUnits" : getDeploymentUnits() } + attributeIfContent("COTMessages", logMessages) /]
+  [/#if]
+[/#macro]
+
+[#if (commandLineOptions.Deployment.Unit.Subset!"") == "genplan" ]
+  [@initialiseDefaultScriptOutput format=commandLineOptions.Deployment.Output.Format /]
+  [@addDefaultGenerationPlan subsets="config" /]
+[#else]
+  [#assign allDeploymentUnits = true]
+  [#assign commandLineOptions =
+      mergeObjects(
+          commandLineOptions,
+          {
+              "Deployment" : {
+                  "Unit" : {
+                      "Name" : ""
+                  }
+              }
+          }
+      ) ]
+[/#if]
+
+[@generateOutput
+  deploymentFramework=commandLineOptions.Deployment.Framework.Name
+  type=commandLineOptions.Deployment.Output.Type
+  format=commandLineOptions.Deployment.Output.Format
+/]

--- a/execution/contextTree.sh
+++ b/execution/contextTree.sh
@@ -704,6 +704,7 @@ function isValidUnit() {
 
   # Known levels
   declare -gA unit_required=( \
+    ["unitlist"]="false" \
     ["blueprint"]="false" \
     ["buildblueprint"]="true" \
     ["account"]="true" \


### PR DESCRIPTION
Adds a new level deployment which will generate a list of all deployment units found a blueprint and return them as a list 

This is intended to be used as a way to locate deployment units and loop through them for template generation 