### PR TITLE
<refactor> Remove baseState from state routines

### DIFF
--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -167,7 +167,7 @@
     [#return profile[key]!{} ]
 [/#function]
 
-[#function invokeComponentMacro occurrence resourceGroup type qualifiers=[] parent={} baseState={} includeShared=false ]
+[#function invokeComponentMacro occurrence resourceGroup type qualifiers=[] parent={} includeShared=false ]
     [#local placement = (occurrence.State.ResourceGroups[resourceGroup].Placement)!{} ]
     [#if placement?has_content]
         [#local macroOptions = [] ]
@@ -209,11 +209,10 @@
         [/#if]
         [#local macro = getFirstDefinedDirective(macroOptions)]
         [#if macro?has_content]
-            [#if parent?has_content || baseState?has_content]
+            [#if parent?has_content ]
                 [@(.vars[macro])
                     occurrence=occurrence
-                    parent=parent
-                    baseState=baseState /]
+                    parent=parent /]
             [#else]
                 [@(.vars[macro])
                     occurrence=occurrence /]
@@ -237,7 +236,6 @@
             resourceGroup,
             "setup",
             qualifiers,
-            {},
             {}
         )]
 [/#function]
@@ -249,7 +247,6 @@
             resourceGroup,
             "genplan",
             qualifiers,
-            {},
             {}
         )]
 [/#function]
@@ -261,21 +258,19 @@
             resourceGroup,
             "testcase",
             qualifiers,
-            {},
-            {},
+            {}
             true
         )]
 [/#function]
 
-[#function invokeStateMacro occurrence resourceGroup parent={} baseState={} ]
+[#function invokeStateMacro occurrence resourceGroup parent={} ]
     [#return
         invokeComponentMacro(
             occurrence,
             resourceGroup,
             "state",
             [],
-            parent,
-            baseState
+            parent
         )]
 [/#function]
 

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -243,7 +243,7 @@
         ]
 
         [#-- Attempt to invoke state macro for resource group --]
-        [#if invokeStateMacro(occurrence, key, parentOccurrence, state)]
+        [#if invokeStateMacro(occurrence, key, parentOccurrence)]
             [#local state = mergeObjects(state, componentState) ]
         [#else]
             [@debug

--- a/providers/aws/components/apigateway/state.ftl
+++ b/providers/aws/components/apigateway/state.ftl
@@ -57,7 +57,7 @@ configured and Mode 4 is used if CloudFront is not configured. No mappings are
 created in either case.
 --]
 
-[#macro aws_apigateway_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_apigateway_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/apiusageplan/state.ftl
+++ b/providers/aws/components/apiusageplan/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_apiusageplan_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_apiusageplan_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/baseline/state.ftl
+++ b/providers/aws/components/baseline/state.ftl
@@ -1,7 +1,7 @@
 [#ftl]
 [#assign LOCAL_SSH_PRIVATE_KEY_RESOURCE_TYPE = "sshPrivKey" ]
 
-[#macro aws_baseline_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_baseline_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
@@ -36,7 +36,7 @@
     ]
 [/#macro]
 
-[#macro aws_baselinedata_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_baselinedata_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
@@ -99,7 +99,7 @@
     ]
 [/#macro]
 
-[#macro aws_baselinekey_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_baselinekey_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/bastion/state.ftl
+++ b/providers/aws/components/bastion/state.ftl
@@ -1,5 +1,5 @@
 [#ftl]
-[#macro aws_bastion_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_bastion_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/cache/state.ftl
+++ b/providers/aws/components/cache/state.ftl
@@ -1,5 +1,5 @@
 [#ftl]
-[#macro aws_cache_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_cache_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
 
     [#local id = formatResourceId(AWS_CACHE_RESOURCE_TYPE, core.Id) ]

--- a/providers/aws/components/cdn/state.ftl
+++ b/providers/aws/components/cdn/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_cdn_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_cdn_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
@@ -45,7 +45,7 @@
 [/#macro]
 
 
-[#macro aws_cdnroute_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_cdnroute_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/computecluster/state.ftl
+++ b/providers/aws/components/computecluster/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_computecluster_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_computecluster_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution ]
     [#local buildReference = getOccurrenceBuildReference(occurrence) ]

--- a/providers/aws/components/configstore/state.ftl
+++ b/providers/aws/components/configstore/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_configstore_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_configstore_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
@@ -44,7 +44,7 @@
     ]
 [/#macro]
 
-[#macro aws_configbranch_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_configbranch_cf_state occurrence parent={} ]
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
 

--- a/providers/aws/components/contenthub/state.ftl
+++ b/providers/aws/components/contenthub/state.ftl
@@ -2,17 +2,16 @@
 [#-- Resources --]
 [#assign COT_CONTENTHUB_HUB_RESOURCE_TYPE = "contenthub"]
 
-[#macro aws_contenthub_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_contenthub_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
 
     [#if core.External!false ]
-        [#local engine = (baseState.Attributes["ENGINE"])!"COTFatal: Engine not found" ]
-        [#local repoistory = (baseState.Attributes["REPOSITORY"])!"COTFatal: Repository not found" ]
-        [#local branch = (baseState.Attributes["BRANCH"])!"COTFatal: Bracnch not found" ]
-        [#local prefix = (baseState.Attributes["PREFIX"])!"COTFatal: Prefix not found" ]
+        [#local engine = (occurrence.State.Attributes["ENGINE"])!"COTFatal: Engine not found" ]
+        [#local repoistory = (occurrence.State.Attributes["REPOSITORY"])!"COTFatal: Repository not found" ]
+        [#local branch = (occurrence.State.Attributes["BRANCH"])!"COTFatal: Bracnch not found" ]
+        [#local prefix = (occurrence.State.Attributes["PREFIX"])!"COTFatal: Prefix not found" ]
 
         [#assign componentState =
-            baseState +
             {
                 "Attributes" : {
                     "ENGINE" : engine,

--- a/providers/aws/components/contentnode/state.ftl
+++ b/providers/aws/components/contentnode/state.ftl
@@ -2,7 +2,7 @@
 [#-- Resources --]
 [#assign COT_CONTENTHUB_NODE_RESOURCE_TYPE = "contentnode"]
 
-[#macro aws_contentnode_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_contentnode_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/datafeed/state.ftl
+++ b/providers/aws/components/datafeed/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_datafeed_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_datafeed_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/datapipeline/state.ftl
+++ b/providers/aws/components/datapipeline/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_datapipeline_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_datapipeline_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution ]
     [#local buildReference = getOccurrenceBuildReference(occurrence) ]

--- a/providers/aws/components/dataset/state.ftl
+++ b/providers/aws/components/dataset/state.ftl
@@ -3,7 +3,7 @@
 [#-- Resources --]
 [#assign DATASET_S3_SNAPSHOT_RESOURCE_TYPE = "s3Snapshot" ]
 
-[#macro aws_dataset_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_dataset_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution ]
     [#local buildReference = getOccurrenceBuildReference(occurrence, true ) ]

--- a/providers/aws/components/datavolume/state.ftl
+++ b/providers/aws/components/datavolume/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_datavolume_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_datavolume_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/db/state.ftl
+++ b/providers/aws/components/db/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_db_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_db_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/ec2/state.ftl
+++ b/providers/aws/components/ec2/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_ec2_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_ec2_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
 
     [#local zoneResources = {}]

--- a/providers/aws/components/ecs/state.ftl
+++ b/providers/aws/components/ecs/state.ftl
@@ -21,7 +21,7 @@
                 source)]
 [/#function]
 
-[#macro aws_ecs_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_ecs_cf_state occurrence parent={} ]
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
 
@@ -145,7 +145,7 @@
     ]
 [/#macro]
 
-[#macro aws_service_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_service_cf_state occurrence parent={} ]
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
 
@@ -263,7 +263,7 @@
     ]
 [/#macro]
 
-[#macro aws_task_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_task_cf_state occurrence parent={} ]
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
 

--- a/providers/aws/components/efs/state.ftl
+++ b/providers/aws/components/efs/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_efs_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_efs_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
 
     [#local id = formatEFSId( core.Tier, core.Component, occurrence) ]
@@ -41,7 +41,7 @@
     ]
 [/#macro]
 
-[#macro aws_efsmount_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_efsmount_cf_state occurrence parent={} ]
     [#local configuration = occurrence.Configuration.Solution]
 
     [#local efsId = parent.State.Attributes["EFS"] ]

--- a/providers/aws/components/es/state.ftl
+++ b/providers/aws/components/es/state.ftl
@@ -1,12 +1,11 @@
 [#ftl]
 
-[#macro aws_es_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_es_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
 
     [#if core.External!false]
-        [#local esId = baseState.Attributes["ES_DOMAIN_ARN"]!"COTFatal: Could not find ARN" ]
+        [#local esId = occurrence.State.Attributes["ES_DOMAIN_ARN"]!"COTFatal: Could not find ARN" ]
         [#assign componentState =
-            baseState +
             valueIfContent(
                 {
                     "Resources" : {

--- a/providers/aws/components/federatedrole/state.ftl
+++ b/providers/aws/components/federatedrole/state.ftl
@@ -1,12 +1,12 @@
 [#ftl]
 
-[#macro aws_federatedrole_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_federatedrole_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
 
     [#local identityPoolId = formatResourceId(AWS_COGNITO_IDENTITYPOOL_RESOURCE_TYPE, core.Id)]
     [#local identityPoolName = replaceAlphaNumericOnly(core.FullName, "X") ]
 
-    [#assign componentState = 
+    [#assign componentState =
         {
             "Resources" : {
                 "identitypool" : {
@@ -32,10 +32,10 @@
 
 [/#macro]
 
-[#macro aws_federatedroleassignment_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_federatedroleassignment_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
 
-    [#assign componentState = 
+    [#assign componentState =
         {
             "Resources" : {
                 "role" : {

--- a/providers/aws/components/gateway/state.ftl
+++ b/providers/aws/components/gateway/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_gateway_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_gateway_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
     [#local engine = solution.Engine ]
@@ -107,7 +107,7 @@
     ]
 [/#macro]
 
-[#macro aws_gatewaydestination_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_gatewaydestination_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/lambda/state.ftl
+++ b/providers/aws/components/lambda/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_lambda_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_lambda_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
 
     [#assign componentState =
@@ -21,7 +21,7 @@
     ]
 [/#macro]
 
-[#macro aws_function_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_function_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution ]
 

--- a/providers/aws/components/lb/state.ftl
+++ b/providers/aws/components/lb/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_lb_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_lb_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution ]
 
@@ -49,7 +49,7 @@
     ]
 [/#macro]
 
-[#macro aws_lbport_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_lbport_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/mobileapp/state.ftl
+++ b/providers/aws/components/mobileapp/state.ftl
@@ -3,7 +3,7 @@
 [#-- Resources --]
 [#assign COT_MOBILEAPP_RESOURCE_TYPE = "mobileapp"]
 
-[#macro aws_mobileapp_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_mobileapp_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/mobilenotifier/state.ftl
+++ b/providers/aws/components/mobilenotifier/state.ftl
@@ -10,7 +10,7 @@
         ) ]
 [/#function]
 
-[#macro aws_mobilenotifier_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_mobilenotifier_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
@@ -32,7 +32,7 @@
     ]
 [/#macro]
 
-[#macro aws_mobilenotifierplatform_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_mobilenotifierplatform_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/network/state.ftl
+++ b/providers/aws/components/network/state.ftl
@@ -2,7 +2,7 @@
 
 [#-- Resources --]
 
-[#macro aws_network_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_network_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
@@ -138,7 +138,7 @@
     ]
 [/#macro]
 
-[#macro aws_networkroute_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_networkroute_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
@@ -198,7 +198,7 @@
     ]
 [/#macro]
 
-[#macro aws_networkacl_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_networkacl_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/objectsql/state.ftl
+++ b/providers/aws/components/objectsql/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_objectsql_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_objectsql_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
 
     [#local workGroupId = formatResourceId(AWS_ATHENA_WORKGROUP_RESOURCE_TYPE, core.Id)]
@@ -29,8 +29,8 @@
                 "Inbound" : {},
                 "Outbound" : {
                     "default" : "consume",
-                    "consume" : 
-                        athenaConsumePermission(workGroupId) + 
+                    "consume" :
+                        athenaConsumePermission(workGroupId) +
                         s3AllPermission(baselineComponentIds["AppData"], getAppDataFilePrefix(occurrence))
                }
             }

--- a/providers/aws/components/s3/state.ftl
+++ b/providers/aws/components/s3/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_s3_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_s3_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/serviceregistry/state.ftl
+++ b/providers/aws/components/serviceregistry/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_serviceregistry_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_serviceregistry_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
@@ -28,7 +28,7 @@
     ]
 [/#macro]
 
-[#macro aws_serviceregistryservice_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_serviceregistryservice_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/spa/state.ftl
+++ b/providers/aws/components/spa/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_spa_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_spa_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/sqs/state.ftl
+++ b/providers/aws/components/sqs/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_sqs_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_sqs_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
 
     [#if core.External!false]

--- a/providers/aws/components/topic/state.ftl
+++ b/providers/aws/components/topic/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_topic_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_topic_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
@@ -36,7 +36,7 @@
     ]
 [/#macro]
 
-[#macro aws_topicsubscription_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_topicsubscription_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/user/state.ftl
+++ b/providers/aws/components/user/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_user_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_user_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/providers/aws/components/userpool/state.ftl
+++ b/providers/aws/components/userpool/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro aws_userpool_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_userpool_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
 
     [#if core.External!false]
@@ -19,7 +19,6 @@
         [#local attrLbAuthHeader =  occurrence.State.Attributes["USERPOOL_AUTHORIZATION_HEADER"]!"Authorization"]
 
         [#assign componentState =
-            baseState +
             {
                 "Roles" : {
                     "Inbound" : {
@@ -154,7 +153,7 @@
     ]
 [/#macro]
 
-[#macro aws_userpoolclient_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_userpoolclient_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
@@ -191,7 +190,7 @@
         }]
 [/#macro]
 
-[#macro aws_userpoolauthprovider_cf_state occurrence parent={} baseState={}  ]
+[#macro aws_userpoolauthprovider_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
 
     [#local authProviderId = formatResourceId(AWS_COGNITO_USERPOOL_AUTHPROVIDER_RESOURCE_TYPE, core.Id)]

--- a/providers/shared/components/externalservice/state.ftl
+++ b/providers/shared/components/externalservice/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro shared_externalservice_default_state occurrence parent={} baseState={}  ]
+[#macro shared_externalservice_default_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 


### PR DESCRIPTION
baseState was originally added to support typed external links.

Through several refactors, the need for baseState has disappeared and indeed currently no value is ever provided.

- Change state routines that depend on baseState to draw their values from the provided occurrence instead (a custom value of which is generated for external links).

- Remove the baseState attribute on all state routines.

@RossMurr4y we'll need the same change reflected in the Azure support