### PR TITLE
<fix> Handle optional name and in parameters

### DIFF
--- a/engine/openapi.ftl
+++ b/engine/openapi.ftl
@@ -144,8 +144,14 @@
                     "Default" : "apiKey"
                 },
                 {
-                    "Names" : "Header",
+                    "Names" : ["Header", "name"],
                     "Type" : STRING_TYPE
+                },
+                {
+                    "Names" : ["In", "in"],
+                    "Type" : STRING_TYPE,
+                    "Values" : ["header", "query", "cookie"],
+                    "Default" : "header"
                 },
                 {
                     "Names" : "AuthType",
@@ -470,7 +476,7 @@
                 [#local scheme +=
                     {
                         "name" : value.Header!("COTFatal: No header specified for scheme " + key),
-                        "in" : "header"
+                        "in" : value.In
                     }
                 ]
                 [#local Authorizer = value.Authorizer!{} ]


### PR DESCRIPTION
apiKeys can have "in" and "name" provided so include them in the analysis of security schemes.