### PR TITLE
<feature> CMDB v2.0.1 - Add du/placement subdirectories to the state tree

### DIFF
--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -679,33 +679,23 @@ function process_template() {
   # Defaults
   local passes=("template")
   local template_alternatives=("primary")
-  local cf_dir_default="${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
 
   case "${level}" in
 
-    unitlist)
-      cf_dir_default="${PRODUCT_STATE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
-      ;;
-
-    blueprint)
-      cf_dir_default="${PRODUCT_STATE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
-      ;;
-
-    buildblueprint)
-      cf_dir_default="${PRODUCT_STATE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
+    unitlist|blueprint|buildblueprint)
+      local cf_dir_default="${PRODUCT_STATE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
       ;;
 
     account)
-      cf_dir_default="${ACCOUNT_STATE_DIR}/cf/shared"
+      local cf_dir_default="${ACCOUNT_STATE_DIR}/cf/shared"
       ;;
 
-    solution)
+    product)
+      local cf_dir_default="${PRODUCT_STATE_DIR}/cf/shared"
       ;;
 
-    segment)
-      ;;
-
-    application)
+    solution|segment|application)
+      local cf_dir_default="${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
       ;;
 
     *)
@@ -725,18 +715,10 @@ function process_template() {
       # No subdirectories for deployment units
       ;;
     *)
-      readarray -t legacy_files < <(find "${cf_dir}" -mindepth 1 -maxdepth 1 -name "*${deployment_unit}*" )
+      readarray -t legacy_files < <(find "${cf_dir_default}" -mindepth 1 -maxdepth 1 -name "*${deployment_unit}*" )
 
       if [[ (-d "${cf_dir_default}/${deployment_unit}") || "${#legacy_files[@]}" -eq 0 ]]; then
-        case "${region}" in
-          us-east-1)
-            local placement="global"
-            ;;
-          *)
-            local placement="default"
-            ;;
-        esac
-        local cf_dir_default="${cf_dir_default}/${deployment_unit}/${placement}"
+        local cf_dir_default=$(getUnitCFDir "${cf_dir_default}" "${level}" "${deployment_unit}" "" "${region}" )
       fi
       ;;
   esac

--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -680,28 +680,23 @@ function process_template() {
   local passes=("template")
   local template_alternatives=("primary")
   local cf_dir_default="${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
-  local cf_dir="${OUTPUT_DIR:-${cf_dir_default}}"
 
   case "${level}" in
 
     unitlist)
       cf_dir_default="${PRODUCT_STATE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
-      cf_dir="${OUTPUT_DIR:-${cf_dir_default}}"
       ;;
 
     blueprint)
       cf_dir_default="${PRODUCT_STATE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
-      cf_dir="${OUTPUT_DIR:-${cf_dir_default}}"
       ;;
 
     buildblueprint)
       cf_dir_default="${PRODUCT_STATE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
-      cf_dir="${OUTPUT_DIR:-${cf_dir_default}}"
       ;;
 
     account)
       cf_dir_default="${ACCOUNT_STATE_DIR}/cf/shared"
-      cf_dir="${OUTPUT_DIR:-${cf_dir_default}}"
       ;;
 
     solution)
@@ -717,6 +712,37 @@ function process_template() {
       fatalCantProceed "\"${LEVEL}\" is not one of the known stack levels." && return 1
       ;;
   esac
+
+  # Handle >=v2.0.1 cmdb where du/placement subdirectories were introduced for state
+  #
+  # Assumption is that if files whose names contain the du are not present in
+  # the base cf_dir, then the du directory structure should be used
+  #
+  # This will start to cause the new structure to be created by default for new units,
+  # and will accommodate the cmdb update when it is performed.
+  case "${level}" in
+    unitlist|blueprint|buildblueprint)
+      # No subdirectories for deployment units
+      ;;
+    *)
+      readarray -t legacy_files < <(find "${cf_dir}" -mindepth 1 -maxdepth 1 -name "*${deployment_unit}*" )
+
+      if [[ (-d "${cf_dir_default}/${deployment_unit}") || "${#legacy_files[@]}" -eq 0 ]]; then
+        case "${region}" in
+          us-east-1)
+            local placement="global"
+            ;;
+          *)
+            local placement="default"
+            ;;
+        esac
+        local cf_dir_default="${cf_dir_default}/${deployment_unit}/${placement}"
+      fi
+      ;;
+  esac
+
+  # Permit an override
+  cf_dir="${OUTPUT_DIR:-${cf_dir_default}}"
 
   # Ensure the aws tree for the templates exists
   [[ ! -d ${cf_dir} ]] && mkdir -p ${cf_dir}

--- a/aws/manageDeployment.sh
+++ b/aws/manageDeployment.sh
@@ -314,7 +314,7 @@ function main() {
   # Run the prologue script if present
   # Refresh the stack outputs in case something from pseudo stack is needed
   [[ -s "${PROLOGUE}" ]] && \
-    { info "Processing prologue script ..." && . "${PROLOGUE}" && assemble_composite_stack_outputs || return $?; }
+    { info "Processing prologue script ..." && . "${PROLOGUE}" || return $?; }
 
   process_deployment_status=0
   # Process the deployment
@@ -331,13 +331,11 @@ function main() {
       return ${process_deployment_status}
   esac
 
-  assemble_composite_stack_outputs
-
   # Run the epilogue script if present
   # Refresh the stack outputs in case something from the just created stack is needed
   # by the epilogue script
   [[ -s "${EPILOGUE}" ]] && \
-  { info "Processing epilogue script ..." && assemble_composite_stack_outputs && . "${EPILOGUE}" || return $?; }
+  { info "Processing epilogue script ..." && . "${EPILOGUE}" || return $?; }
 
   return 0
 }

--- a/execution/contextTree.sh
+++ b/execution/contextTree.sh
@@ -1543,7 +1543,7 @@ function upgrade_cmdb_repo_to_v2_0_1() {
             local result=$?
             ;;
           arm)
-            contains "${state_filename}" "([a-z0-9]+)-(.+)-([a-z][a-z0-9]+)-(eastus)(-pseudo)?-(.+)";
+            contains "${state_filename}" "([a-z0-9]+)-(.+)-([a-z][a-z0-9]+)-(eastus|australiaeast|australiasoutheast|australiacentral|australiacentral2)(-pseudo)?-(.+)";
             local result=$?
             ;;
           *)

--- a/execution/contextTree.sh
+++ b/execution/contextTree.sh
@@ -1537,31 +1537,19 @@ function upgrade_cmdb_repo_to_v2_0_1() {
         local state_filename="$(fileName "${state_file}")"
 
         # Filename format varies with deployment framework
-        case "${deployment_framework}" in
-          cf)
-            contains "${state_filename}" "([a-z0-9]+)-(.+)-([a-z][a-z0-9]+)-([a-z]{2}-[a-z]+-[1-9])(-pseudo)?-(.+)";
-            local result=$?
-            ;;
-          arm)
-            contains "${state_filename}" "([a-z0-9]+)-(.+)-([a-z][a-z0-9]+)-(eastus|australiaeast|australiasoutheast|australiacentral|australiacentral2)(-pseudo)?-(.+)";
-            local result=$?
-            ;;
-          *)
-            debug "${dry_run}Ignoring ${deployment_framework} deployment framework ..."
-            continue
-            ;;
-        esac
+        if
+          contains "${state_filename}" "([a-z0-9]+)-(.+)-([a-z][a-z0-9]+)-([a-z]{2}-[a-z]+-[1-9])(-pseudo)?-(.+)" ||
+          contains "${state_filename}" "([a-z0-9]+)-(.+)-([a-z][a-z0-9]+)-(eastus|australiaeast|australiasoutheast|australiacentral|australiacentral2)(-pseudo)?-(.+)"; then
 
-        # Ignore files that don't match expected format
-        if [[ ${result} -ne 0 ]]; then
-          warn "${dry_run}Ignoring ${state_file}, doesn't match the expected state filename format for ${deployment_framework} ..."
+          local stack_level="${BASH_REMATCH[1]}"
+          local stack_deployment_unit="${BASH_REMATCH[2]}"
+          local stack_account="${BASH_REMATCH[3]}"
+          local stack_region="${BASH_REMATCH[4]}"
+
+        else
+          warn "${dry_run}Ignoring ${state_file}, doesn't match one of the expected state filename formats ..."
           continue
         fi
-
-        local stack_level="${BASH_REMATCH[1]}"
-        local stack_deployment_unit="${BASH_REMATCH[2]}"
-        local stack_account="${BASH_REMATCH[3]}"
-        local stack_region="${BASH_REMATCH[4]}"
 
         case "${stack_level}" in
           defn)


### PR DESCRIPTION
Move existing state files into subdirectories based on the deployment unit.

Also add a placement subdirectory based on the the region.

Definition files are deleted as their names are occurrence rather than deployment unit based, but they are recopied as part of each build so will be refreshed on next build and placed in the correct deployment directory s a result. 

NOTE: The v2.0.1 upgrade will not be triggered by default as the maximum cmdb version for upgrade hasn't been altered. This will permit selective testing before the upgrade being automated more generally.

To test this upgrade set

```export GENERATION_MAX_CMDB_UPGRADE_VERSION=v2.0.1```