### PR TITLE
<feature> APIGW add option security control

### DIFF
--- a/engine/openapi.ftl
+++ b/engine/openapi.ftl
@@ -230,6 +230,12 @@
             "Names" : ["Options"],
             "Type" : [BOOLEAN_TYPE],
             "Default" : true
+        },
+        {
+            "Names" : ["OptionsSecurity"],
+            "Type" : STRING_TYPE,
+            "Values" : [ "UseVerb", "disabled" ],
+            "Default" : "UseVerb"
         }
     ]
 ]
@@ -1149,7 +1155,11 @@ is useful to see what the global settings are from a debug perspective
                             "Type" : "mock-cors"
                         }
                     ) +
-                    optionsSecurity
+                    valueIfTrue(
+                        optionsSecurity
+                        globalConfiguration.OptionsSecurity == "UseVerb",
+                        {}
+                    )
                 }
             ]
         [/#if]

--- a/engine/openapi.ftl
+++ b/engine/openapi.ftl
@@ -1156,7 +1156,7 @@ is useful to see what the global settings are from a debug perspective
                         }
                     ) +
                     valueIfTrue(
-                        optionsSecurity
+                        optionsSecurity,
                         globalConfiguration.OptionsSecurity == "UseVerb",
                         {}
                     )


### PR DESCRIPTION
Add the ability to control how security is applied to options verbs which are added automatically through the openapi enrichment process

This is most commonly used for mock CORS preflight checks which are used to determine the appropriate methods that can be consumed at an endpoint 

Since one CORS option controls credentials, clients don't have to send the Authorisation header when making the preflight check using the OPTIONS method. 

More details on CORS and preflight checks are available here
https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Preflighted_requests 