### PR TITLE
<fix> disable concurrent builds and add quiet period

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,8 @@
 pipeline {
     options {
         timestamps()
+        disableConcurrentBuilds()
+        quietPeriod(30)
     }
 
     agent none


### PR DESCRIPTION
Couple of minor fixes to the Jenkinsile 
- Don't allow multiple builds to run on the same job ( each PR, branch is its own job so won't stop them) 
- Add a quiet period so we aren't trigger lots of builds when merging PR's quickly