### PR TITLE
<fix> Use default values for ES nodes counts instead of value check

### DIFF
--- a/providers/aws/components/es/setup.ftl
+++ b/providers/aws/components/es/setup.ftl
@@ -44,9 +44,9 @@
     [#local lgName = (resources["lg"].Name)!"" ]
 
     [#local processorProfile = getProcessor(occurrence, "es")]
-    [#local dataNodeCount = valueIfContent(
+    [#local dataNodeCount = valueIfTrue(
                                 processorProfile.Count,
-                                processorProfile.Count,
+                                ( processorProfile.Count > 0 ),
                                 multiAZ?then(
                                     processorProfile.CountPerZone * zones?size,
                                     processorProfile.CountPerZone

--- a/providers/shared/references/Processor/id.ftl
+++ b/providers/shared/references/Processor/id.ftl
@@ -44,8 +44,7 @@
             "Children" : [
                 {
                     "Names" : "Processor",
-                    "Type" : STRING_TYPE,
-                    "Mandatory" : true
+                    "Type" : STRING_TYPE
                 }
             ]
         },
@@ -54,8 +53,7 @@
             "Children" : [
                 {
                     "Names" : "Processor",
-                    "Type" : STRING_TYPE,
-                    "Mandatory" : true
+                    "Type" : STRING_TYPE
                 }
             ]
         },
@@ -64,8 +62,7 @@
             "Children" : [
                 {
                     "Names" : "Processor",
-                    "Type" : STRING_TYPE,
-                    "Mandatory" : true
+                    "Type" : STRING_TYPE
                 }
             ]
         },
@@ -74,8 +71,7 @@
             "Children" : [
                 {
                     "Names" : "Processor",
-                    "Type" : STRING_TYPE,
-                    "Mandatory" : true
+                    "Type" : STRING_TYPE
                 }
             ] +
             nodeCountChildConfiguration
@@ -85,8 +81,7 @@
             "Children" : [
                 {
                     "Names" : "Processor",
-                    "Type" : STRING_TYPE,
-                    "Mandatory" : true
+                    "Type" : STRING_TYPE
                 }
             ] +
             nodeCountChildConfiguration
@@ -96,8 +91,7 @@
             "Children" : [
                 {
                     "Names" : "Processor",
-                    "Type" : STRING_TYPE,
-                    "Mandatory" : true
+                    "Type" : STRING_TYPE
                 }
             ] +
             nodeCountChildConfiguration
@@ -107,8 +101,7 @@
             "Children" : [
                 {
                     "Names" : "Processor",
-                    "Type" : STRING_TYPE,
-                    "Mandatory" : true
+                    "Type" : STRING_TYPE
                 },
                 {
                     "Names" : "CountPerZone",
@@ -122,8 +115,7 @@
             "Children" : [
                 {
                     "Names" : [ "Processor", "DataNodeProcessor" ],
-                    "Type" : STRING_TYPE,
-                    "Mandatory" : true
+                    "Type" : STRING_TYPE
                 },
                 {
                     "Names" : [ "CountPerZone", "DataNodeCountPerZone" ],
@@ -140,8 +132,7 @@
                     "Children" : [
                         {
                             "Names" : "Processor",
-                            "Type" : STRING_TYPE,
-                            "Mandatory: true
+                            "Type" : STRING_TYPE
                         },
                         {
                             "Names" : "Count",
@@ -161,8 +152,7 @@
             "Children" : [
                 {
                     "Names" : "Processor",
-                    "Type" : STRING_TYPE,
-                    "Mandatory" : true
+                    "Type" : STRING_TYPE
                 },
                 {
                     "Names" : "DesiredCorePerZone",

--- a/providers/shared/references/Processor/id.ftl
+++ b/providers/shared/references/Processor/id.ftl
@@ -44,7 +44,8 @@
             "Children" : [
                 {
                     "Names" : "Processor",
-                    "Type" : STRING_TYPE
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
                 }
             ]
         },
@@ -53,7 +54,8 @@
             "Children" : [
                 {
                     "Names" : "Processor",
-                    "Type" : STRING_TYPE
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
                 }
             ]
         },
@@ -62,7 +64,8 @@
             "Children" : [
                 {
                     "Names" : "Processor",
-                    "Type" : STRING_TYPE
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
                 }
             ]
         },
@@ -71,7 +74,8 @@
             "Children" : [
                 {
                     "Names" : "Processor",
-                    "Type" : STRING_TYPE
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
                 }
             ] +
             nodeCountChildConfiguration
@@ -81,7 +85,8 @@
             "Children" : [
                 {
                     "Names" : "Processor",
-                    "Type" : STRING_TYPE
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
                 }
             ] +
             nodeCountChildConfiguration
@@ -91,7 +96,8 @@
             "Children" : [
                 {
                     "Names" : "Processor",
-                    "Type" : STRING_TYPE
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
                 }
             ] +
             nodeCountChildConfiguration
@@ -101,11 +107,13 @@
             "Children" : [
                 {
                     "Names" : "Processor",
-                    "Type" : STRING_TYPE
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
                 },
                 {
                     "Names" : "CountPerZone",
-                    "Type" : NUMBER_TYPE
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 1
                 }
             ]
         },
@@ -114,22 +122,26 @@
             "Children" : [
                 {
                     "Names" : [ "Processor", "DataNodeProcessor" ],
-                    "Type" : STRING_TYPE
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
                 },
                 {
                     "Names" : [ "CountPerZone", "DataNodeCountPerZone" ],
-                    "Type" : NUMBER_TYPE
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 1
                 },
                 {
                     "Names" : [ "Count", "DataNodeCount" ],
-                    "Type" : NUMBER_TYPE
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 0
                 },
                 {
                     "Names" : "Master",
                     "Children" : [
                         {
                             "Names" : "Processor",
-                            "Type" : STRING_TYPE
+                            "Type" : STRING_TYPE,
+                            "Mandatory: true
                         },
                         {
                             "Names" : "Count",
@@ -149,15 +161,18 @@
             "Children" : [
                 {
                     "Names" : "Processor",
-                    "Type" : STRING_TYPE
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
                 },
                 {
                     "Names" : "DesiredCorePerZone",
-                    "Type" : NUMBER_TYPE
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 1
                 },
                 {
                     "Names" : "DesiredTaskPerZone",
-                    "Type" : NUMBER_TYPE
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 1
                 }
             ]
         }


### PR DESCRIPTION
To remove the risk of null values causing issues this PR adds default counts to the processor profile configuration. This way we know it will always have a value 