### PR TITLE
SPA Port Attribute Option

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -493,6 +493,39 @@ behaviour.
     [/#if]
 [/#function]
 
+
+[#-- Primary is used on component attributes --]
+[#assign DOMAIN_ROLE_PRIMARY="primary" ]
+
+[#-- Secondaries allow a smooth transition from one domain to another --]
+[#assign DOMAIN_ROLE_SECONDARY="secondary" ]
+
+[#-- Names --]
+[#function formatHostDomainName host parts style=""]
+    [#local result =
+        formatDomainName(
+            formatName(host),
+            parts
+        )]
+    [#switch style]
+        [#case "hyphenated"]
+            [#return result?replace(".", "-")]
+            [#break]
+        [#default]
+            [#return result]
+    [/#switch]
+
+[/#function]
+
+[#-- Resources --]
+[#function isPrimaryDomain domainObject]
+    [#return domainObject.Role == DOMAIN_ROLE_PRIMARY ]
+[/#function]
+
+[#function isSecondaryDomain domainObject]
+    [#return domainObject.Role == DOMAIN_ROLE_SECONDARY ]
+[/#function]
+
 [#function getDomainObjects certificateObject qualifiers...]
     [#local result = [] ]
     [#local primaryNotSeen = true]

--- a/providers/aws/services/dns/id.ftl
+++ b/providers/aws/services/dns/id.ftl
@@ -1,42 +1,10 @@
 [#ftl]
 
-[#-- Primary is used on component attributes --]
-[#assign DOMAIN_ROLE_PRIMARY="primary" ]
-
-[#-- Secondaries allow a smooth transition from one domain to another --]
-[#assign DOMAIN_ROLE_SECONDARY="secondary" ]
-
-[#-- Names --]
-[#function formatHostDomainName host parts style=""]
-    [#local result =
-        formatDomainName(
-            formatName(host),
-            parts
-        )]
-    [#switch style]
-        [#case "hyphenated"]
-            [#return result?replace(".", "-")]
-            [#break]
-        [#default]
-            [#return result]
-    [/#switch]
-
-[/#function]
-
 [#-- Resources --]
-
 [#function formatDomainId ids...]
     [#return formatResourceId(
                 "domain",
                 ids)]
-[/#function]
-
-[#function isPrimaryDomain domainObject]
-    [#return domainObject.Role == DOMAIN_ROLE_PRIMARY ]
-[/#function]
-
-[#function isSecondaryDomain domainObject]
-    [#return domainObject.Role == DOMAIN_ROLE_SECONDARY ]
 [/#function]
 
 [#function formatSegmentDNSZoneId extensions...]

--- a/providers/shared/components/spa/id.ftl
+++ b/providers/shared/components/spa/id.ftl
@@ -50,8 +50,18 @@
             {
                 "Names" : "Port",
                 "Description" : "The port used to access the SPA content.",
-                "Type" : STRING_TYPE,
-                "Default" : "https"
+                "Children" : [
+                    {
+                        "Names" : "HTTP",
+                        "Type" : STRING_TYPE,
+                        "Default" : "http"
+                    },
+                    {
+                        "Names" : "HTTPS",
+                        "Type" : STRING_TYPE,
+                        "Default" : "https"
+                    }
+                ]
             }
         ]
 /]

--- a/providers/shared/components/spa/id.ftl
+++ b/providers/shared/components/spa/id.ftl
@@ -46,6 +46,12 @@
                 "Description" : "The path appended to files that will be used for config",
                 "Type" : STRING_TYPE,
                 "Default" : "config"
+            },
+            {
+                "Names" : "Port",
+                "Description" : "The port used to access the SPA content.",
+                "Type" : STRING_TYPE,
+                "Default" : "https"
             }
         ]
 /]

--- a/providers/shared/references/Port/id.ftl
+++ b/providers/shared/references/Port/id.ftl
@@ -23,7 +23,18 @@
         },
         {
             "Names" : "Port",
-            "Type" : NUMBER_TYPE
+            "Children" : [
+                {
+                    "Names" : "Http",
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 80
+                },
+                {
+                    "Names" : "Https",
+                    "Type" : NUMBER_TYPE,
+                    "Default" : 443
+                }
+            ]
         },
         {
             "Names" : "HealthCheck",

--- a/providers/shared/references/Port/id.ftl
+++ b/providers/shared/references/Port/id.ftl
@@ -23,18 +23,7 @@
         },
         {
             "Names" : "Port",
-            "Children" : [
-                {
-                    "Names" : "Http",
-                    "Type" : NUMBER_TYPE,
-                    "Default" : 80
-                },
-                {
-                    "Names" : "Https",
-                    "Type" : NUMBER_TYPE,
-                    "Default" : 443
-                }
-            ]
+            "Type" : NUMBER_TYPE
         },
         {
             "Names" : "HealthCheck",


### PR DESCRIPTION
Rather than hard-code HTTPS into the SPA Component, this PR introduces the ability to set a port for an SPA provider whilst defaulting to HTTPS.

This PR also migrates some DNS related functions and variables and moves them into Common.ftl alongside other domain-related functions.