### PR TITLE
<fix> fargate and ES pass role permissions

### DIFF
--- a/providers/aws/components/ecs/state.ftl
+++ b/providers/aws/components/ecs/state.ftl
@@ -274,6 +274,8 @@
     [#local taskName = core.Name]
     [#local taskRoleId = formatDependentRoleId(taskId)]
 
+    [#local executionRoleId = formatDependentRoleId(taskId, "execution")]
+
     [#local lgId = formatDependentLogGroupId(taskId) ]
     [#local lgName = core.FullAbsolutePath ]
 
@@ -359,7 +361,7 @@
                 "executionRole",
                 solution.Engine == "fargate",
                 {
-                    "Id" : formatDependentRoleId(taskId, "execution"),
+                    "Id" : executionRoleId,
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
                     "IncludeInDeploymentState" : false
                 }
@@ -380,10 +382,17 @@
                     }
                 },
                 "Outbound" : {
-                    "run" :  ecsTaskRunPermission(ecsId) +
+                    "run" :
+                        ecsTaskRunPermission(ecsId) +
                         solution.UseTaskRole?then(
                             iamPassRolePermission(
                                 getReference(taskRoleId, ARN_ATTRIBUTE_TYPE)
+                            ),
+                            []
+                        ) +
+                        (solution.Engine == "fargate")?then(
+                            iamPassRolePermission(
+                                getReference(executionRoleId, ARN_ATTRIBUTE_TYPE)
                             ),
                             []
                         )

--- a/providers/aws/components/es/state.ftl
+++ b/providers/aws/components/es/state.ftl
@@ -95,7 +95,11 @@
                     "Outbound" : {
                         "default" : "consume",
                         "consume" : esConsumePermission(esId),
-                        "datafeed" : esKinesesStreamPermission(esId)
+                        "datafeed" : esKinesesStreamPermission(esId),
+                        "snapshot" : esConsumePermission(esId) +
+                                        iamPassRolePermission(
+                                            getExistingReference(esSnapshotRoleId, ARN_ATTRIBUTE_TYPE)
+                                        )
                     },
                     "Inbound" : {
                     }


### PR DESCRIPTION
Adds pass role permissions 
- Fargate containers have two roles - one for execution of the task and one for the task to consume other services 
- ES - Pass role for the configuration of the snapshot repository by a service linked to the ES component with the snapshot role