### PR TITLE
<fix> Build blueprint production

### DIFF
--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -353,7 +353,7 @@ function process_template_pass() {
 
       pass_level_prefix["config"]="blueprint"
       pass_description["config"]="blueprint"
-      output_suffix=".json"
+      [[ ${pass} == "config" ]] && output_suffix=".json"
       ;;
 
     buildblueprint)
@@ -367,7 +367,6 @@ function process_template_pass() {
 
       pass_level_prefix["config"]="build_blueprint-"
       pass_description["config"]="buildblueprint"
-      output_suffix=".json"
       ;;
 
     account)

--- a/aws/runExpoAppPublish.sh
+++ b/aws/runExpoAppPublish.sh
@@ -176,7 +176,7 @@ function main() {
   info "Generating build blueprint..."
   "${GENERATION_DIR}/createBuildblueprint.sh" -u "${DEPLOYMENT_UNIT}" -o "${AUTOMATION_DATA_DIR}" >/dev/null || return $?
 
-  BUILD_BLUEPRINT="${AUTOMATION_DATA_DIR}/build_blueprint-${DEPLOYMENT_UNIT}-.json"
+  BUILD_BLUEPRINT="${AUTOMATION_DATA_DIR}/build_blueprint-${DEPLOYMENT_UNIT}-config.json"
 
   # Make sure we are in the build source directory
   BINARY_PATH="${AUTOMATION_DATA_DIR}/binary"

--- a/aws/runLambda.sh
+++ b/aws/runLambda.sh
@@ -88,7 +88,7 @@ function main() {
     ${GENERATION_DIR}/createBuildblueprint.sh -u "${DEPLOYMENT_UNIT}"  -o "${AUTOMATION_DATA_DIR}" >/dev/null || return $?
 
     COT_TEMPLATE_DIR="${PRODUCT_STATE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
-    BUILD_BLUEPRINT="${COT_TEMPLATE_DIR}/build_blueprint-${DEPLOYMENT_UNIT}-.json"
+    BUILD_BLUEPRINT="${COT_TEMPLATE_DIR}/build_blueprint-${DEPLOYMENT_UNIT}-config.json"
 
     DEPLOYMENT_UNIT_TYPE="$(jq -r '.Type' < "${BUILD_BLUEPRINT}" )"
 

--- a/aws/runSentryRelease.sh
+++ b/aws/runSentryRelease.sh
@@ -105,7 +105,7 @@ function main() {
   info "Generating build blueprint..."
   "${GENERATION_DIR}/createBuildblueprint.sh" -u "${DEPLOYMENT_UNIT}" -o "${AUTOMATION_DATA_DIR}" >/dev/null || return $?
 
-  BUILD_BLUEPRINT="${AUTOMATION_DATA_DIR}/build_blueprint-${DEPLOYMENT_UNIT}-.json"
+  BUILD_BLUEPRINT="${AUTOMATION_DATA_DIR}/build_blueprint-${DEPLOYMENT_UNIT}-config.json"
 
   SOURCE_MAP_PATH="${AUTOMATION_DATA_DIR}/source_map"
   OPS_PATH="${AUTOMATION_DATA_DIR}/ops"


### PR DESCRIPTION
Build blueprint generation was failing because it was forcing the extension of its genplan to be .json.

Tweak the output file expected by all the consumers so the standard output suffix as included in the generated genplan will work correctly.

Also fix the generation of a blueprint to only force the output suffix in the pass that generates the blueprint.

The investigation was triggered by an attempt to encrypt credentials using manageCrypto.sh - one of the clients for createBuildblueprint.

This change thus includes some extra debug messages and ciphertext prefix handling, along with a fix to the handling on in file attribute updates.