### PR TITLE
<fix> Only delete legacy OAI if not in use

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1637,7 +1637,7 @@ function is_oai_credential_used() {
 
   # Check for existing identity
   oai_id=$(aws --region "${region}" cloudfront list-cloud-front-origin-access-identities \
-  --query "CloudFrontOriginAccessIdentityList.Items[?Comment==\'${name}\'].Id" --output text) || return $?
+  --query "CloudFrontOriginAccessIdentityList.Items[?Comment=='${name}'].Id" --output text) || return $?
 
   # check if used if present
   if [[ -n "${oai_id}" ]]; then

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1635,25 +1635,24 @@ function is_oai_credential_used() {
   local region="$1"; shift
   local name="$1"; shift
 
-  local oai_status_file="$( getTempFile oai_used_XXXXXX.json)"
-  local oai_id=
-  local oai_etag=
-
   # Check for existing identity
-  aws --region "${region}" cloudfront list-cloud-front-origin-access-identities > "${oai_status_file}" || return $?
-  oai_id=$(jq -r ".CloudFrontOriginAccessIdentityList.Items[] | select(.Comment==\"${name}\") | .Id" < "${oai_status_file}") || return $?
+  oai_id=$(aws --region "${region}" cloudfront list-cloud-front-origin-access-identities \
+  --query "CloudFrontOriginAccessIdentityList.Items[?Comment==\'${name}\'].Id" --output text) || return $?
 
   # check if used if present
   if [[ -n "${oai_id}" ]]; then
-    oai_ids=$(aws --region "${region}" cloudfront list-distributions --query "DistributionList.Items[].Origins.Items[].S3OriginConfig.OriginAccessIdentity" --output text)
+    oai_ids=$(aws --region "${region}" cloudfront list-distributions --query "DistributionList.Items[].Origins.Items[].S3OriginConfig.OriginAccessIdentity" --output text) || return $?
     if [[ -n "${oai_ids}" ]]; then
-      contains "${oai_ids}" "${oai_id}"
-      return $?
+      if contains "${oai_ids}" "${oai_id}"; then
+        echo "true"
+        return 0
+      fi
     fi
   fi
 
   # Not in use
-  return 1
+  echo "false"
+  return 0
 }
 
 # -- RDS --

--- a/providers/aws/components/baseline/setup.ftl
+++ b/providers/aws/components/baseline/setup.ftl
@@ -378,10 +378,11 @@
                             ) +
                             valueIfTrue(
                                 [
-                                    "   info \"Removing old ssh pseudo stack output\"",
+                                    "   info \"Removing old ssh pseudo stack output ...\"",
                                     "   legacy_pseudo_stack_file=\"$(fileBase \"$\{BASH_SOURCE}\")\"",
                                     "   legacy_pseudo_stack_filepath=\"$\{CF_DIR/baseline/cmk}/$\{legacy_pseudo_stack_file/-baseline-/-cmk-}-keypair-pseudo-stack.json\"",
                                     "   if [ -f \"$\{legacy_pseudo_stack_filepath}\" ]; then",
+                                    "       info \"Deleting $\{legacy_pseudo_stack_filepath} ...\"",
                                     "       rm -f \"$\{legacy_pseudo_stack_filepath}\"",
                                     "   else",
                                     "       warn \"Unable to locate pseudo stack file $\{legacy_pseudo_stack_filepath}\"",
@@ -471,23 +472,25 @@
                                         "    rm -f \"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-pseudo-stack.json\"",
                                         "    ;;",
                                         "  create|update)",
-                                        "    info \"Removing legacy oai credential\"",
-                                        "    if is_oai_credential_used" + " " +
+                                        "    info \"Removing legacy oai credential ...\"",
+                                        "    used=$(is_oai_credential_used" + " " +
                                                "\"" + regionId + "\" " +
-                                               "\"" + legacyOAIName + "\"; then",
-                                        "      warn \"Legacy OAI in use - it will need to be manually deleted ...\"",
+                                               "\"" + legacyOAIName + "\" ) || return $?",
+                                        "    if [[ \"$\{used}\" == \"true\" ]]; then",
+                                        "      warn \"Legacy OAI in use - rerun the baseline unit to remove it once it is no longer in use ...\"",
                                         "    else",
                                         "      delete_oai_credentials" + " " +
                                                  "\"" + regionId + "\" " +
                                                  "\"" + legacyOAIName + "\" || return $?",
-                                        "    fi",
-                                        "    info \"Removing legacy oai pseudo stack output\"",
-                                        "    legacy_pseudo_stack_file=\"$(fileBase \"$\{BASH_SOURCE}\")\"",
-                                        "    legacy_pseudo_stack_filepath=\"$\{CF_DIR/baseline/cmk}/$\{legacy_pseudo_stack_file/-baseline-/-cmk-}-pseudo-stack.json\"",
-                                        "    if [ -f \"$\{legacy_pseudo_stack_filepath}\" ]; then",
-                                        "       rm -f \"$\{legacy_pseudo_stack_filepath}\"",
-                                        "    else",
-                                        "       warn \"Unable to locate pseudo stack file $\{legacy_pseudo_stack_filepath}\"",
+                                        "      info \"Removing legacy oai pseudo stack output\"",
+                                        "      legacy_pseudo_stack_file=\"$(fileBase \"$\{BASH_SOURCE}\")\"",
+                                        "      legacy_pseudo_stack_filepath=\"$\{CF_DIR/baseline/cmk}/$\{legacy_pseudo_stack_file/-baseline-/-cmk-}-pseudo-stack.json\"",
+                                        "      if [ -f \"$\{legacy_pseudo_stack_filepath}\" ]; then",
+                                        "         info \"Deleting $\{legacy_pseudo_stack_filepath} ...\"",
+                                        "         rm -f \"$\{legacy_pseudo_stack_filepath}\"",
+                                        "      else",
+                                        "         warn \"Unable to locate pseudo stack file $\{legacy_pseudo_stack_filepath}\"",
+                                        "      fi",
                                         "    fi",
                                         "    ;;",
                                         " esac"

--- a/providers/aws/components/baseline/setup.ftl
+++ b/providers/aws/components/baseline/setup.ftl
@@ -472,9 +472,15 @@
                                         "    ;;",
                                         "  create|update)",
                                         "    info \"Removing legacy oai credential\"",
-                                        "    delete_oai_credentials" + " " +
+                                        "    if is_oai_credential_used" + " " +
                                                "\"" + regionId + "\" " +
-                                               "\"" + legacyOAIName + "\" || return $?",
+                                               "\"" + legacyOAIName + "\"; then",
+                                        "      warn \"Legacy OAI in use - it will need to be manually deleted ...\"",
+                                        "    else",
+                                        "      delete_oai_credentials" + " " +
+                                                 "\"" + regionId + "\" " +
+                                                 "\"" + legacyOAIName + "\" || return $?",
+                                        "    fi",
                                         "    info \"Removing legacy oai pseudo stack output\"",
                                         "    legacy_pseudo_stack_file=\"$(fileBase \"$\{BASH_SOURCE}\")\"",
                                         "    legacy_pseudo_stack_filepath=\"$\{CF_DIR/baseline/cmk}/$\{legacy_pseudo_stack_file/-baseline-/-cmk-}-pseudo-stack.json\"",

--- a/providers/shared/references/Environment/id.ftl
+++ b/providers/shared/references/Environment/id.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[@addReference 
+[@addReference
     type=ENVIRONMENT_REFERENCE_TYPE
     pluralType="Environments"
     properties=[
@@ -63,6 +63,10 @@
                         {
                             "Names" : "Enabled",
                             "Type" : BOOLEAN_TYPE
+                        },
+                        {
+                            "Names" : "Expiration",
+                            "Type" : NUMBER_TYPE
                         }
                     ]
                 },
@@ -113,7 +117,7 @@
         },
         {
             "Names" : "DomainBehaviours",
-            "Children" : [ 
+            "Children" : [
                 {
                     "Names" : "Segment",
                     "Type" : STRING_TYPE


### PR DESCRIPTION
When migrating legacy OAIs to the baseline equivalent, don't try and delete the legacy OAI if it is still in use.

Because the legacy stack will still be deleted (as is replaced with baseline's own OAI), cleanup of the legacy OAI will need to be performed manually.