### PR TITLE
Certificate Utils into Common.ftl

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -612,6 +612,31 @@ behaviour.
     ]
 [/#function]
 
+[#function getCertificateDomains certificateObject]
+    [#return certificateObject.Domains![] ]
+[/#function]
+
+[#function getCertificatePrimaryDomain certificateObject]
+    [#list certificateObject.Domains as domain]
+        [#if isPrimaryDomain(domain) ]
+            [#return domain ]
+            [#break]
+        [/#if]
+    [/#list]
+    [#return {} ]
+[/#function]
+
+[#function getCertificateSecondaryDomains certificateObject]
+    [#local result = [] ]
+    [#list certificateObject.Domains as domain]
+        [#if isSecondaryDomain(domain) ]
+            [#local result += [domain] ]
+            [#break]
+        [/#if]
+    [/#list]
+    [#return result ]
+[/#function]
+
 [#function getHostName certificateObject occurrence]
 
     [#local core = occurrence.Core ]

--- a/providers/aws/services/acm/id.ftl
+++ b/providers/aws/services/acm/id.ftl
@@ -24,31 +24,6 @@
                 extensions)]
 [/#function]
 
-[#function getCertificateDomains certificateObject]
-    [#return certificateObject.Domains![] ]
-[/#function]
-
-[#function getCertificatePrimaryDomain certificateObject]
-    [#list certificateObject.Domains as domain]
-        [#if isPrimaryDomain(domain) ]
-            [#return domain ]
-            [#break]
-        [/#if]
-    [/#list]
-    [#return {} ]
-[/#function]
-
-[#function getCertificateSecondaryDomains certificateObject]
-    [#local result = [] ]
-    [#list certificateObject.Domains as domain]
-        [#if isSecondaryDomain(domain) ]
-            [#local result += [domain] ]
-            [#break]
-        [/#if]
-    [/#list]
-    [#return result ]
-[/#function]
-
 [#function formatDomainCertificateId certificateObject, hostName=""]
     [#local primaryDomain = getCertificatePrimaryDomain(certificateObject) ]
     [#return


### PR DESCRIPTION
These two common certificate functions are used by more than a single provider. This PR moves them out of a AWS Service ID file and into engine/common where the remainder of the certificate utility functions reside.