### PR TITLE
<fix> Include v2.0.0 cleanup in the upgrade order

### DIFF
--- a/execution/contextTree.sh
+++ b/execution/contextTree.sh
@@ -1850,7 +1850,7 @@ function cleanup_cmdb() {
   local dry_run="$1";shift
   local maximum_version="${1:-v1.1.1}";shift
 
-  local upgrade_order=("v1.0.0" "v1.1.0" "v1.1.1")
+  local upgrade_order=("v1.0.0" "v1.1.0" "v1.1.1" "v2.0.0")
 
   debug "Maximum CMDB cleanup version required is ${maximum_version}"
 


### PR DESCRIPTION
So that a v2.0.0 cleanup can be configured, add it to the cleanup order.