### PR TITLE
<fix> RDS encrypted snapshots

### DIFF
--- a/providers/aws/components/db/setup.ftl
+++ b/providers/aws/components/db/setup.ftl
@@ -151,7 +151,7 @@
 
     [#local rdsPreDeploySnapshotId = formatName(
                                         rdsFullName,
-                                        commandLineOptions.Run.Id,
+                                        (commandLineOptions.Run.Id)?split('')?reverse?join(''),
                                         "pre-deploy")]
 
     [#local rdsTags = getOccurrenceCoreTags(occurrence, rdsFullName)]
@@ -258,6 +258,7 @@
                         "info \"Checking Snapshot Encryption... \"",
                         "encrypt_snapshot" +
                         " \"" + region + "\" " +
+                        " \"" + hostType + "\" " +
                         " \"" + rdsPreDeploySnapshotId + "\" " +
                         " \"" + cmkKeyArn + "\" || return $?",
                         "}",
@@ -637,7 +638,7 @@
                         id=scalingTargetId
                         minCount=processorCounts.MinCount
                         maxCount=processorCounts.MaxCount
-                        scalingResourceId=getAutScalingRDSClusterResourceId(rdsId)
+                        scalingResourceId=getAutoScalingRDSClusterResourceId(rdsId)
                         scalableDimension="rds:cluster:ReadReplicaCount"
                         resourceType=serviceResourceType
                         scheduledActions=scheduledActions

--- a/providers/aws/services/autoscaling/resource.ftl
+++ b/providers/aws/services/autoscaling/resource.ftl
@@ -123,7 +123,7 @@
     ]
 [/#function]
 
-[#function getAutScalingRDSClusterResourceId clusterId ]
+[#function getAutoScalingRDSClusterResourceId clusterId ]
     [#return
         {
             "Fn::Join" : [
@@ -131,6 +131,20 @@
                 [
                     "cluster",
                     getReference(clusterId)
+                ]
+            ]
+        }
+    ]
+[/#function]
+
+[#function getAutoScalingLambdaResourceId lambdaAliasId ]
+    [#return
+        {
+            "Fn::Join" : [
+                ":",
+                [
+                    "function",
+                    getReference(lambdaAliasId)
                 ]
             ]
         }

--- a/providers/aws/services/autoscaling/resource.ftl
+++ b/providers/aws/services/autoscaling/resource.ftl
@@ -137,20 +137,6 @@
     ]
 [/#function]
 
-[#function getAutoScalingLambdaResourceId lambdaAliasId ]
-    [#return
-        {
-            "Fn::Join" : [
-                ":",
-                [
-                    "function",
-                    getReference(lambdaAliasId)
-                ]
-            ]
-        }
-    ]
-[/#function]
-
 [#function getAutoScalingAppStepPolicy
     adjustmentType
     cooldown


### PR DESCRIPTION
- fixes #1205 to include the instance host type when managing encrypted snapshots
- makes the predeploysnapshot Id a reverse of the runId to force the creation of new templates on every template generation - This ensures that at snapshot will be created on each manage Environment 
- Fixes a typo in the function name for autoscaling auroroa