### PR TITLE
<fix> ES Acccess Policy Updates

### DIFF
--- a/providers/aws/inputsources/shared/masterdata.ftl
+++ b/providers/aws/inputsources/shared/masterdata.ftl
@@ -2138,6 +2138,9 @@
       },
       "db": {
         "SSLCertificateAuthority": "rds-ca-2019"
+      },
+      "es" : {
+        "ProtocolPolicy" : "https-only"
       }
     }
   },

--- a/providers/aws/masterData.json
+++ b/providers/aws/masterData.json
@@ -2128,6 +2128,9 @@
       },
       "db": {
         "SSLCertificateAuthority": "rds-ca-2019"
+      },
+      "es" : {
+        "ProtocolPolicy" : "https-only"
       }
     }
   },

--- a/providers/shared/components/es/id.ftl
+++ b/providers/shared/components/es/id.ftl
@@ -74,6 +74,11 @@
                             "Names" : "Alert",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
+                        },
+                        {
+                            "Names" : "Security",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
                         }
                     ]
             },

--- a/providers/shared/references/SecurityProfile/id.ftl
+++ b/providers/shared/references/SecurityProfile/id.ftl
@@ -1,18 +1,69 @@
 [#ftl]
 
-[@addReference 
+[@addReference
     type=SECURITYPROFILE_REFERENCE_TYPE
     pluralType="SecurityProfiles"
     properties=[
             {
                 "Type"  : "Description",
-                "Value" : "Security Configuration Options" 
+                "Value" : "Security Configuration Options"
             }
         ]
     attributes=[
         {
-            "Names" : "*",
-            "Description" : "The component type the profile applies to",
+            "Names" : "lb",
+            "Children" : [
+                {
+                    "Names" : "application",
+                    "Children" : [
+                        {
+                            "Names" : "HTTPSProfile",
+                            "Type" : STRING_TYPE
+                        },
+                        {
+                            "Names" : "WAFProfile",
+                            "Type" : STRING_TYPE
+                        },
+                        {
+                            "Names" : "WAFValueSet",
+                            "Type" : STRING_TYPE
+                        }
+                    ]
+                },
+                {
+                    "Names" : "classic",
+                    "Children" : [
+                        {
+                            "Names" : "HTTPSProfile",
+                            "Type" : STRING_TYPE
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "Names" : "apigateway",
+            "Children" : [
+                {
+                    "Names" : "HTTPSProfile",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Names" : "ProtocolPolicy",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Names" : "WAFProfile",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Names" : "WAFValueSet",
+                    "Type" : STRING_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : "cdn",
             "Children" : [
                 {
                     "Names" : "HTTPSProfile",
@@ -25,11 +76,25 @@
                 {
                     "Names" : "WAFValueSet",
                     "Type" : STRING_TYPE
-                },
+                }
+            ]
+        },
+        {
+            "Names" : "db",
+            "Children" : [
                 {
                     "Names" : "SSLCertificateAuthority",
-                    "Description" : "The Certificate authority to use for SSL Clients",
                     "Type" : STRING_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : "es",
+            "Children" : [
+                {
+                    "Names" : "ProtocolPolicy",
+                    "Type" : STRING_TYPE,
+                    "Values" : [ "https-only", "http-https", "http-only" ]
                 }
             ]
         }


### PR DESCRIPTION
A couple more fixes from testing the ES deployment to VPC 

- Creates a Service linked role for Elasticsearch to create ENI - This only needs to be created once per account - the script will check and see if one exists and move on if its not there 
- Adds Security profile to control the endpoint Protocol ( http vs https ) 
   - In VPC this updates the security groups 
   - Public has HTTPS only control but its not in cloudformation yet 
- Access policies cannot contain IP's when they applied to VPC based instances 
   - Moves the IP control over to security groups 
   - When you only want IP based auth on VPC based instances you need to add an open access policy 
- Similar to the processor profile splits out the Security Profiles based on their types 
