### PR TITLE
<fix> Permit host name in certificate behaviours

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -709,8 +709,8 @@ behaviour.
     [/#list]
     [#return
         valueIfTrue(
-            certificateObject.Host,
-            certificateObject.Host?has_content && (!(includes.Host)),
+            certificateObject.Host!"",
+            certificateObject.Host?has_content && (!(includes.Host!true)),
             formatName(parts)
         )
     ]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -647,8 +647,7 @@
 [#assign hostNameChildConfiguration = [
     {
         "Names" : "Host",
-        "Type" : STRING_TYPE,
-        "Default" : ""
+        "Type" : STRING_TYPE
     },
     {
         "Names" : "HostParts",


### PR DESCRIPTION
Don't default the host name in certificate configurations so that it can be defined at any point where certificate behaviours are defined (blueprint, tenant, product).