### PR TITLE
<feature> ECS OnDemand Compute Provider

### DIFF
--- a/providers/aws/components/ecs/state.ftl
+++ b/providers/aws/components/ecs/state.ftl
@@ -85,6 +85,17 @@
         [/#list]
     [/#if]
 
+    [#local computeProvider = {}]
+    [#if solution.ComputeProvider == "ec2OnDemand" ]
+        [#local computeProvider += {
+                "ecsCapacityProviderOnDemand" : {
+                    "Id" : formatResourceId(AWS_ECS_CAPACIITY_PROVIDER_RESOURCE_TYPE, core.Id, 'OnDemand'),
+                    "Type" : AWS_ECS_CAPACIITY_PROVIDER_RESOURCE_TYPE
+                }
+            }
+        ]
+    [/#if]
+
     [#-- TODO(mfl): Use formatDependentRoleId() for roles --]
     [#assign componentState =
         {
@@ -133,7 +144,8 @@
                 }
             } +
             attributeIfContent("logMetrics", logMetrics) +
-            autoScaling,
+            autoScaling +
+            computeProvider,
             "Attributes" : {
                 "ARN" : getExistingReference(clusterId, ARN_ATTRIBUTE_TYPE)
             },

--- a/providers/aws/components/es/setup.ftl
+++ b/providers/aws/components/es/setup.ftl
@@ -66,12 +66,14 @@
         [#if deploymentSubsetRequired("prologue", false)]
             [@addToDefaultBashScriptOutput
                 content=[
-                    "info \"ES Service Linked Role Setup\"",
-                    "if [[ -z \"$( aws --region \"" + regionId + "\" iam list-roles --path-prefix \"/aws-service-role/es.amazonaws.com/\" --query \"Roles[*].Arn\" --output text )\" ]]; then",
-                    "aws --region \"" + regionId + "\" iam create-service-linked-role --aws-service-name \"es.amazonaws.com\"",
-                    "else",
-                    "info \"Role Already exists\"",
-                    "fi"
+                    " case $\{STACK_OPERATION} in",
+                    "   create|update)",
+                    "       create_iam_service_linked_role" +
+                    "       \"" + region + "\" " +
+                    "       \"es.amazonaws.com\" " +
+                    "       || return $?",
+                    "       ;;",
+                    " esac"
                 ]
             /]
         [/#if]

--- a/providers/aws/services/ecs/id.ftl
+++ b/providers/aws/services/ecs/id.ftl
@@ -4,4 +4,4 @@
 [#assign AWS_ECS_RESOURCE_TYPE = "ecs" ]
 [#assign AWS_ECS_TASK_RESOURCE_TYPE = "ecsTask"]
 [#assign AWS_ECS_SERVICE_RESOURCE_TYPE = "ecsService"]
-
+[#assign AWS_ECS_CAPACIITY_PROVIDER_RESOURCE_TYPE = "ecsCapacityProvider" ]

--- a/providers/shared/components/ecs/id.ftl
+++ b/providers/shared/components/ecs/id.ftl
@@ -228,6 +228,12 @@
                 "Names" : "Role",
                 "Description" : "Server configuration role",
                 "Default" : ""
+            },
+            {
+                "Names" : "ComputeProvider",
+                "Description" : "The default compute provider for the cluster",
+                "Values" : [ "ec2", "ec2OnDemand" ],
+                "Default" : "ec2"
             }
         ]
 /]


### PR DESCRIPTION
Adds support for on demand Ec2 Instance autoscaling for ECS ( https://docs.amazonaws.cn/en_us/AmazonECS/latest/developerguide/cluster-auto-scaling.html ) 

Essentially it creates a tracked autoscaling policy on the Ec2 Autoscale cluster along with a metric of the required resources for the ECS cluster. When a task starts and there are now instances to service the task, it will sit in a provisioning state until the autoscaling action has completed. 
The same goes when there aren't any tasks to run, the cluster will remove any ec2 instances running without tasks on them 

This required a basic implementation of the ECS capacity providers which provide a way to define where containers should be deployed ( ec2, fargate, fargate spot etc) using weighted rules 

As this is a new feature and people might have their own EC2 autoscaling rules setup this is not enabled by default 

An example - This is an ECS cluster using a autoscale group with a min and desired processor count of 0. When I schedule a task or a service on this cluster, ECS will update a metric on the demand required on the cluster and autoscaling will bump it up to 1 EC2 instance to meet the need. 

```
{
    "Tiers" : {
        "app" : {
            "Components" : {
                "apphost" : {
                    "ECS" : {
                        "Instances" : {
                            "default" : {
                                "DeploymentUnits" : ["apphost"]
                            }
                        },
                        "Profiles" : {
                            "Processor" : "default"
                        },
                        "ComputeProvider" : "ec2OnDemand"
                        }
                }
            }
        }
    },
    "Processors" : {
        "default" : {
            "ECS" : {
                "Processor" : "t3.small",
                "DesiredCount" : 0,
                "MaxCount" : 2,
                "MinCount" : 0
            }
        }
    }
}
```
