### PR TITLE
Shared Baseline Provider to load for all providers

### DIFF
--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -3,10 +3,12 @@
 [#include "common.ftl"]
 [#include "openapi.ftl"]
 
+[#-- Shared Provider Configurations --]
+[@includeSharedComponentConfiguration component="baseline" /]
+
 [#-- Temporary AWS stuff --]
 [#if commandLineOptions.Deployment.Provider.Name = "aws"]
     [@includeProviderConfiguration provider=AWS_PROVIDER /]
-    [@includeSharedComponentConfiguration component="baseline" /]
     [@includeProviderComponentDefinitionConfiguration provider="aws" component="baseline" /]
     [@includeProviderComponentConfiguration provider="aws" component="baseline" services="baseline" /]
     [@includeProviderComponentDefinitionConfiguration provider="aws" component="s3" /]


### PR DESCRIPTION
The shared baseline component contains the functions required for linking to the baseline. Without pre-loading it, you can't link to it. This PR ensures that its pre-loaded for all providers.