### PR TITLE
<feature> Supported lambda run-times

### DIFF
--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -85,7 +85,25 @@
             {
                 "Names" : "RunTime",
                 "Type" : STRING_TYPE,
-                "Values" : ["nodejs", "nodejs4.3", "nodejs6.10", "nodejs8.10", "nodejs10.x", "java8", "python2.7", "python3.6", "dotnetcore1.0", "dotnetcore2.0", "dotnetcore2.1", "nodejs4.3-edge", "go1.x"],
+                "Values" : [
+                    "dotnetcore1.0",
+                    "dotnetcore2.1",
+                    "go1.x",
+                    "java8",
+                    "java11",
+                    "nodejs",
+                    "nodejs4.3",
+                    "nodejs4.3-edge",
+                    "nodejs6.10",
+                    "nodejs8.10",
+                    "nodejs10.x",
+                    "nodejs12.x",
+                    "python2.7",
+                    "python3.6",
+                    "python3.7",
+                    "python3.8",
+                    "ruby2.5"
+                ],
                 "Mandatory" : true
             },
             {


### PR DESCRIPTION
Add the latest run-times supported by lambda. For now we'll leave some of the older ones like node6 there for existing deployments.