### PR TITLE
<fix> remove es explicit count in favour of per zone

### DIFF
--- a/providers/aws/components/es/state.ftl
+++ b/providers/aws/components/es/state.ftl
@@ -36,6 +36,10 @@
         [#local solution = occurrence.Configuration.Solution]
         [#local esId = formatResourceId(AWS_ES_RESOURCE_TYPE, core.Id)]
         [#local esHostName = getExistingReference(esId, DNS_ATTRIBUTE_TYPE) ]
+        [#local esSnapshotRoleId = formatDependentRoleId(esId, "snapshotStore" ) ]
+
+        [#local baselineLinks = getBaselineLinks(occurrence, [ "AppData" ] )]
+        [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
         [#assign componentState =
             {
@@ -48,6 +52,11 @@
                     },
                     "servicerole" : {
                         "Id" : formatDependentRoleId(esId),
+                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                        "IncludeInDeploymentState" : false
+                    },
+                    "snapshotrole" : {
+                        "Id" : esSnapshotRoleId,
                         "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
                         "IncludeInDeploymentState" : false
                     }
@@ -77,7 +86,10 @@
                     "FQDN" : esHostName,
                     "URL" : "https://" + esHostName,
                     "KIBANA_URL" : "https://" + esHostName + "/_plugin/kibana/",
-                    "PORT" : 443
+                    "PORT" : 443,
+                    "SNAPSHOT_ROLE_ARN" : getExistingReference(esSnapshotRoleId, ARN_ATTRIBUTE_TYPE),
+                    "SNAPSHOT_BUCKET" : baselineComponentIds["AppData"],
+                    "SNAPSHOT_PATH" : getAppDataFilePrefix(occurrence)
                 },
                 "Roles" : {
                     "Outbound" : {

--- a/providers/shared/references/Processor/id.ftl
+++ b/providers/shared/references/Processor/id.ftl
@@ -123,11 +123,6 @@
                     "Default" : 1
                 },
                 {
-                    "Names" : [ "Count", "DataNodeCount" ],
-                    "Type" : NUMBER_TYPE,
-                    "Default" : 0
-                },
-                {
                     "Names" : "Master",
                     "Children" : [
                         {


### PR DESCRIPTION
Since ES data nodes can only be added in counts based on the number of zones selected the explicit count doesn't make sense. This removes the explicit count for data nodes but keeps it for master nodes 

Also adds a new IAM role which can be used to create S3 based snapshot store within the AppData store of the es cluster. Useful for snapshots you want to access 