### PR TITLE
Feature - numberAttributeIfContent

### DIFF
--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -34,6 +34,12 @@
         value?has_content?then(value,content)) ]
 [/#function]
 
+[#function numberAttributeIfContent attribute content]
+    [#return attributeIfContent(
+        attribute,
+        content?has_content?then(content?number, content))]
+[/#function]
+
 [#------------------------
 -- Powers of 2 handling --
 --------------------------]


### PR DESCRIPTION
Azure and likely other providers will require number values within templates instead of numbers-as-strings. However, you often want to be able to set an "empty" default value for these attributes which is most easily just an empty string. This PR introduces a function to format a new attribute with the format as a number if content exists, otherwise return an empty string.

Example resource.ftl
``` freemarker
[#function getWebAppIpSecurityRestriction
    ipAddress=""
    subnetMask=""
    vnetSubnetResourceId=""
    action=""
    tag=""
    priority=""
    name=""
    description=""]

    [#return {} +
        attributeIfContent("ipAddress", ipAddress) +
        attributeIfContent("subnetMask", subnetMask) +
        attributeIfContent("vnetSubnetResourceId", vnetSubnetResourceId) +
        attributeIfContent("action", action) +
        attributeIfContent("tag", tag) +
        numberAttributeIfContent("priority", priority) +
        attributeIfContent("name", name) +
        attributeIfContent("description", description)
    ]

[/#function]
```

In the given example, if the user calls the function getWebAppIpSecurityRestriction with a priority of "5" or 5, the result would be a `{"priority": 5}`. However if priority was not specified and its default value used, as its only converted to a number if it has content freemarker does not attempt to convert the empty string to a number (which would give an error).