### PR TITLE
<feature> lambda reserved executions

### DIFF
--- a/providers/aws/components/lambda/setup.ftl
+++ b/providers/aws/components/lambda/setup.ftl
@@ -299,7 +299,8 @@
                     "KMSKeyId" : cmkKeyId,
                     "Name" : fnName,
                     "Description" : fnName,
-                    "Tracing" : solution.Tracing
+                    "Tracing" : solution.Tracing,
+                    "ReservedExecutions" : solution.ReservedExecutions
                 }
             roleId=roleId
             securityGroupIds=

--- a/providers/aws/services/lambda/resource.ftl
+++ b/providers/aws/services/lambda/resource.ftl
@@ -117,6 +117,11 @@
                             (settings.Tracing.Mode!"") == "active",
                             "PassThrough")
                 }
+            ) +
+            attributeIfTrue(
+                "ReservedConcurrentExecutions",
+                settings.ReservedExecutions >= 1,
+                settings.ReservedExecutions
             )
 
         outputs=LAMBDA_FUNCTION_OUTPUT_MAPPINGS

--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -187,6 +187,11 @@
             {
                 "Names" : "Tracing",
                 "Children" : tracingChildConfiguration
+            },
+            {
+                "Names" : "ReservedExecutions",
+                "Type" : NUMBER_TYPE,
+                "Default" : -1
             }
         ]
     parent=LAMBDA_COMPONENT_TYPE


### PR DESCRIPTION
Adds support for configuring reserved executions on lambda functions

This is used to ensure that a busy lambda doesn't flood the execution limit on the account and also to ensure that the lambda has room to get busy 