### PR TITLE
<Fix> Port reference data can include Success Codes

### DIFF
--- a/providers/shared/references/Port/id.ftl
+++ b/providers/shared/references/Port/id.ftl
@@ -47,6 +47,10 @@
                 {
                     "Names" : "Timeout",
                     "Type" : [ NUMBER_TYPE, STRING_TYPE ]
+                },
+                {
+                    "Names" : "SuccessCodes",
+                    "Type" : STRING_TYPE
                 }
             ]
         },


### PR DESCRIPTION
Add SuccessCodes as an optional parameter on the HealthCheck data for a port.