### PR TITLE
<feature>Jenkinsfile for template testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
             steps {
                 sh '''#!/usr/bin/env bash
                 ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l unitlist
-                UNIT_LIST="$(jq '.DeploymentUnits | @csv' | ~/cot_tests/unitlistconfig.json)"
+                UNIT_LIST="$(jq '.DeploymentUnits | @csv' < ~/cot_tests/unitlistconfig.json)"
 
                 echo "Generating units for ${UNIT_LIST}
                 '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,21 +15,10 @@ pipeline {
     }
 
     stages {
-        stage('Generate test cases') {
+        stage('Run AWS Template Steps') {
             steps {
                 sh '''#!/usr/bin/env bash
-                ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l unitlist
-                UNIT_LIST="$(jq -r '.DeploymentUnits[]' < ~/cot_tests/unitlistconfig.json)"
-
-                for unit in "${UNIT_LIST}"
-                do
-                    echo "Running templates for $unit"
-                    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l segment -u $unit || true
-                    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l solution -u $unit || true
-                    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l application -u $unit || true
-                done
-
-                ls -l ~/cot_tests/
+                ${WORKSPACE}/test/aws/run_aws_template_tests.sh
                 '''
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,8 +17,7 @@ pipeline {
     stages {
         stage('Generate test cases') {
             steps {
-                sh '''#!/usr
-                /bin/env bash
+                sh '''#!/usr/bin/env bash
                 ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l unitlist
                 UNIT_LIST="$(jq -r '.DeploymentUnits[]' < ~/cot_tests/unitlistconfig.json)"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,11 +23,13 @@ pipeline {
 
                 for unit in "${UNIT_LIST}"
                 do
-                    echo "Running template for $unit"
-                    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l segment -u $unit
-                    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l solution -u $unit
-                    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l application -u $unit
+                    echo "Running templates for $unit"
+                    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l segment -u $unit || true
+                    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l solution -u $unit || true
+                    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l application -u $unit || true
                 done
+
+                ls -l ~/cot_tests/
                 '''
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     }
 
     stages {
-        stage('Run AWS Template Steps') {
+        stage('Run AWS Template Tests') {
             steps {
                 sh '''#!/usr/bin/env bash
                 ${WORKSPACE}/test/aws/run_aws_template_tests.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,11 +17,18 @@ pipeline {
     stages {
         stage('Generate test cases') {
             steps {
-                sh '''#!/usr/bin/env bash
+                sh '''#!/usr
+                /bin/env bash
                 ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l unitlist
-                UNIT_LIST="$(jq '.DeploymentUnits | @csv' < ~/cot_tests/unitlistconfig.json)"
+                UNIT_LIST="$(jq -r '.DeploymentUnits[]' < ~/cot_tests/unitlistconfig.json)"
 
-                echo "Generating units for ${UNIT_LIST}
+                for $unit in $UNIT_LIST
+                do
+                    echo "Running template for $unit"
+                    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l segment -u $unit
+                    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l solution -u $unit
+                    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l application -u $unit
+                done
                 '''
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,8 +18,8 @@ pipeline {
         stage('Generate test cases') {
             steps {
                 sh '''#!/usr/bin/env bash
-                ${GENERATION_DIR}/createTemplate.sh -p aws -p awstest -o ~/cot_tests/ -l unitlist
-                cat ~/cot_tests/unitlist.json
+                ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l unitlist
+                cat ~/cot_tests/unitlistconfig.json
                 '''
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,9 @@ pipeline {
             steps {
                 sh '''#!/usr/bin/env bash
                 ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l unitlist
-                cat ~/cot_tests/unitlistconfig.json
+                UNIT_LIST="$(jq '.DeploymentUnits | @csv' | ~/cot_tests/unitlistconfig.json)"
+
+                echo "Generating units for ${UNIT_LIST}
                 '''
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
                 ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l unitlist
                 UNIT_LIST="$(jq -r '.DeploymentUnits[]' < ~/cot_tests/unitlistconfig.json)"
 
-                for $unit in $UNIT_LIST
+                for unit in "${UNIT_LIST}"
                 do
                     echo "Running template for $unit"
                     ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l segment -u $unit

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,27 @@
+#!groovy
+
+pipeline {
+    options {
+        timestamps()
+    }
+
+    agent {
+        label 'codeontaplatest'
+    }
+
+    environment {
+        GENERATION_DIR="${WORKSPACE}/aws"
+        GENERATION_BASE_DIR="${WORKSPACE}"
+    }
+
+    stages {
+        stage('Generate test cases') {
+            steps {
+                sh '''#!/usr/bin/env bash
+                ${GENERATION_DIR}/createTemplate.sh -p aws -p awstest -o ~/cot_tests/ -l unitlist
+                cat ~/cot_tests/unitlist.json
+                '''
+            }
+        }
+    }
+}

--- a/providers/awstest/scenarios/lb.ftl
+++ b/providers/awstest/scenarios/lb.ftl
@@ -110,7 +110,10 @@
                                 "Resources.listenerRuleXelbXhttpslbXhttpX100.Properties.Priority"
                             ]
                         }
-                    },
+                    }
+                },
+                "validation" : {
+                    "OutputSuffix" : "template.json",
                     "Tools" : {
                         "CFNLint" : true,
                         "CFNNag" : true
@@ -120,7 +123,7 @@
             "TestProfiles" : {
                 "Component" : {
                     "lb" : {
-                        "TestCases" : [ "httpslb" ]
+                        "TestCases" : [ "httpslb", "validation" ]
                     }
                 }
             }

--- a/providers/awstest/scenarios/lb.ftl
+++ b/providers/awstest/scenarios/lb.ftl
@@ -110,6 +110,10 @@
                                 "Resources.listenerRuleXelbXhttpslbXhttpX100.Properties.Priority"
                             ]
                         }
+                    },
+                    "Tools" : {
+                        "CFNLint" : true,
+                        "CFNNag" : true
                     }
                 }
             },

--- a/providers/shared/shared.ftl
+++ b/providers/shared/shared.ftl
@@ -30,13 +30,21 @@
 
     [#local tests = {} ]
     [#list testCaseNames as testCaseName ]
+        [#local testCaseFullName = concatenate(
+                                        [
+                                            (solution.DeploymentUnits),
+                                            (occurrence.Core.ShortTypedName),
+                                            testCaseName
+                                        ],
+                                        "_"
+                                    )?replace("-", "_")]
         [#if testCases[testCaseName]?? ]
             [#local testCase = testCases[testCaseName] ]
 
             [#local tests = mergeObjects(
                 tests,
                 {
-                    testCaseName  : {
+                    testCaseFullName  : {
                         "filename" : concatenate(
                                         [
                                             commandLineOptions.Deployment.Output.Prefix,
@@ -53,7 +61,7 @@
             [#list (testCase.Structural.JSON.Match)!{} as id,matchTest ]
                 [#local tests = combineEntities(tests,
                     {
-                        testCaseName : {
+                        testCaseFullName : {
                             "json_structure" : {
                                 "match" : [
                                     {
@@ -71,7 +79,7 @@
             [#list (testCase.Structural.JSON.Length)!{} as id,legnthTest ]
                 [#local tests = combineEntities(tests,
                     {
-                        testCaseName : {
+                        testCaseFullName : {
                             "json_structure"  : {
                                 "length" : [
                                         {
@@ -99,7 +107,7 @@
                 [#local tests = mergeObjects(
                     tests,
                     {
-                        testCaseName  : {
+                        testCaseFullName  : {
                             "json_structure" : {
                                 "exists" : existPaths
                             }
@@ -121,7 +129,7 @@
                 [#local tests = mergeObjects(
                     tests,
                     {
-                        testCaseName  : {
+                        testCaseFullName  : {
                             "json_structure" : {
                                 "not_empty" : notEmtpyPaths
                             }
@@ -133,7 +141,7 @@
             [#list (testCase.Structural.CFN.Resource)!{} as id,CFNResourceTest ]
                 [#local tests = combineEntities(tests,
                     {
-                        testCaseName : {
+                        testCaseFullName : {
                             "cfn_structure"  : {
                                 "resource" : [
                                     {
@@ -161,7 +169,7 @@
                 [#local tests = mergeObjects(
                     tests,
                     {
-                        testCaseName  : {
+                        testCaseFullName  : {
                             "cfn_structure" : {
                                 "output" : cfnOutputPaths
                             }

--- a/test/aws/run_aws_template_tests.sh
+++ b/test/aws/run_aws_template_tests.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
-${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l unitlist
+
+echo "###############################################"
+echo "# Running template tests for the AWS provider #"
+echo "###############################################"
+
+echo "Generating unit list..."
+${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l unitlist > /dev/null 2>&1
 UNIT_LIST="$(jq -r '.DeploymentUnits | join(" ")' < ~/cot_tests/unitlistconfig.json)"
 
 for unit in $UNIT_LIST; do
-    echo "Running templates for $unit"
-    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l segment -u $unit || true
-    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l solution -u $unit || true
-    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l application -u $unit || true
+    echo "Creating templates for $unit ..."
+    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l segment -u $unit > /dev/null 2>&1 || true
+    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l solution -u $unit > /dev/null 2>&1 || true
+    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l application -u $unit > /dev/null 2>&1 || true
 done
 
 cot test generate --directory ~/cot_tests/ -o ~/cot_tests/test_templates.py

--- a/test/aws/run_aws_template_tests.sh
+++ b/test/aws/run_aws_template_tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l unitlist
+UNIT_LIST="$(jq -r '.DeploymentUnits | join(" ")' < ~/cot_tests/unitlistconfig.json)"
+
+for unit in $UNIT_LIST; do
+    echo "Running templates for $unit"
+    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l segment -u $unit || true
+    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l solution -u $unit || true
+    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o ~/cot_tests/ -l application -u $unit || true
+done
+
+cot test generate --directory ~/cot_tests/ -o ~/cot_tests/test_templates.py
+
+cd ~/cot_tests
+echo "Running Tests..."
+cot test run -t ~/cot_tests/test_templates.py


### PR DESCRIPTION
This PR adds an initial testing process to validate template generation and content. 

The initial script focuses on running the aws plugin templates using the awstest provider. The process uses the unitlist to generate the list of deploymentunits in the blueprint and then runs createTemplate.sh on each level using the same deployment unit. This is the only way at the moment to know which unit is required. 

We don't worry about template generation failing, instead we are just focussing on running any test cases which have been generated