### PR TITLE
<fix> ES advanced options

### DIFF
--- a/providers/aws/components/es/setup.ftl
+++ b/providers/aws/components/es/setup.ftl
@@ -125,7 +125,7 @@
     [/#if]
 
     [#local esAdvancedOptions = {} ]
-    [#list solution.AdvancedOptions as option]
+    [#list solution.AdvancedOptions as id,option]
         [#local esAdvancedOptions +=
             {
                 option.Id : option.Value

--- a/providers/aws/components/es/setup.ftl
+++ b/providers/aws/components/es/setup.ftl
@@ -382,7 +382,7 @@
                             {
                                 "DedicatedMasterEnabled" : true,
                                 "DedicatedMasterCount" : master.Count,
-                                "DedicatedMasterType" : master.Processor
+                                "DedicatedMasterType" : (master.Processor)!"COTFatal: No master processor type provided"
                             },
                             ( master.Count > 0 ),
                             {

--- a/providers/aws/inputsources/shared/masterdata.ftl
+++ b/providers/aws/inputsources/shared/masterdata.ftl
@@ -1301,8 +1301,12 @@
         "DesiredPerZone": 1
       },
       "ElasticSearch": {
-        "Processor": "m3.medium.elasticsearch",
-        "CountPerZone": 1
+        "Processor": "t2.medium.elasticsearch",
+        "CountPerZone": 1,
+        "Master" : {
+          "Processor" : "t2.small.elasticsearch",
+          "CountPerZone" : 0
+        }
       },
       "service": {
         "DesiredPerZone": 1,

--- a/providers/aws/masterData.json
+++ b/providers/aws/masterData.json
@@ -1291,8 +1291,12 @@
         "Processor": "db.t2.small"
       },
       "ElasticSearch": {
-        "Processor": "m3.medium.elasticsearch",
-        "CountPerZone": 1
+        "Processor": "t2.medium.elasticsearch",
+        "CountPerZone": 1,
+        "Master" : {
+          "Processor" : "t2.small.elasticsearch",
+          "CountPerZone" : 0
+        }
       },
       "service": {
         "DesiredPerZone": 1,

--- a/providers/shared/components/es/id.ftl
+++ b/providers/shared/components/es/id.ftl
@@ -33,8 +33,17 @@
             },
             {
                 "Names" : "AdvancedOptions",
-                "Type" : ARRAY_OF_STRING_TYPE,
-                "Default" : []
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Id",
+                        "Type" : STRING_TYPE
+                    },
+                    {
+                        "Names" : "Value",
+                        "Type" : STRING_TYPE
+                    }
+                ]
             },
             {
                 "Names" : "Version",


### PR DESCRIPTION
Align the advanced options configuration with the composite objects structure 
add default instances sizes for the master nodes ( only applied if the counts enable the master )