### PR TITLE
Enable Plugin Provider Pseudo Stacks

### DIFF
--- a/engine/inputdata/stackOutput.ftl
+++ b/engine/inputdata/stackOutput.ftl
@@ -15,7 +15,7 @@
     ],
     "Attributes" : [
         {
-            "Names" : "Account",
+            "Names" : ["Account", "Subscription"],
             "Type" : STRING_TYPE,
             "Mandatory" : true
         },

--- a/providers/shared/inputsources/composite/stackoutput.ftl
+++ b/providers/shared/inputsources/composite/stackoutput.ftl
@@ -1,0 +1,44 @@
+[#ftl]
+
+[#macro shared_input_composite_stackoutput_seed id="" deploymentUnit="" level="" region="" account=""]
+
+    [#local stackOutputs = [] ]
+
+    [#-- Cloudformation Stack Output Processing --]
+    [#-- Stack outputs from cloudformation are processed based on the output from the awscli command --]
+    [#-- aws cloudformation describe-stacks --]
+    [#-- The component level is determined by the first part of the file name --]
+    [#list commandLineOptions.Composites.StackOutputs as stackOutputFile ]
+
+        [#local level = ((stackOutputFile["FileName"])?split('-'))[0] ]
+
+        [#list (stackOutputFile["Content"]![]) as rawStackOutput ]
+            [#if (rawStackOutput["Stacks"]!{})?has_content ]
+                [#list rawStackOutput["Stacks"] as stack ]
+                    [#if (stack["Outputs"]![])?has_content ]
+
+                        [#local stackOutput = {} ]
+
+                        [#if stack["Outputs"]?is_sequence ]
+                            [#list stack["Outputs"] as output ]
+                                [#local stackOutput += {
+                                    output.OutputKey : output.OutputValue
+                                }]
+                            [/#list]
+                        [/#if]
+
+                        [#if stack["Outputs"]?is_collection ]
+                            [#local stackOutput = stack["Outputs"] ]
+                        [/#if]
+
+                        [#if stackOutput?has_content ]
+                            [#local stackOutputs += [ mergeObjects( { "Level" : level} , stackOutput) ] ]
+                        [/#if]
+                    [/#if]
+                [/#list]
+            [/#if]
+        [/#list]
+    [/#list]
+
+    [@addStackOutputs stackOutputs /]
+[/#macro]


### PR DESCRIPTION
The shared provider does not have a stackoutput macro, so when getStackOutputObject looks up pseudostacks generated by another provider it cannot find any. This PR copies/renames the primary composite stackoutput macro for AWS into the shared provider.