### PR TITLE
<fix> SQS External Link and logwatch principal

### DIFF
--- a/providers/aws/components/mobilenotifier/state.ftl
+++ b/providers/aws/components/mobilenotifier/state.ftl
@@ -80,7 +80,7 @@
                     "Engine" : engine,
                     "Type" : AWS_SNS_PLATFORMAPPLICATION_RESOURCE_TYPE,
                     "Monitored" : true
-                } + 
+                } +
                 attributeIfTrue(
                     "Deployed",
                     ( engine == MOBILENOTIFIER_SMS_ENGINE),
@@ -117,7 +117,7 @@
             "Roles" : {
                 "Inbound" : {
                     "logwatch" : {
-                        "Principal" : "logs." + region + ".amazonaws.com",
+                        "Principal" : { "Service" : "logs." + region + ".amazonaws.com"},
                         "LogGroupIds" : [ lgId, lgFailureId ]
                     }
                 },

--- a/providers/aws/components/sqs/state.ftl
+++ b/providers/aws/components/sqs/state.ftl
@@ -4,9 +4,8 @@
     [#local core = occurrence.Core]
 
     [#if core.External!false]
-        [#local id = baseState.Attributes["ARN"]!"" ]
+        [#local id = occurrence.State.Attributes["ARN"]!"" ]
         [#assign componentState =
-            baseState +
             valueIfContent(
                 {
                     "Roles" : {


### PR DESCRIPTION
Change SQS external link state processing to work with the current way the state macro is called.

Also correct the format of the principal for log watchers - looks like AWS have tightened up or changed the principal format for a service invocation.