### PR TITLE
<fix> only return numbers for processor counts

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -344,9 +344,9 @@ behaviour.
 
     [#return
         {
-            "MaxCount"      : maxCount!0,
-            "MinCount"      : minCount!0,
-            "DesiredCount"  : desiredCount!0
+            "MaxCount"      : maxCount?has_content?then(maxCount?number, 0 ),
+            "MinCount"      : minCount?has_content?then(minCount?number, 0 ),
+            "DesiredCount"  : desiredCount?has_content?then(desiredCount?number, 0 )
         }
     ]
 [/#function]

--- a/providers/aws/components/ecs/setup.ftl
+++ b/providers/aws/components/ecs/setup.ftl
@@ -565,7 +565,7 @@
                 " esac"
             ]
         /]
-        
+
         [#-- asgName is used as a capacity provider name as the capacity providers can't be updated or deleted at the moment --]
         [#-- change to ecsOnDemandCapacityProviderId when update/delete is supported--]
         [#if computeProvider == "ec2OnDemand" ]
@@ -909,7 +909,7 @@
 
 
                 [#local processorProfile = getProcessor(subOccurrence, "service" )]
-                [#local processorCounts = getProcessorCounts(processorProfile, multiAZ, (solution.DesiredCount)!"" ) ]
+                [#local processorCounts = getProcessorCounts(processorProfile, multiAZ, solution.DesiredCount ) ]
 
                 [#local desiredCount = processorCounts.DesiredCount ]
                 [#if hibernate ]


### PR DESCRIPTION
Only return numbers instead of empty strings when calculating processor counts. We use the return values in number comparisons which doesn't work for strings