### PR TITLE
<feature> Registry scopes

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -910,6 +910,7 @@ behaviour.
               formatRelativePath(
                 getRegistryPrefix(registry, occurrence),
                 product,
+                getOccurrenceBuildScopeExtension(occurrence),
                 getOccurrenceBuildUnit(occurrence),
                 getOccurrenceBuildReference(occurrence)) + " " +
                 "\"$\{tmpdir}\" || return $?",

--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -676,7 +676,10 @@
                 "RegistryEndPoint" : getRegistryEndPoint("docker", task),
                 "Image" :
                     formatRelativePath(
-                        productName,
+                        formatName(
+                            productName,
+                            getOccurrenceBuildScopeExtension(task)
+                        ),
                         formatName(
                             getOccurrenceBuildUnit(task),
                             getOccurrenceBuildReference(task)

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -32,6 +32,17 @@
         ) ]
 [/#function]
 
+[#function getOccurrenceBuildScopeExtension occurrence ]
+    [#local extension = ""]
+    [#switch getOccurrenceSettingValue(occurrence, "BUILD_SCOPE", true)]
+        [#case "segment"]
+            [#local extension = segmentName]
+            [#break]
+    [/#switch]
+
+    [#return extension]
+[/#function]
+
 [#function getOccurrenceNetwork occurrence]
     [#return getTierNetwork(occurrence.Core.Tier.Id)]
 [/#function]
@@ -471,6 +482,7 @@
     [#local occurrenceBuildCommit = occurrenceBuild.COMMIT!{} ]
     [#local occurrenceBuildTag = occurrenceBuild.TAG!{} ]
     [#local occurrenceBuildFormats = occurrenceBuild.FORMATS!{} ]
+    [#local occurrenceBuildScope = occurrenceBuild.SCOPE!{} ]
 
     [#-- Reference could be a deployment unit or a component --]
     [#if occurrenceBuild.REFERENCE?has_content]
@@ -499,27 +511,19 @@
     [#return
         attributeIfContent(
             "BUILD_FORMATS",
-            valueIfContent(
-                occurrenceBuildFormats,
-                occurrenceBuildFormats,
-                occurrenceBuild.FORMATS!{}
-            )
+            contentIfContent(occurrenceBuildFormats, occurrenceBuild.FORMATS!{})
         ) +
         attributeIfContent(
             "BUILD_REFERENCE",
-            valueIfContent(
-                occurrenceBuildCommit,
-                occurrenceBuildCommit,
-                occurrenceBuild.COMMIT!{}
-            )
+            contentIfContent(occurrenceBuildCommit, occurrenceBuild.COMMIT!{})
+        ) +
+        attributeIfContent(
+            "BUILD_SCOPE",
+            contentIfContent(occurrenceBuildScope, occurrenceBuild.SCOPE!{})
         ) +
         attributeIfContent(
             "APP_REFERENCE",
-            valueIfContent(
-                occurrenceBuildTag,
-                occurrenceBuildTag,
-                occurrenceBuild.TAG!{}
-            )
+            contentIfContent(occurrenceBuildTag, occurrenceBuild.TAG!{})
         ) +
         attributeIfContent(
             "BUILD_UNIT",

--- a/providers/aws/components/computecluster/setup.ftl
+++ b/providers/aws/components/computecluster/setup.ftl
@@ -101,6 +101,7 @@
             getRegistryEndPoint("scripts", occurrence),
             getRegistryPrefix("scripts", occurrence),
             productName,
+            getOccurrenceBuildScopeExtension(occurrence),
             getOccurrenceBuildUnit(occurrence),
             getOccurrenceBuildReference(occurrence)
             ) ]
@@ -163,7 +164,9 @@
                         s3ReadPermission(
                             formatRelativePath(
                                 getRegistryEndPoint("scripts", occurrence),
-                                getRegistryPrefix("scripts", occurrence) ) )+
+                                getRegistryPrefix("scripts", occurrence)
+                            )
+                        ) +
                         s3ListPermission(codeBucket) +
                         s3ReadPermission(codeBucket) +
                         s3ListPermission(operationsBucket) +

--- a/providers/aws/components/contentnode/setup.ftl
+++ b/providers/aws/components/contentnode/setup.ftl
@@ -50,7 +50,9 @@
                                     regionId + " " +
                                     getRegistryEndPoint("contentnode", occurrence) + " " +
                                     formatRelativePath(
-                                        getRegistryPrefix("contentnode", occurrence) + productName,
+                                        getRegistryPrefix("contentnode", occurrence),
+                                        productName,
+                                        getOccurrenceBuildScopeExtension(occurrence),
                                         getOccurrenceBuildUnit(occurrence),
                                         getOccurrenceBuildReference(occurrence)) + " " +
                                     "   \"$\{tmpdir}\" || return $?",

--- a/providers/aws/components/datapipeline/state.ftl
+++ b/providers/aws/components/datapipeline/state.ftl
@@ -3,7 +3,6 @@
 [#macro aws_datapipeline_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution ]
-    [#local buildReference = getOccurrenceBuildReference(occurrence) ]
 
     [#local pipelineId = formatResourceId( AWS_DATA_PIPELINE_RESOURCE_TYPE, core.Id )]
 

--- a/providers/aws/components/dataset/state.ftl
+++ b/providers/aws/components/dataset/state.ftl
@@ -25,6 +25,7 @@
             [#local registryPrefix = formatRelativePath(
                                                 getRegistryPrefix("dataset", occurrence),
                                                 productName,
+                                                getOccurrenceBuildScopeExtension(occurrence),
                                                 getOccurrenceBuildUnit(occurrence))]
             [#local datasetPrefix = formatRelativePath(solution.Prefix)]
 

--- a/providers/aws/components/lambda/setup.ftl
+++ b/providers/aws/components/lambda/setup.ftl
@@ -76,7 +76,9 @@
             "S3Bucket" : getRegistryEndPoint("lambda", fn),
             "S3Key" :
                 formatRelativePath(
-                    getRegistryPrefix("lambda", fn) + productName,
+                    getRegistryPrefix("lambda", fn),
+                    productName,
+                    getOccurrenceBuildScopeExtension(fn),
                     getOccurrenceBuildUnit(fn),
                     getOccurrenceBuildReference(fn),
                     "lambda.zip"

--- a/providers/aws/components/mobileapp/setup.ftl
+++ b/providers/aws/components/mobileapp/setup.ftl
@@ -25,6 +25,7 @@
     [#local codeSrcPrefix = formatRelativePath(
                                 getRegistryPrefix("scripts", occurrence),
                                     productName,
+                                    getOccurrenceBuildScopeExtension(occurrence),
                                     getOccurrenceBuildUnit(occurrence),
                                     getOccurrenceBuildReference(occurrence))]
 


### PR DESCRIPTION
Introduce the idea of a registry having a "scope", with "account" level being the current default.

The initial use case is to be able to reuse the same deployment unit value in different segments of a product, and to associate each use with its own image, rather than sharing images as is currently supported. This change thus introduces "segment" scoped registries.

The scope value is obtained via the "Scope" attribute of a build.

This change needs to be introduced in parallel to or ahead of the equivalent automation change which will see images starting to be segment scoped when stored.

This change is an interim approach until code units are introduced, with the details of the registry to access being attributes of the code unit that can then be queried via buildblueprint.