### PR TITLE
<fix> apigateway allow empty on ContentHandling

### DIFF
--- a/engine/openapi.ftl
+++ b/engine/openapi.ftl
@@ -301,7 +301,7 @@
         {
             "Names" : ["ContentHandling", "contentHandling"],
             "Type" : STRING_TYPE,
-            "Values" : ["CONVERT_TO_BINARY", "CONVERT_TO_TEXT"]
+            "Values" : ["", "CONVERT_TO_BINARY", "CONVERT_TO_TEXT"]
         },
         {
             "Names" : ["Requests"],


### PR DESCRIPTION
Allow for an empty value on ContentHandling validation - the current default value if none is sent