### PR TITLE
<refactor> move RDS CA Control to cloudformation

### DIFF
--- a/providers/aws/components/db/setup.ftl
+++ b/providers/aws/components/db/setup.ftl
@@ -715,6 +715,7 @@
                         availabilityZone=zones[0].AWSZone
                         encrypted=solution.Encrypted
                         kmsKeyId=cmkKeyId
+                        caCertificate=requiredRDSCA
                         masterUsername=rdsUsername
                         masterPassword=rdsPassword
                         databaseName=rdsDatabaseName
@@ -894,27 +895,6 @@
                     [
                         "}",
                         "reset_master_password || return $?"
-                    ],
-                []) +
-                (rdsCA != requiredRDSCA && !auroraCluster )?then(
-                    [
-                        "# Update RDS CA",
-                        "function update_rds_ca() {",
-                        "info \"Updating RDS CA ... \"",
-                        "rdsCAIdentifier=\"" + requiredRDSCA + "\"",
-                        "update_rds_ca_identifier" +
-                        " \"" + region + "\" " +
-                        " \"" + rdsFullName + "\" " +
-                        " \"$\{rdsCAIdentifier}\" || return $?"
-                    ] +
-                    pseudoStackOutputScript(
-                            "RDS CA Identifier",
-                            { formatId(rdsId, "ca") : requiredRDSCA },
-                            "ca"
-                    ) +
-                    [
-                        "}",
-                        "update_rds_ca || return $?"
                     ],
                 []) +
                 [

--- a/providers/aws/services/rds/resource.ftl
+++ b/providers/aws/services/rds/resource.ftl
@@ -79,6 +79,7 @@
     performanceInsights
     performanceInsightsRetention
     tags
+    caCertificate
     engineVersion=""
     clusterMember=false
     clusterId=""
@@ -116,7 +117,8 @@
             "DeleteAutomatedBackups" : deleteAutomatedBackups,
             "DBSubnetGroupName": getReference(subnetGroupId),
             "DBParameterGroupName": getReference(parameterGroupId),
-            "OptionGroupName": getReference(optionGroupId)
+            "OptionGroupName": getReference(optionGroupId),
+            "CACertificateIdentifier" : caCertificate
         } +
         valueIfTrue(
             {


### PR DESCRIPTION
AWS hasn't announced it in documentation yet but they have added support for setting the CA Certificate identifier via Cloudformation on RDS instances 

https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/211 

This PR moves our existing CLI support into Cloudformation