### PR TITLE
<refactor> Move test case scenarios into provider

### DIFF
--- a/aws/createBlueprint.sh
+++ b/aws/createBlueprint.sh
@@ -7,9 +7,9 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 function options() {
 
   # Parse options
-  while getopts ":f:hi:o:p:t:" option; do
+  while getopts ":f:hi:o:p:" option; do
       case "${option}" in
-          f|i|o|p|s|t) TEMPLATE_ARGS="${TEMPLATE_ARGS} -${option} ${OPTARG}" ;;
+          f|i|o|p) TEMPLATE_ARGS="${TEMPLATE_ARGS} -${option} ${OPTARG}" ;;
           h) usage; return 1 ;;
           \?) fatalOption; return 1 ;;
       esac
@@ -37,7 +37,7 @@ PARAMETERS:
 (o) -i GENERATION_INPUT_SOURCE is the source of input data to use when generating the template
     -h                         shows this text
 (o) -o OUTPUT_DIR              is the directory where the outputs will be saved - defaults to the PRODUCT_STATE_DIR
-(o) -p GENERATION_PROVIDERS     is the provider to for template generation
+(o) -p GENERATION_PROVIDER     is a provider to load for template generation - multiple providers can be added with extra arguments
 (o) -f GENERATION_FRAMEWORK    is the output framework to use for template generation
 
   (m) mandatory, (o) optional, (d) deprecated

--- a/aws/createBlueprint.sh
+++ b/aws/createBlueprint.sh
@@ -30,7 +30,7 @@ DESCRIPTION:
         ( tenant, account, product, solution, environment, segment )
 
 USAGE:
-  $(basename $0) -i GENERATION_INPUT_SOURCE -s GENERATION_SUBPROVIDERS
+  $(basename $0)
 
 PARAMETERS:
 

--- a/aws/createBlueprint.sh
+++ b/aws/createBlueprint.sh
@@ -7,7 +7,7 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 function options() {
 
   # Parse options
-  while getopts ":f:hi:o:p:s:t:" option; do
+  while getopts ":f:hi:o:p:t:" option; do
       case "${option}" in
           f|i|o|p|s|t) TEMPLATE_ARGS="${TEMPLATE_ARGS} -${option} ${OPTARG}" ;;
           h) usage; return 1 ;;
@@ -37,9 +37,8 @@ PARAMETERS:
 (o) -i GENERATION_INPUT_SOURCE is the source of input data to use when generating the template
     -h                         shows this text
 (o) -o OUTPUT_DIR              is the directory where the outputs will be saved - defaults to the PRODUCT_STATE_DIR
-(o) -p GENERATION_PROVIDER     is the provider to for template generation
+(o) -p GENERATION_PROVIDERS     is the provider to for template generation
 (o) -f GENERATION_FRAMEWORK    is the output framework to use for template generation
-(o) -s GENERATION_SUBPROVIDERS is a command seperated list of additional providers to include in the loading process
 
   (m) mandatory, (o) optional, (d) deprecated
 

--- a/aws/createBlueprint.sh
+++ b/aws/createBlueprint.sh
@@ -30,7 +30,7 @@ DESCRIPTION:
         ( tenant, account, product, solution, environment, segment )
 
 USAGE:
-  $(basename $0) -i GENERATION_INPUT_SOURCE -t GENERATION_TESTCASE -s GENERATION_SCENARIOS
+  $(basename $0) -i GENERATION_INPUT_SOURCE -s GENERATION_SUBPROVIDERS
 
 PARAMETERS:
 
@@ -39,8 +39,7 @@ PARAMETERS:
 (o) -o OUTPUT_DIR              is the directory where the outputs will be saved - defaults to the PRODUCT_STATE_DIR
 (o) -p GENERATION_PROVIDER     is the provider to for template generation
 (o) -f GENERATION_FRAMEWORK    is the output framework to use for template generation
-(o) -t GENERATION_TESTCASE     is the test case you would like to generate a template for
-(o) -s GENERATION_SCENARIOS    is a comma seperated list of framework scenarios to load
+(o) -s GENERATION_SUBPROVIDERS is a command seperated list of additional providers to include in the loading process
 
   (m) mandatory, (o) optional, (d) deprecated
 

--- a/aws/createBuildblueprint.sh
+++ b/aws/createBuildblueprint.sh
@@ -7,7 +7,7 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 function options() {
 
   # Parse options
-  while getopts ":f:hi:o:p:s:t:u:" option; do
+  while getopts ":f:hi:o:p:t:u:" option; do
       case "${option}" in
           f|i|o|p|s|t|u) TEMPLATE_ARGS="${TEMPLATE_ARGS} -${option} ${OPTARG}" ;;
           h) usage; return 1 ;;
@@ -33,9 +33,8 @@ PARAMETERS:
 (o) -i GENERATION_INPUT_SOURCE is the source of input data to use when generating the template
     -h                         shows this text
 (o) -o OUTPUT_DIR              is the directory where the outputs will be saved - defaults to the PRODUCT_STATE_DIR
-(o) -p GENERATION_PROVIDER     is the provider to for template generation
+(o) -p GENERATION_PROVIDERS     is the provider to for template generation
 (o) -f GENERATION_FRAMEWORK    is the output framework to use for template generation
-(o) -s GENERATION_SUBPROVIDERS is a command seperated list of additional providers to include in the loading process
 (m) -u DEPLOYMENT_UNIT         is the deployment unit to be included in the template
 
   (m) mandatory, (o) optional, (d) deprecated

--- a/aws/createBuildblueprint.sh
+++ b/aws/createBuildblueprint.sh
@@ -7,9 +7,9 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 function options() {
 
   # Parse options
-  while getopts ":f:hi:o:p:t:u:" option; do
+  while getopts ":f:hi:o:p:u:" option; do
       case "${option}" in
-          f|i|o|p|s|t|u) TEMPLATE_ARGS="${TEMPLATE_ARGS} -${option} ${OPTARG}" ;;
+          f|i|o|p|u) TEMPLATE_ARGS="${TEMPLATE_ARGS} -${option} ${OPTARG}" ;;
           h) usage; return 1 ;;
           \?) fatalOption; return 1 ;;
       esac
@@ -30,11 +30,11 @@ USAGE:
 
 PARAMETERS:
 
+(o) -f GENERATION_FRAMEWORK    is the output framework to use for template generation
 (o) -i GENERATION_INPUT_SOURCE is the source of input data to use when generating the template
     -h                         shows this text
 (o) -o OUTPUT_DIR              is the directory where the outputs will be saved - defaults to the PRODUCT_STATE_DIR
-(o) -p GENERATION_PROVIDERS     is the provider to for template generation
-(o) -f GENERATION_FRAMEWORK    is the output framework to use for template generation
+(o) -p GENERATION_PROVIDER     is a provider to load for template generation - multiple providers can be added with extra arguments
 (m) -u DEPLOYMENT_UNIT         is the deployment unit to be included in the template
 
   (m) mandatory, (o) optional, (d) deprecated
@@ -59,7 +59,7 @@ OUTPUTS:
 
   - File
     - Name: blueprint.json
-    - Directory: "AUTOMATION_DATA_DIR" or "PRODUCT_INFRASTRUCTURE_DIR/cot/ENVIRONMENT/SEGMENT/"
+    - Directory: "OUTPUT_DIR" or "PRODUCT_INFRASTRUCTURE_DIR/cot/ENVIRONMENT/SEGMENT/"
 
 NOTES:
 

--- a/aws/createBuildblueprint.sh
+++ b/aws/createBuildblueprint.sh
@@ -35,8 +35,7 @@ PARAMETERS:
 (o) -o OUTPUT_DIR              is the directory where the outputs will be saved - defaults to the PRODUCT_STATE_DIR
 (o) -p GENERATION_PROVIDER     is the provider to for template generation
 (o) -f GENERATION_FRAMEWORK    is the output framework to use for template generation
-(o) -s GENERATION_SCENARIOS    is a comma seperated list of framework scenarios to load
-(o) -t GENERATION_TESTCASE     is the test case you would like to generate a template for
+(o) -s GENERATION_SUBPROVIDERS is a command seperated list of additional providers to include in the loading process
 (m) -u DEPLOYMENT_UNIT         is the deployment unit to be included in the template
 
   (m) mandatory, (o) optional, (d) deprecated

--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -299,7 +299,7 @@ function process_template_pass() {
   local template_composites=()
 
   # Define the possible passes
-  local pass_list=("genplan" "testplan" "pregeneration" "prologue" "template" "epilogue" "cli" "parameters" "config")
+  local pass_list=("genplan" "testcase" "pregeneration" "prologue" "template" "epilogue" "cli" "parameters" "config")
 
   # Initialise the components of the pass filenames
   declare -A pass_level_prefix

--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -12,6 +12,8 @@ GENERATION_PROVIDERS_DEFAULT="aws"
 GENERATION_FRAMEWORK_DEFAULT="cf"
 GENERATION_INPUT_SOURCE_DEFAULT="composite"
 
+arrayFromList GENERATION_PROVIDERS "${GENERATION_PROVIDERS}" ","
+
 function usage() {
   cat <<EOF
 
@@ -32,7 +34,7 @@ where
 (m) -u DEPLOYMENT_UNIT         is the deployment unit to be included in the template
 (o) -z DEPLOYMENT_UNIT_SUBSET  is the subset of the deployment unit required
 (o) -d DEPLOYMENT_MODE         is the deployment mode the template will be generated for
-(o) -p GENERATION_PROVIDERS     is a list of comma separated providers to load for template generation
+(o) -p GENERATION_PROVIDER     is a provider to load for template generation - multiple providers can be added with extra arguments
 (o) -f GENERATION_FRAMEWORK    is the output framework to use for template generation
 
 (m) mandatory, (o) optional, (d) deprecated
@@ -59,7 +61,7 @@ EOF
 function options() {
 
   # Parse options
-  while getopts ":c:d:f:g:hi:l:o:p:q:r:s:u:z:" option; do
+  while getopts ":c:d:f:g:hi:l:o:p:q:r:u:z:" option; do
       case "${option}" in
           c) CONFIGURATION_REFERENCE="${OPTARG}" ;;
           d) DEPLOYMENT_MODE="${OPTARG}" ;;
@@ -69,10 +71,9 @@ function options() {
           i) GENERATION_INPUT_SOURCE="${OPTARG}" ;;
           l) LEVEL="${OPTARG}" ;;
           o) OUTPUT_DIR="${OPTARG}" ;;
-          p) GENERATION_PROVIDERS="${OPTARG}" ;;
+          p) GENERATION_PROVIDERS+=("${OPTARG}") ;;
           q) REQUEST_REFERENCE="${OPTARG}" ;;
           r) REGION="${OPTARG}" ;;
-          s) GENERATION_SUBPROVIDERS="${OPTARG}" ;;
           u) DEPLOYMENT_UNIT="${OPTARG}" ;;
           z) DEPLOYMENT_UNIT_SUBSET="${OPTARG}" ;;
           \?) fatalOption; return 1 ;;
@@ -84,9 +85,13 @@ function options() {
   CONFIGURATION_REFERENCE="${CONFIGURATION_REFERENCE:-${CONFIGURATION_REFERENCE_DEFAULT}}"
   REQUEST_REFERENCE="${REQUEST_REFERENCE:-${REQUEST_REFERENCE_DEFAULT}}"
   DEPLOYMENT_MODE="${DEPLOYMENT_MODE:-${DEPLOYMENT_MODE_DEFAULT}}"
-  GENERATION_PROVIDERS="${GENERATION_PROVIDERS:-${GENERATION_PROVIDERS_DEFAULT}}"
   GENERATION_FRAMEWORK="${GENERATION_FRAMEWORK:-${GENERATION_FRAMEWORK_DEFAULT}}"
   GENERATION_INPUT_SOURCE="${GENERATION_INPUT_SOURCE:-${GENERATION_INPUT_SOURCE_DEFAULT}}"
+
+  if [[ "${#GENERATION_PROVIDERS[@]}" == "0" ]]; then
+    GENERATION_PROVIDERS+=("${GENERATION_PROVIDERS_DEFAULT}")
+  fi
+  GENERATION_PROVIDERS=$(listFromArray "GENERATION_PROVIDERS" ",")
 
   # Check level and deployment unit
   ! isValidUnit "${LEVEL}" "${DEPLOYMENT_UNIT}" && fatal "Deployment unit/level not valid" &&  return 1

--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -34,8 +34,7 @@ where
 (o) -d DEPLOYMENT_MODE         is the deployment mode the template will be generated for
 (o) -p GENERATION_PROVIDER     is the provider to for template generation
 (o) -f GENERATION_FRAMEWORK    is the output framework to use for template generation
-(o) -t GENERATION_TESTCASE     is the test case you would like to generate a template for
-(o) -s GENERATION_SCENARIOS    is a comma seperated list of framework scenarios to load
+(o) -s GENERATION_SUBPROVIDERS is a command seperated list of additional providers to include in the loading process
 
 (m) mandatory, (o) optional, (d) deprecated
 
@@ -61,7 +60,7 @@ EOF
 function options() {
 
   # Parse options
-  while getopts ":c:d:f:g:hi:l:o:p:q:r:s:t:u:z:" option; do
+  while getopts ":c:d:f:g:hi:l:o:p:q:r:s:u:z:" option; do
       case "${option}" in
           c) CONFIGURATION_REFERENCE="${OPTARG}" ;;
           d) DEPLOYMENT_MODE="${OPTARG}" ;;
@@ -74,8 +73,7 @@ function options() {
           p) GENERATION_PROVIDER="${OPTARG}" ;;
           q) REQUEST_REFERENCE="${OPTARG}" ;;
           r) REGION="${OPTARG}" ;;
-          s) GENERATION_SCENARIOS="${OPTARG}" ;;
-          t) GENERATION_TESTCASE="${OPTARG}" ;;
+          s) GENERATION_SUBPROVIDERS="${OPTARG}" ;;
           u) DEPLOYMENT_UNIT="${OPTARG}" ;;
           z) DEPLOYMENT_UNIT_SUBSET="${OPTARG}" ;;
           \?) fatalOption; return 1 ;;
@@ -92,9 +90,7 @@ function options() {
   GENERATION_INPUT_SOURCE="${GENERATION_INPUT_SOURCE:-${GENERATION_INPUT_SOURCE_DEFAULT}}"
 
   # Check level and deployment unit
-  if [[ -z "${GENERATION_TESTCASE}" ]]; then
-    ! isValidUnit "${LEVEL}" "${DEPLOYMENT_UNIT}" && fatal "Deployment unit/level not valid" &&  return 1
-  fi
+  ! isValidUnit "${LEVEL}" "${DEPLOYMENT_UNIT}" && fatal "Deployment unit/level not valid" &&  return 1
 
   # Ensure other mandatory arguments have been provided
   if [[ (-z "${REQUEST_REFERENCE}") || (-z "${CONFIGURATION_REFERENCE}") ]]; then
@@ -332,7 +328,7 @@ function process_template_pass() {
     ["cli"]="cli.json"
     ["parameters"]="parameters.json"
     ["config"]="config.json"
-    ["testplan"]="testplan.json"
+    ["testcase"]="testcase.json"
   )
 
   # Template pass specifics
@@ -446,17 +442,16 @@ function process_template_pass() {
 
   # Args common across all passes
   local args=()
-  [[ -n "${provider}" ]]                && args+=("-v" "provider=${provider}")
-  [[ -n "${deployment_framework}" ]]    && args+=("-v" "deploymentFramework=${deployment_framework}")
-  [[ -n "${GENERATION_MODEL}" ]]        && args+=("-v" "deploymentFrameworkModel=${GENERATION_MODEL}")
-  [[ -n "${output_type}" ]]             && args+=("-v" "outputType=${output_type}")
-  [[ -n "${output_format}" ]]           && args+=("-v" "outputFormat=${output_format}")
-  [[ -n "${deployment_unit}" ]]         && args+=("-v" "deploymentUnit=${deployment_unit}")
-  [[ -n "${resource_group}" ]]          && args+=("-v" "resourceGroup=${resource_group}")
-  [[ -n "${GENERATION_LOG_LEVEL}" ]]    && args+=("-v" "logLevel=${GENERATION_LOG_LEVEL}")
-  [[ -n "${GENERATION_INPUT_SOURCE}" ]] && args+=("-v" "inputSource=${GENERATION_INPUT_SOURCE}")
-  [[ -n "${GENERATION_SCENARIOS}" ]]    && args+=("-v" "scenarios=${GENERATION_SCENARIOS}")
-  [[ -n "${GENERATION_TESTCASE}" ]]     && args+=("-v" "testCase=${GENERATION_TESTCASE}")
+  [[ -n "${provider}" ]]                  && args+=("-v" "provider=${provider}")
+  [[ -n "${deployment_framework}" ]]      && args+=("-v" "deploymentFramework=${deployment_framework}")
+  [[ -n "${GENERATION_MODEL}" ]]          && args+=("-v" "deploymentFrameworkModel=${GENERATION_MODEL}")
+  [[ -n "${output_type}" ]]               && args+=("-v" "outputType=${output_type}")
+  [[ -n "${output_format}" ]]             && args+=("-v" "outputFormat=${output_format}")
+  [[ -n "${deployment_unit}" ]]           && args+=("-v" "deploymentUnit=${deployment_unit}")
+  [[ -n "${resource_group}" ]]            && args+=("-v" "resourceGroup=${resource_group}")
+  [[ -n "${GENERATION_LOG_LEVEL}" ]]      && args+=("-v" "logLevel=${GENERATION_LOG_LEVEL}")
+  [[ -n "${GENERATION_INPUT_SOURCE}" ]]   && args+=("-v" "inputSource=${GENERATION_INPUT_SOURCE}")
+  [[ -n "${GENERATION_SUBPROVIDERS}" ]]   && args+=("-v" "subProviders=${GENERATION_SUBPROVIDERS}")
 
   # Include the template composites
   # Removal of drive letter (/?/) is specifically for MINGW

--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -8,7 +8,7 @@ trap '. ${GENERATION_BASE_DIR}/execution/cleanupContext.sh' EXIT SIGHUP SIGINT S
 CONFIGURATION_REFERENCE_DEFAULT="unassigned"
 REQUEST_REFERENCE_DEFAULT="unassigned"
 DEPLOYMENT_MODE_DEFAULT="update"
-GENERATION_PROVIDER_DEFAULT="aws"
+GENERATION_PROVIDERS_DEFAULT="aws"
 GENERATION_FRAMEWORK_DEFAULT="cf"
 GENERATION_INPUT_SOURCE_DEFAULT="composite"
 
@@ -32,9 +32,8 @@ where
 (m) -u DEPLOYMENT_UNIT         is the deployment unit to be included in the template
 (o) -z DEPLOYMENT_UNIT_SUBSET  is the subset of the deployment unit required
 (o) -d DEPLOYMENT_MODE         is the deployment mode the template will be generated for
-(o) -p GENERATION_PROVIDER     is the provider to for template generation
+(o) -p GENERATION_PROVIDERS     is a list of comma separated providers to load for template generation
 (o) -f GENERATION_FRAMEWORK    is the output framework to use for template generation
-(o) -s GENERATION_SUBPROVIDERS is a command seperated list of additional providers to include in the loading process
 
 (m) mandatory, (o) optional, (d) deprecated
 
@@ -43,7 +42,7 @@ DEFAULTS:
 CONFIGURATION_REFERENCE = "${CONFIGURATION_REFERENCE_DEFAULT}"
 REQUEST_REFERENCE       = "${REQUEST_REFERENCE_DEFAULT}"
 DEPLOYMENT_MODE         = "${DEPLOYMENT_MODE_DEFAULT}"
-GENERATION_PROVIDER     = "${GENERATION_PROVIDER_DEFAULT}"
+GENERATION_PROVIDERS    = "${GENERATION_PROVIDERS_DEFAULT}"
 GENERATION_FRAMEWORK    = "${GENERATION_FRAMEWORK_DEFAULT}"
 GENERATION_INPUT_SOURCE = "${GENRATION_INPUT_SOURCE_DEFAULT}"
 
@@ -70,7 +69,7 @@ function options() {
           i) GENERATION_INPUT_SOURCE="${OPTARG}" ;;
           l) LEVEL="${OPTARG}" ;;
           o) OUTPUT_DIR="${OPTARG}" ;;
-          p) GENERATION_PROVIDER="${OPTARG}" ;;
+          p) GENERATION_PROVIDERS="${OPTARG}" ;;
           q) REQUEST_REFERENCE="${OPTARG}" ;;
           r) REGION="${OPTARG}" ;;
           s) GENERATION_SUBPROVIDERS="${OPTARG}" ;;
@@ -85,7 +84,7 @@ function options() {
   CONFIGURATION_REFERENCE="${CONFIGURATION_REFERENCE:-${CONFIGURATION_REFERENCE_DEFAULT}}"
   REQUEST_REFERENCE="${REQUEST_REFERENCE:-${REQUEST_REFERENCE_DEFAULT}}"
   DEPLOYMENT_MODE="${DEPLOYMENT_MODE:-${DEPLOYMENT_MODE_DEFAULT}}"
-  GENERATION_PROVIDER="${GENERATION_PROVIDER:-${GENERATION_PROVIDER_DEFAULT}}"
+  GENERATION_PROVIDERS="${GENERATION_PROVIDERS:-${GENERATION_PROVIDERS_DEFAULT}}"
   GENERATION_FRAMEWORK="${GENERATION_FRAMEWORK:-${GENERATION_FRAMEWORK_DEFAULT}}"
   GENERATION_INPUT_SOURCE="${GENERATION_INPUT_SOURCE:-${GENERATION_INPUT_SOURCE_DEFAULT}}"
 
@@ -263,7 +262,7 @@ function get_openapi_definition_file() {
 
 
 function process_template_pass() {
-  local provider="${1,,}"; shift
+  local providers="${1,,}"; shift
   local deployment_framework="${1,,}"; shift
   local output_type="${1,,}"; shift
   local output_format="${1,,}"; shift
@@ -442,7 +441,7 @@ function process_template_pass() {
 
   # Args common across all passes
   local args=()
-  [[ -n "${provider}" ]]                  && args+=("-v" "provider=${provider}")
+  [[ -n "${providers}" ]]                 && args+=("-v" "providers=${providers}")
   [[ -n "${deployment_framework}" ]]      && args+=("-v" "deploymentFramework=${deployment_framework}")
   [[ -n "${GENERATION_MODEL}" ]]          && args+=("-v" "deploymentFrameworkModel=${GENERATION_MODEL}")
   [[ -n "${output_type}" ]]               && args+=("-v" "outputType=${output_type}")
@@ -451,7 +450,6 @@ function process_template_pass() {
   [[ -n "${resource_group}" ]]            && args+=("-v" "resourceGroup=${resource_group}")
   [[ -n "${GENERATION_LOG_LEVEL}" ]]      && args+=("-v" "logLevel=${GENERATION_LOG_LEVEL}")
   [[ -n "${GENERATION_INPUT_SOURCE}" ]]   && args+=("-v" "inputSource=${GENERATION_INPUT_SOURCE}")
-  [[ -n "${GENERATION_SUBPROVIDERS}" ]]   && args+=("-v" "subProviders=${GENERATION_SUBPROVIDERS}")
 
   # Include the template composites
   # Removal of drive letter (/?/) is specifically for MINGW
@@ -735,7 +733,7 @@ function process_template() {
 
   # First see if an generation plan can be generated
   process_template_pass \
-      "${GENERATION_PROVIDER}" \
+      "${GENERATION_PROVIDERS}" \
       "${GENERATION_FRAMEWORK}" \
       "script" \
       "bash" \

--- a/engine/bootstrap.ftl
+++ b/engine/bootstrap.ftl
@@ -20,8 +20,7 @@
     option={
         "Deployment" : {
             "Provider" : {
-                "Name" : provider!"",
-                "SubProviders" : (subProviders?split(","))![]
+                "Names" : asArray( providers?split(",") )![]
             },
             "Framework" : {
                 "Name" : deploymentFramework!"",
@@ -155,7 +154,7 @@
 [#-- Include the shared provider --]
 [@includeProviderConfiguration provider=SHARED_PROVIDER /]
 
-[#list providers as provider ]
+[#list commandLineOptions.Deployment.Provider.Names as provider ]
     [#-- Load Input Sources --]
     [@includeBaseInputSourceConfiguration
         provider=provider
@@ -183,7 +182,7 @@
         scenarios=scenarioList
     /]
 
-    [#list providers as provider ]
+    [#list commandLineOptions.Deployment.Provider.Names as provider ]
         [@includeScenarioConfiguration
             provider=provider
             scenarios=scenarioList
@@ -205,7 +204,7 @@
 [/#if]
 
 [#-- Include any command line provider/input source --]
-[#list providers as provider ]
+[#list commandLineOptions.Deployment.Provider.Names as provider ]
     [@includeInputSourceConfiguration
         provider=provider
         inputSource="shared"
@@ -236,7 +235,7 @@
 [/#if]
 
 [#-- Include any command line provider/deployment framework --]
-[#list providers as provider]
+[#list commandLineOptions.Deployment.Provider.Names as provider]
     [@includeProviderConfiguration provider=provider /]
     [#if commandLineOptions.Deployment.Framework.Name?has_content]
         [@includeDeploymentFrameworkConfiguration

--- a/engine/bootstrap.ftl
+++ b/engine/bootstrap.ftl
@@ -10,9 +10,7 @@
 [@addCommandLineOption
     option={
         "Input" : {
-            "Source" : inputSource!"composite",
-            "Scenarios" : (scenarios?split(","))![],
-            "TestCase" : testCase!""
+            "Source" : inputSource!"composite"
         }
     }
 /]
@@ -22,7 +20,8 @@
     option={
         "Deployment" : {
             "Provider" : {
-                "Name" : provider!""
+                "Name" : provider!"",
+                "SubProviders" : (subProviders?split(","))![]
             },
             "Framework" : {
                 "Name" : deploymentFramework!"",
@@ -156,32 +155,26 @@
 [#-- Include the shared provider --]
 [@includeProviderConfiguration provider=SHARED_PROVIDER /]
 
-[#-- Include any command line based input data source --]
-[#if commandLineOptions.Deployment.Provider.Name?has_content ]
+[#list providers as provider ]
+    [#-- Load Input Sources --]
     [@includeBaseInputSourceConfiguration
-        provider=commandLineOptions.Deployment.Provider.Name
+        provider=provider
         inputSource="shared"
     /]
     [#if commandLineOptions.Input.Source?has_content]
         [@includeBaseInputSourceConfiguration
-            provider=commandLineOptions.Deployment.Provider.Name
+            provider=provider
             inputSource=commandLineOptions.Input.Source
         /]
     [/#if]
-[/#if]
 
-[#-- Include any command line provider --]
-[#if commandLineOptions.Deployment.Provider.Name?has_content ]
-    [@includeProviderConfiguration provider=commandLineOptions.Deployment.Provider.Name /]
-[/#if]
+   [#-- Include any command line provider --]
+   [@includeProviderConfiguration provider=provider /]
+[/#list]
+
 
 [#-- start the blueprint with the masterData --]
 [@addBlueprint blueprint=getMasterData() /]
-
-[#-- Set the scenarios provided via the CLI --]
-[@updateScenarioList
-    scenarioIds=commandLineOptions.Input.Scenarios
-/]
 
 [#-- Load Scenarios --]
 [#if scenarioList?has_content ]
@@ -190,12 +183,12 @@
         scenarios=scenarioList
     /]
 
-    [#if commandLineOptions.Deployment.Provider.Name?has_content ]
+    [#list providers as provider ]
         [@includeScenarioConfiguration
-            provider=commandLineOptions.Deployment.Provider.Name
+            provider=provider
             scenarios=scenarioList
         /]
-    [/#if]
+    [/#list]
 [/#if]
 
 [#-- Include any shared input sources --]
@@ -212,18 +205,18 @@
 [/#if]
 
 [#-- Include any command line provider/input source --]
-[#if commandLineOptions.Deployment.Provider.Name?has_content ]
+[#list providers as provider ]
     [@includeInputSourceConfiguration
-        provider=commandLineOptions.Deployment.Provider.Name
+        provider=provider
         inputSource="shared"
     /]
     [#if commandLineOptions.Input.Source?has_content]
         [@includeInputSourceConfiguration
-            provider=commandLineOptions.Deployment.Provider.Name
+            provider=provider
             inputSource=commandLineOptions.Input.Source
         /]
     [/#if]
-[/#if]
+[/#list]
 
 [#-- Set the context for templates processing --]
 [#include "setContext.ftl" ]
@@ -243,15 +236,15 @@
 [/#if]
 
 [#-- Include any command line provider/deployment framework --]
-[#if commandLineOptions.Deployment.Provider.Name?has_content ]
-    [@includeProviderConfiguration provider=commandLineOptions.Deployment.Provider.Name /]
+[#list providers as provider]
+    [@includeProviderConfiguration provider=provider /]
     [#if commandLineOptions.Deployment.Framework.Name?has_content]
         [@includeDeploymentFrameworkConfiguration
-            provider=commandLineOptions.Deployment.Provider.Name
+            provider=provider
             deploymentFramework=commandLineOptions.Deployment.Framework.Name
         /]
     [/#if]
-[/#if]
+[/#list]
 
 [#-- Populate the model to be used --]
 [#assign model =

--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -254,12 +254,12 @@
         )]
 [/#function]
 
-[#function invokeTestPlanMacro occurrence resourceGroup qualifiers=[] ]
+[#function invokeTestCaseMacro occurrence resourceGroup qualifiers=[] ]
     [#return
         invokeComponentMacro(
             occurrence,
             resourceGroup,
-            "testplan",
+            "testcase",
             qualifiers,
             {},
             {},

--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -351,7 +351,7 @@
                     genPlanStepOutputMappings,
                     {
                         provider : {
-                            subset : { 
+                            subset : {
                                 "OutputType" : outputType,
                                 "OutputFormat" : outputFormat
                             }
@@ -411,18 +411,18 @@
 
     [#-- Determine the steps required --]
     [#list asArray(alternatives) as alternative]
-        [#local step = getGenPlanStepOutputMapping( commandLineOptions.Deployment.Provider.Name, subset) ]
+        [#local step = getGenPlanStepOutputMapping( (commandLineOptions.Deployment.Provider.Names)[0], subset) ]
         [#if ! step?has_content ]
             [#return {}]
         [/#if]
-        [#local step_name = [subset, alternative, commandLineOptions.Deployment.Provider.Name, commandLineOptions.Deployment.Framework.Name]?join("-") ]
+        [#local step_name = [subset, alternative, (commandLineOptions.Deployment.Provider.Names)[0], commandLineOptions.Deployment.Framework.Name]?join("-") ]
         [#local steps =
             mergeObjects(
                 steps,
                 {
                     subset : {
                         alternative : {
-                            commandLineOptions.Deployment.Provider.Name : {
+                            (commandLineOptions.Deployment.Provider.Names)[0] : {
                                 commandLineOptions.Deployment.Framework.Name : {
                                     "Name" : step_name
                                 } + step

--- a/engine/provider.ftl
+++ b/engine/provider.ftl
@@ -6,12 +6,6 @@
 
 [#assign includeOnceConfiguration = {} ]
 
-[#assign providers = combineEntities(
-                        [ commandLineOptions.Deployment.Provider.Name ],
-                        commandLineOptions.Deployment.Provider.SubProviders,
-                        UNIQUE_COMBINE_BEHAVIOUR
-                    )]
-
 [#-- Only load configuration once --]
 [#function isConfigurationIncluded configuration]
     [#local index = concatenate(configuration, "_")?lower_case]

--- a/engine/provider.ftl
+++ b/engine/provider.ftl
@@ -6,6 +6,12 @@
 
 [#assign includeOnceConfiguration = {} ]
 
+[#assign providers = combineEntities(
+                        [ commandLineOptions.Deployment.Provider.Name ],
+                        commandLineOptions.Deployment.Provider.SubProviders,
+                        UNIQUE_COMBINE_BEHAVIOUR
+                    )]
+
 [#-- Only load configuration once --]
 [#function isConfigurationIncluded configuration]
     [#local index = concatenate(configuration, "_")?lower_case]

--- a/engine/scenario.ftl
+++ b/engine/scenario.ftl
@@ -8,7 +8,6 @@
 [/#macro]
 
 [#macro addScenario
-    id
     blueprint={}
     settingSets=[]
     stackOutputs=[]
@@ -16,30 +15,23 @@
 ]
 
     [#if blueprint?has_content ]
-        [@addBlueprint 
-            blueprint=blueprint 
+        [@addBlueprint
+            blueprint=blueprint
         /]
     [/#if]
 
     [#list settingSets as settingSet ]
-        [@addSettings 
-            type=settingSet.Type!"Settings" 
-            scope=settingSet.Scope!"Products" 
-            namespace=settingSet.Namespace!id
+        [@addSettings
+            type=settingSet.Type!"Settings"
+            scope=settingSet.Scope!"Products"
+            namespace=settingSet.Namespace
             settings=settingSet.Settings!{}
         /]
     [/#list]
 
-    [#list stackOutputs as stackOutput ]
-        [@addStackOutputs 
-            [
-                {
-                    "DeploymentUnit" : id!deploymentUnit
-                } +
-                stackOutput
-            ]
-        /]
-    [/#list]
+    [@addStackOutputs
+        outputs=stackOutputs
+    /]
 
     [#if commandLineOption?has_content ]
         [@addCommandLineOption options=commandLineOption /]

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -7,7 +7,7 @@
 [@includeSharedComponentConfiguration component="baseline" /]
 
 [#-- Temporary AWS stuff --]
-[#if commandLineOptions.Deployment.Provider.Name = "aws"]
+[#if (commandLineOptions.Deployment.Provider.Names)?seq_contains("aws") ]
     [@includeProviderConfiguration provider=AWS_PROVIDER /]
     [@includeProviderComponentDefinitionConfiguration provider="aws" component="baseline" /]
     [@includeProviderComponentConfiguration provider="aws" component="baseline" services="baseline" /]
@@ -178,7 +178,7 @@
                 accountObject
         } ]
 
-    [#if commandLineOptions.Deployment.Provider.Name = "aws"]
+    [#if (commandLineOptions.Deployment.Provider.Names)?seq_contains("aws")]
         [#assign credentialsBucket = getExistingReference(formatAccountS3Id("credentials"))]
         [#assign codeBucket = getExistingReference(formatAccountS3Id("code")) ]
         [#assign registryBucket = getExistingReference(formatAccountS3Id("registry")) ]
@@ -330,7 +330,7 @@
             (tenantObject.PlacementProfiles)!{}
         ) ]
 
-    [#if commandLineOptions.Deployment.Provider.Name = "aws"]
+    [#if (commandLineOptions.Deployment.Provider.Names)?seq_contains("aws")]
     [#assign segmentSeed = getExistingReference(formatSegmentSeedId()) ]
 
 
@@ -355,7 +355,7 @@
                             ((segmentObject.SSH.Enabled)!(segmentObject.Bastion.Enabled)!true)]
     [#assign sshActive = sshEnabled &&
                             ((segmentObject.SSH.Active)!(segmentObject.Bastion.Active)!false)]
-    [#if commandLineOptions.Deployment.Provider.Name = "aws"]
+    [#if (commandLineOptions.Deployment.Provider.Names)?seq_contains("aws")]
         [#assign sshFromProxySecurityGroup = getExistingReference(formatSSHFromProxySecurityGroupId())]
     [/#if]
 

--- a/providers/awstest/awstest.ftl
+++ b/providers/awstest/awstest.ftl
@@ -1,0 +1,24 @@
+[#ftl]
+
+[#--
+    The test provider loads in scenarios with test configuration
+    which is used to perform unit tests of the templates we generate
+
+    To add a new test scneraio
+    - Add a new scenario under the scnenarios folder in this provider
+    - Add the name of the scnenario to the list below
+
+    All scenarios will be loaded over the top of each other
+    Make sure to add the data appropriately
+
+--]
+
+[#assign AWSTEST_PROVIDER = "awstest"]
+
+[#assign testScenarios = [
+    "lb"
+]]
+
+[@updateScenarioList
+    scenarioIds=testScenarios
+/]

--- a/providers/awstest/scenarios/lb.ftl
+++ b/providers/awstest/scenarios/lb.ftl
@@ -54,56 +54,62 @@
                 "httpslb" : {
                     "OutputSuffix" : "template",
                     "Structural" : {
-                        "CFNResource" : {
-                            "httpListenerRule" : {
-                                "Name" : "listenerRuleXelbXhttpslbXhttpX100",
-                                "Type" : "AWS::ElasticLoadBalancingV2::ListenerRule"
-                            },
-                            "httpListener" : {
-                                "Name" : "listenerXelbXhttpslbXhttps",
-                                "Type" : "AWS::ElasticLoadBalancingV2::Listener"
-                            },
-                            "loadBalancer" : {
-                                "Name" : "albXelbXhttpslb",
-                                "Type" : "AWS::ElasticLoadBalancingV2::LoadBalancer"
-                            }
-                        },
-                        "Exists" : [
-                            "Outputs.securityGroupXlistenerXelbXhttpslbXhttps"
-                        ],
-                        "Match" : {
-                            "LBName" : {
-                                "Path"  : "Resources.albXelbXhttpslb.Properties.Name",
-                                "Value" : "mockedup-int-elb-httpslb"
-                            },
-                            "HTTPAction" : {
-                                "Path" : "Resources.listenerRuleXelbXhttpslbXhttpX100.Properties.Actions[0]",
-                                "Value" : {
-                                    "Type": "redirect",
-                                    "RedirectConfig": {
-                                        "Protocol": "HTTPS",
-                                        "Port": "443",
-                                        "Host": "#\{host}",
-                                        "Path": "/#\{path}",
-                                        "Query": "#\{query}",
-                                        "StatusCode": "HTTP_301"
-                                    }
+                        "CFN" : {
+                            "Resource" : {
+                                "httpListenerRule" : {
+                                    "Name" : "listenerRuleXelbXhttpslbXhttpX100",
+                                    "Type" : "AWS::ElasticLoadBalancingV2::ListenerRule"
+                                },
+                                "httpListener" : {
+                                    "Name" : "listenerXelbXhttpslbXhttps",
+                                    "Type" : "AWS::ElasticLoadBalancingV2::Listener"
+                                },
+                                "loadBalancer" : {
+                                    "Name" : "albXelbXhttpslb",
+                                    "Type" : "AWS::ElasticLoadBalancingV2::LoadBalancer"
                                 }
                             },
-                            "HTTPSAction" : {
-                                "Path" : "Resources.listenerRuleXelbXhttpslbXhttpsX500.Properties.Actions[0].Type",
-                                "Value" : "forward"
-                            }
+                            "Output" : [
+                                "securityGroupXlistenerXelbXhttpslbXhttps",
+                                "listenerRuleXelbXhttpslbXhttpsX500",
+                                "tgXdefaultXelbXhttpslbXhttps"
+                            ]
                         },
-                        "Length" : {
-                            "listenerActions" : {
-                                "Path" : "Resources.listenerRuleXelbXhttpslbXhttpX100.Properties.Actions",
-                                "Count" : 1
-                            }
-                        },
-                        "NotEmpty" : [
-                            "Resources.listenerRuleXelbXhttpslbXhttpX100.Properties.Priority"
-                        ]
+                        "JSON" : {
+                            "Match" : {
+                                "LBName" : {
+                                    "Path"  : "Resources.albXelbXhttpslb.Properties.Name",
+                                    "Value" : "mockedup-int-elb-httpslb"
+                                },
+                                "HTTPAction" : {
+                                    "Path" : "Resources.listenerRuleXelbXhttpslbXhttpX100.Properties.Actions[0]",
+                                    "Value" : {
+                                        "Type": "redirect",
+                                        "RedirectConfig": {
+                                            "Protocol": "HTTPS",
+                                            "Port": "443",
+                                            "Host": "#\{host}",
+                                            "Path": "/#\{path}",
+                                            "Query": "#\{query}",
+                                            "StatusCode": "HTTP_301"
+                                        }
+                                    }
+                                },
+                                "HTTPSAction" : {
+                                    "Path" : "Resources.listenerRuleXelbXhttpslbXhttpsX500.Properties.Actions[0].Type",
+                                    "Value" : "forward"
+                                }
+                            },
+                            "Length" : {
+                                "listenerActions" : {
+                                    "Path" : "Resources.listenerRuleXelbXhttpslbXhttpX100.Properties.Actions",
+                                    "Count" : 1
+                                }
+                            },
+                            "NotEmpty" : [
+                                "Resources.listenerRuleXelbXhttpslbXhttpX100.Properties.Priority"
+                            ]
+                        }
                     }
                 }
             },

--- a/providers/awstest/scenarios/lb.ftl
+++ b/providers/awstest/scenarios/lb.ftl
@@ -1,9 +1,10 @@
 [#ftl]
 
 [#-- Get stack output --]
-[#macro aws_scenario_lbhttps ]
+[#macro awstest_scenario_lb ]
+
+    [#-- HTTPS Load Balancer --]
     [@addScenario
-        id="lbhttps"
         blueprint={
             "Tiers" : {
                 "elb" : {

--- a/providers/shared/deploymentframeworks/default/legacy.ftl
+++ b/providers/shared/deploymentframeworks/default/legacy.ftl
@@ -50,10 +50,10 @@
                                 [/#if]
                                 [#break]
 
-                            [#case "testplan" ]
-                                [#if invokeTestPlanMacro( occurrence, key, [ level ]) ]
+                            [#case "testcase" ]
+                                [#if invokeTestCaseMacro( occurrence, key, [ level ]) ]
                                     [@debug
-                                        message="Testplan Processing key:" + key + "..."
+                                        message="Test case Processing key:" + key + "..."
                                         enabled=false
                                     /]
                                 [/#if]

--- a/providers/shared/deploymentframeworks/default/output.ftl
+++ b/providers/shared/deploymentframeworks/default/output.ftl
@@ -189,7 +189,7 @@
     [/#if]
 
 
-    [#local subsets = combineEntities( subsets, [ "testplan" ], UNIQUE_COMBINE_BEHAVIOUR) ]
+    [#local subsets = combineEntities( subsets, [ "testcase" ], UNIQUE_COMBINE_BEHAVIOUR) ]
 
     [#list asArray(subsets) as subset]
         [#-- Each subset gets its own section --]
@@ -198,7 +198,7 @@
             [#case "genplan"]
                 [#local name = section + "-100" ]
                 [#break]
-            [#case "testplan"]
+            [#case "testcase"]
                 [#local name = section + "-200"]
                 [#break]
             [#case "pregeneration"]
@@ -294,7 +294,7 @@
 [@addGenPlanStepOutputMapping
     provider=SHARED_PROVIDER
     subsets=[
-        "testplan",
+        "testcase",
         "cli",
         "config",
         "parameters"

--- a/providers/shared/deploymentframeworks/default/output.ftl
+++ b/providers/shared/deploymentframeworks/default/output.ftl
@@ -261,7 +261,7 @@
                             "plan_steps+=(\"${step_name}\")",
                             "plan_subsets[\"${step_name}\"]=\"" + subset + "\"",
                             "plan_alternatives[\"${step_name}\"]=\"" + alternative + "\"",
-                            "plan_providers[\"${step_name}\"]=\"" + provider + "\"",
+                            "plan_providers[\"${step_name}\"]=\"" + (commandLineOptions.Deployment.Provider.Names)?join(",") + "\"",
                             "plan_deployment_frameworks[\"${step_name}\"]=\"" + deploymentFramework + "\"",
                             "plan_output_types[\"${step_name}\"]=\"" + value.OutputType + "\"",
                             "plan_output_formats[\"${step_name}\"]=\"" + value.OutputFormat + "\"",

--- a/providers/shared/references/TestCase/id.ftl
+++ b/providers/shared/references/TestCase/id.ftl
@@ -19,67 +19,80 @@
             "Names" : "Structural",
             "Children" : [
                 {
-                    "Names" : "Match",
-                    "Description" : "Does a JSON path match a value",
-                    "SubObjects" : true,
+                    "Names" : "JSON",
+                    "Description" : "Generic JSON level structure tests",
                     "Children" : [
                         {
-                            "Names" : "Path",
-                            "Type" : STRING_TYPE
+                            "Names" : "Match",
+                            "Description" : "Does a JSON path match a value",
+                            "SubObjects" : true,
+                            "Children" : [
+                                {
+                                    "Names" : "Path",
+                                    "Type" : STRING_TYPE
+                                },
+                                {
+                                    "Names" : "Value",
+                                    "Type" : ANY_TYPE
+                                }
+                            ]
                         },
                         {
-                            "Names" : "Value",
-                            "Type" : ANY_TYPE
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Length",
-                    "Description" : "Length of an Array at a given JSON path",
-                    "SubObjects" : true,
-                    "Children" : [
-                        {
-                            "Names" : "Path",
-                            "Type" : STRING_TYPE
+                            "Names" : "Length",
+                            "Description" : "Length of an Array at a given JSON path",
+                            "SubObjects" : true,
+                            "Children" : [
+                                {
+                                    "Names" : "Path",
+                                    "Type" : STRING_TYPE
+                                },
+                                {
+                                    "Names" : "Count",
+                                    "Type" : NUMBER_TYPE
+                                }
+                            ]
                         },
                         {
-                            "Names" : "Count",
-                            "Type" : NUMBER_TYPE
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Exists",
-                    "Description" : "Does a JSON path exist",
-                    "Type" : ARRAY_OF_STRING_TYPE
-                },
-                {
-                    "Names" : "NotEmpty",
-                    "Description" : "Is the value of a JSON path not emtpy",
-                    "Type" : ARRAY_OF_STRING_TYPE
-                },
-                {
-                    "Names" : "CFNResource",
-                    "Description" : "Does a resource with the type exist",
-                    "SubObjects" : true,
-                    "Children" : [
-                        {
-                            "Names" : "Name",
-                            "Mandatory" : true,
-                            "Type" : STRING_TYPE
+                            "Names" : "Exists",
+                            "Description" : "Does a JSON path exist",
+                            "Type" : ARRAY_OF_STRING_TYPE
                         },
                         {
-                            "Names" : "Type",
-                            "Mandatory" : true,
-                            "Type" : STRING_TYPE
+                            "Names" : "NotEmpty",
+                            "Description" : "Is the value of a JSON path not emtpy",
+                            "Type" : ARRAY_OF_STRING_TYPE
                         }
                     ]
-                },
-                {
-                    "Names" : "CFNOutput",
-                    "Description" : "Does an output with exist",
-                    "Type" : ARRAY_OF_STRING_TYPE
                 }
+                {
+                    "Names" : "CFN",
+                    "Description" : "Cloud formation Template structure",
+                    "Children" : [
+                        {
+                            "Names" : "Resource",
+                            "Description" : "Does a resource with the type exist",
+                            "SubObjects" : true,
+                            "Children" : [
+                                {
+                                    "Names" : "Name",
+                                    "Mandatory" : true,
+                                    "Type" : STRING_TYPE
+                                },
+                                {
+                                    "Names" : "Type",
+                                    "Mandatory" : true,
+                                    "Type" : STRING_TYPE
+                                }
+                            ]
+                        },
+                        {
+                            "Names" : "Output",
+                            "Description" : "Does an output with exist",
+                            "Type" : ARRAY_OF_STRING_TYPE
+                        }
+                    ]
+                }
+
             ]
         },
         {

--- a/providers/shared/services/resource.ftl
+++ b/providers/shared/services/resource.ftl
@@ -2,7 +2,7 @@
 
 [#-- Is a resource part of a deployment unit --]
 [#function isPartOfDeploymentUnit resourceId deploymentUnit deploymentUnitSubset]
-  [#local resourceObject = getStackOutputObject(commandLineOptions.Deployment.Provider.Name, resourceId)]
+  [#local resourceObject = getStackOutputObject( (commandLineOptions.Deployment.Provider.Names)[0], resourceId)]
   [#local
     currentDeploymentUnit =
       deploymentUnit +

--- a/providers/shared/shared.ftl
+++ b/providers/shared/shared.ftl
@@ -38,22 +38,22 @@
                 {
                     testCaseName  : {
                         "filename" : testCase.OutputSuffix,
-                        "no_lint" : testCase.Tools.CFNLint,
-                        "no_vulnerability_check" : testCase.Tools.CFNNag
+                        "cfn_lint" : testCase.Tools.CFNLint,
+                        "cfn_nag"  : testCase.Tools.CFNNag
                     }
                 }
             )]
 
-            [#list (testCase.Structural.Match)!{} as id,matchTest ]
+            [#list (testCase.Structural.JSON.Match)!{} as id,matchTest ]
                 [#local tests = combineEntities(tests,
                     {
                         testCaseName : {
-                            "structure" : {
+                            "json_structure" : {
                                 "match" : [
-                                    [
-                                        matchTest.Path,
-                                        matchTest.Value
-                                    ]
+                                    {
+                                        "path" : matchTest.Path,
+                                        "value" : matchTest.Value
+                                    }
                                 ]
                             }
                         }
@@ -62,15 +62,17 @@
                 )]
             [/#list]
 
-            [#list (testCase.Structural.Length)!{} as id,legnthTest ]
+            [#list (testCase.Structural.JSON.Length)!{} as id,legnthTest ]
                 [#local tests = combineEntities(tests,
                     {
                         testCaseName : {
-                            "structure"  : {
+                            "json_structure"  : {
                                 "length" : [
                                     [
-                                        legnthTest.Path,
-                                        legnthTest.Count
+                                        {
+                                            "path" : legnthTest.Path,
+                                            "value" : legnthTest.Count
+                                        }
                                     ]
                                 ]
                             }
@@ -80,42 +82,60 @@
                 )]
             [/#list]
 
-            [#if testCase.Structural.Exists?has_content ]
+            [#if testCase.Structural.JSON.Exists?has_content ]
+                [#local existPaths = []]
+                [#list testCase.Structural.JSON.Exists as path ]
+                    [#local existPaths += [
+                            {
+                                "path" : path
+                            }
+                        ]
+                    ]
+                [/#list]
                 [#local tests = mergeObjects(
                     tests,
                     {
                         testCaseName  : {
-                            "structure" : {
-                                "exists" : testCase.Structural.Exists
+                            "json_structure" : {
+                                "exists" : existPaths
                             }
                         }
                     }
                 )]
             [/#if]
 
-            [#if testCase.Structural.NotEmpty?has_content ]
+            [#if testCase.Structural.JSON.NotEmpty?has_content ]
+                [#local notEmtpyPaths = []]
+                [#list testCase.Structural.JSON.NotEmpty as path ]
+                    [#local notEmtpyPaths += [
+                            {
+                                "path" : path
+                            }
+                        ]
+                    ]
+                [/#list]
                 [#local tests = mergeObjects(
                     tests,
                     {
                         testCaseName  : {
-                            "structure" : {
-                                "not_empty" : testCase.Structural.NotEmpty
+                            "json_structure" : {
+                                "not_empty" : notEmtpyPaths
                             }
                         }
                     }
                 )]
             [/#if]
 
-            [#list (testCase.Structural.CFNResource)!{} as id,CFNResourceTest ]
+            [#list (testCase.Structural.CFN.Resource)!{} as id,CFNResourceTest ]
                 [#local tests = combineEntities(tests,
                     {
                         testCaseName : {
-                            "structure"  : {
+                            "cfn_structure"  : {
                                 "resource" : [
-                                    [
-                                        CFNResourceTest.Name,
-                                        CFNResourceTest.Type
-                                    ]
+                                    {
+                                        "id" : CFNResourceTest.Name,
+                                        "type" : CFNResourceTest.Type
+                                    }
                                 ]
                             }
                         }
@@ -124,13 +144,22 @@
                 )]
             [/#list]
 
-            [#if testCase.Structural.CFNOutput?has_content ]
+            [#if testCase.Structural.CFN.Output?has_content ]
+                [#local cfnOutputPaths = []]
+                [#list testCase.Structural.CFN.Output as path ]
+                    [#local cfnOutputPaths += [
+                            {
+                                "id" : path
+                            }
+                        ]
+                    ]
+                [/#list]
                 [#local tests = mergeObjects(
                     tests,
                     {
                         testCaseName  : {
-                            "structure" : {
-                                "output" : testCase.Structural.CFNOutput
+                            "cfn_structure" : {
+                                "output" : cfnOutputPaths
                             }
                         }
                     }

--- a/providers/shared/shared.ftl
+++ b/providers/shared/shared.ftl
@@ -4,8 +4,8 @@
 [#assign DEFAULT_DEPLOYMENT_FRAMEWORK = "default"]
 
 
-[#-- Default testplan --]
-[#macro shared_testplan occurrence ]
+[#-- Default testcase --]
+[#macro shared_testcase occurrence ]
     [#local solution = occurrence.Configuration.Solution ]
     [#local componentType = occurrence.Core.Type ]
 
@@ -32,8 +32,6 @@
     [#list testCaseNames as testCaseName ]
         [#if testCases[testCaseName]?? ]
             [#local testCase = testCases[testCaseName] ]
-
-            [@debug message="testCase" context=testCase enabled=true /]
 
             [#local tests = mergeObjects(
                 tests,


### PR DESCRIPTION
Another move around for getting the testing idea working 

Moves the loading processing of scenarios into the ability to load additional providers as SubProviders. SubProviders load like normal providers except when it comes to output management which is set by default to the existing GENERATION_PROVIDER variable 

Along with working for scenarios, this allows for codeontap users to load their own providers on top of standard providers, overriding default values or implementing their own components while still using the resources of another provider 

From a testing side this introduces a new provider `awstest` which contains scenarios designed to test the templates that we generate in a unit testing style, while keeping the testing isolated from the real world provider code