### PR TITLE
Fix - Genplan Parameters Pass

### DIFF
--- a/providers/shared/deploymentframeworks/default/output.ftl
+++ b/providers/shared/deploymentframeworks/default/output.ftl
@@ -338,6 +338,14 @@
     outputSuffix="config.json"
 /]
 
+[@addGenPlanStepOutputMapping
+    provider=SHARED_PROVIDER
+    subset="parameters"
+    outputType=JSON_DEFAULT_OUTPUT_TYPE
+    outputFormat=""
+    outputSuffix="parameters.json"
+/]
+
 [#------------------------------------------------------------
 -- internal support functions for default output processing --
 --------------------------------------------------------------]


### PR DESCRIPTION
reinstated genplan pass for parameters since codeontap/gen3#1075

Looks like this just got missed during a refactor.