### PR TITLE
<fix> cmk to baseline transition

### DIFF
--- a/providers/aws/components/baseline/setup.ftl
+++ b/providers/aws/components/baseline/setup.ftl
@@ -378,8 +378,8 @@
                             ) +
                             valueIfTrue(
                                 [
-                                    "   info \"Removing old ssh pseduo stack output\"",
-                                    "   legacy_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE/\"-baseline-\"/\"-cmk-\"}\")-keypair-pseudo-stack.json\"",
+                                    "   info \"Removing old ssh pseudo stack output\"",
+                                    "   legacy_pseudo_stack_file=\"$\{CF_DIR/\"baseline\"/\"cmk\"}/$(fileBase \"$\{BASH_SOURCE/\"-baseline-\"/\"-cmk-\"}\")-keypair-pseudo-stack.json\"",
                                     "   if [ -f \"$\{legacy_pseudo_stack_file}\" ]; then",
                                     "       rm -f \"$\{legacy_pseudo_stack_file}\"",
                                     "   fi"
@@ -462,14 +462,18 @@
                                     [
                                         "case $\{STACK_OPERATION} in",
                                         "  delete)",
-                                        "  delete_oai_credentials" + " " +
-                                            "\"" + regionId + "\" " +
-                                            "\"" + legacyOAIName + "\" || return $?",
-                                        "  rm -f \"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-pseudo-stack.json\"",
+                                        "    delete_oai_credentials" + " " +
+                                               "\"" + regionId + "\" " +
+                                               "\"" + legacyOAIName + "\" || return $?",
+                                        "    rm -f \"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-pseudo-stack.json\"",
                                         "    ;;",
                                         "  create|update)",
-                                        "    info \"Removing old oai pseduo stack output\"",
-                                        "    legacy_pseudo_stack_file=\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE/\"-baseline-\"/\"-cmk-\"}\")-pseudo-stack.json\"",
+                                        "    info \"Removing legacy oai credential\"",
+                                        "    delete_oai_credentials" + " " +
+                                               "\"" + regionId + "\" " +
+                                               "\"" + legacyOAIName + "\" || return $?",
+                                        "    info \"Removing legacy oai pseudo stack output\"",
+                                        "    legacy_pseudo_stack_file=\"$\{CF_DIR/\"baseline\"/\"cmk\"}/$(fileBase \"$\{BASH_SOURCE/\"-baseline-\"/\"-cmk-\"}\")-pseudo-stack.json\"",
                                         "    if [ -f \"$\{legacy_pseudo_stack_file}\" ]; then",
                                         "       rm -f \"$\{legacy_pseudo_stack_file}\"",
                                         "    fi",


### PR DESCRIPTION
The legacy oai credential was not being removed in the transition from cmk to baseline.

The checks to delete the legacy oai/ssh pseudo stacks were also not compatible with cmdbs >= 2.0.1 as they assumed the baseline and cmk stacks were in the same directory. The CF_DIR is now adjusted accordingly in addition to the filename.