### PR TITLE
<fix> XRay permissions for lambda

### DIFF
--- a/providers/aws/components/lambda/setup.ftl
+++ b/providers/aws/components/lambda/setup.ftl
@@ -180,6 +180,10 @@
             ["arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"],
             ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
         ) +
+        (solution.Tracing.Configured)?then(
+            ["arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"],
+            []
+        ) +
         _context.ManagedPolicy ]
 
     [#local linkPolicies = getLinkTargetsOutboundRoles(_context.Links) ]


### PR DESCRIPTION
Lambda needs permissions on the XRay daemon if tracing is enabled. Write access is needed regardless of whether the mode is PassThrough or Active.