### PR TITLE
<fix> Legacy state directory structure detection

### DIFF
--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -703,7 +703,7 @@ function process_template() {
       # No subdirectories for deployment units
       ;;
     *)
-      readarray -t legacy_files < <(find "${cf_dir_default}" -mindepth 1 -maxdepth 1 -name "*${deployment_unit}*" )
+      readarray -t legacy_files < <(find "${cf_dir_default}" -mindepth 1 -maxdepth 1 -type f -name "*${deployment_unit}*" )
 
       if [[ (-d "${cf_dir_default}/${deployment_unit}") || "${#legacy_files[@]}" -eq 0 ]]; then
         local cf_dir_default=$(getUnitCFDir "${cf_dir_default}" "${level}" "${deployment_unit}" "" "${region}" )


### PR DESCRIPTION
The check for existing files in the root of the state directory was including directories as well as files. 

This resulted in it treating units as legacy for whom there was already a unit that contained the name of the new unit.

An example is a pre-existing directory of bff-v1-imp and a new unit of bff-v1.