### PR TITLE
<feature> CodeOnTap Agent switch role policy

### DIFF
--- a/aws/templates/fragment/fragment_codeontap.ftl
+++ b/aws/templates/fragment/fragment_codeontap.ftl
@@ -6,50 +6,69 @@
     [#assign dockerStageDir = settings["DOCKER_STAGE_DIR"]!"/tmp/docker-build" ]
     [#assign dockerHostDaemon = settings["DOCKER_HOST_DAEMON"]!"/var/run/docker.sock"]
     [#assign jenkinsAgentImage = settings["DOCKER_AGENT_IMAGE"]!"gen3"]
+    [#assign awsAgentAutomationRole = settings["AWS_AUTOMATION_ROLE_NAME"]!"codeontap-automation" ]
 
     [@Attributes image=jenkinsAgentImage /]
-    
-    [@DefaultLinkVariables enabled=false /]
-    [@DefaultCoreVariables enabled=false /]
-    [@DefaultEnvironmentVariables enabled=false /]
+
+    [@DefaultLinkVariables          enabled=false /]
+    [@DefaultCoreVariables          enabled=false /]
+    [@DefaultEnvironmentVariables   enabled=false /]
+    [@DefaultBaselineVariables      enabled=false /]
 
     [@Settings {
         "AWS_AUTOMATION_USER" : "ROLE",
         "DOCKER_STAGE_DIR" : dockerStageDir
     }/]
 
-    [@Volume 
-        name="dockerDaemon" 
-        containerPath="/var/run/docker.sock" 
-        hostPath=dockerHostDaemon  
+    [@Volume
+        name="dockerDaemon"
+        containerPath="/var/run/docker.sock"
+        hostPath=dockerHostDaemon
     /]
-    [@Volume 
-        name="dockerStage" 
-        containerPath=dockerStageDir 
-        hostPath=dockerStageDir 
+    [@Volume
+        name="dockerStage"
+        containerPath=dockerStageDir
+        hostPath=dockerStageDir
     /]
 
     [#-- Validate that the appropriate settings have been provided for the container to work --]
     [#if settings["CODEONTAPVOLUME"]?has_content ]
-        [@Volume 
-            name="codeontap" 
-            containerPath="/var/opt/codeontap/" 
-            hostPath=settings["CODEONTAPVOLUME"] 
-            readOnly=true     
+        [@Volume
+            name="codeontap"
+            containerPath="/var/opt/codeontap/"
+            hostPath=settings["CODEONTAPVOLUME"]
+            readOnly=true
         /]
-    [/#if]  
+    [/#if]
 
     [#if settings["AWS_AUTOMATION_POLICIES"]?has_content ]
         [@ManagedPolicy settings["AWS_AUTOMATION_POLICIES"]?split(",") /]
     [/#if]
 
+    [#assign automationAccounts = asArray( (settings["AWS_AUTOMATION_ACCOUNTS"]!"")?eval ) ]
+
+    [#assign automationAccountRoles = []]
+    [#list automationAccounts as automationAccount ]
+        [#assign automationAccountRoles += [
+                                                formatGlobalArn(
+                                                    "iam",
+                                                    formatRelativePath("role", awsAgentAutomationRole),
+                                                    automationAccount  )
+                                            ]]
+    [/#list]
+
+    [@Policy
+        [
+            getPolicyStatement( ["sts:AssumeRole"], automationAccountRoles)
+        ]
+    /]
     [#break]
 
-[#case "_jenkinsecs" ] 
+[#case "_jenkinsecs" ]
     [#assign settings = _context.DefaultEnvironment]
 
     [#-- The docker stage dir is used to provide a staging location for docker in docker based builds which use the host docker instance --]
-    [#assign dockerStageDirs = 
+    [#assign dockerStageDirs =
             (settings["DOCKER_STAGE_DIR"])?has_content?then(
                     asArray(settings["DOCKER_STAGE_DIR"]),
                     settings["DOCKER_STAGE_DIRS"]?has_content?then(
@@ -57,7 +76,7 @@
                         [ "/tmp/docker-build" ]
                     )
             )]
-    
+
     [#list dockerStageDirs as dockerStageDir]
         [@Directory
             path=dockerStageDir

--- a/aws/templates/fragment/fragment_codeontap.ftl
+++ b/aws/templates/fragment/fragment_codeontap.ftl
@@ -6,7 +6,7 @@
     [#assign dockerStageDir = settings["DOCKER_STAGE_DIR"]!"/tmp/docker-build" ]
     [#assign dockerHostDaemon = settings["DOCKER_HOST_DAEMON"]!"/var/run/docker.sock"]
     [#assign jenkinsAgentImage = settings["DOCKER_AGENT_IMAGE"]!"gen3"]
-    [#assign awsAgentAutomationRole = settings["AWS_AUTOMATION_ROLE_NAME"]!"codeontap-automation" ]
+    [#assign awsAgentAutomationRole = settings["AWS_AUTOMATION_ROLE"]!"codeontap-automation" ]
 
     [@Attributes image=jenkinsAgentImage /]
 
@@ -17,6 +17,7 @@
 
     [@Settings {
         "AWS_AUTOMATION_USER" : "ROLE",
+        "AWS_AUTOMATION_ROLE" : awsAgentAutomationRole,
         "DOCKER_STAGE_DIR" : dockerStageDir
     }/]
 

--- a/aws/templates/fragment/start.ftl
+++ b/aws/templates/fragment/start.ftl
@@ -1,3 +1,3 @@
 [#ftl]
-[@debug message="Fragment Id" context=fragmentId enabled=false /]
+[@debug message="Fragment Id" context=fragmentId enabled=true /]
 [#switch fragmentId]


### PR DESCRIPTION
Adds the ability for codeontap agent containers to define their own switch role policies. 

To use this feature you pass an array of Accounts in the agent settings. They will be formatted into an assume role policy required for the container to assume role into the listed accounts 

```
    "AWS" : {
        "Automation" : {
            "Accounts" : {
                "Value" : [
                    "1234567890"
                ]
            },
            "Role" : "Automation"
        }
    },
```

The Role value defines the name of the role that will be configured in the assume role this is also set as a setting for codeontap itself to keep them aligned 