### PR TITLE
<fix> Make build scope an internal setting

### DIFF
--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -517,8 +517,12 @@
             "BUILD_REFERENCE",
             contentIfContent(occurrenceBuildCommit, occurrenceBuild.COMMIT!{})
         ) +
-        attributeIfContent(
+        attributeIfTrue(
             "BUILD_SCOPE",
+            occurrenceBuildScope?has_content || occurrenceBuild.SCOPE?has_content,
+            {
+                "Internal" : true
+            } +
             contentIfContent(occurrenceBuildScope, occurrenceBuild.SCOPE!{})
         ) +
         attributeIfContent(


### PR DESCRIPTION
Make the build scope an internal setting so it doesn't appear in the context environment. This decision can be revisited if a use case emerges where it would be useful for the application to know the build scope.