### PR TITLE
<feature> DB AWS basic tests

### DIFF
--- a/providers/awstest/provider.ftl
+++ b/providers/awstest/provider.ftl
@@ -16,6 +16,7 @@
 [#assign AWSTEST_PROVIDER = "awstest"]
 
 [#assign testScenarios = [
+    "db",
     "lb"
 ]]
 

--- a/providers/awstest/scenarios/db.ftl
+++ b/providers/awstest/scenarios/db.ftl
@@ -5,6 +5,17 @@
 
     [#-- Base database setup --]
     [@addScenario
+        settingSets=[
+            {
+                "Type" : "Settings",
+                "Scope" : "Products",
+                "Namespace" : "mockedup-integration-aws-db-postgres-base",
+                "Settings" : {
+                    "MASTER_USERNAME" : "testUser",
+                    "MASTER_PASSWORD" : "testPassword"
+                }
+            }
+        ]
         blueprint={
             "Tiers" : {
                 "db" : {
@@ -19,10 +30,7 @@
                                 "Engine" : "postgres",
                                 "EngineVersion" : "11",
                                 "Profiles" : {
-                                    "Testing" : [ "Component" ]
-                                },
-                                "GenerateCredentials" : {
-                                    "Enabled" : true
+                                    "Testing" : [ "postgresdbbase" ]
                                 }
                             }
                         }
@@ -81,9 +89,66 @@
                 }
             },
             "TestProfiles" : {
-                "Component" : {
+                "postgresdbbase" : {
                     "db" : {
                         "TestCases" : [ "postgresdbbase" ]
+                    }
+                }
+            }
+        }
+    /]
+
+
+    [#-- Generated creds --]
+    [@addScenario
+        blueprint={
+            "Tiers" : {
+                "db" : {
+                    "Components" : {
+                        "postgresdbgenerated" : {
+                            "db" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "DeploymentUnits" : ["aws-db-postgres-generated"]
+                                    }
+                                },
+                                "Engine" : "postgres",
+                                "EngineVersion" : "11",
+                                "Profiles" : {
+                                    "Testing" : [ "postgresdbgenerated" ]
+                                },
+                                "GenerateCredentials" : {
+                                    "Enabled" : true,
+                                    "EncryptionScheme" : "kms"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "postgresdbgenerated" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "rdsInstance" : {
+                                    "Name" : "rdsXdbXpostgresdbgenerated",
+                                    "Type" : "AWS::RDS::DBInstance"
+                                }
+                            },
+                            "Output" : [
+                                "rdsXdbXpostgresdbgeneratedXdns",
+                                "rdsXdbXpostgresdbgeneratedXport"
+                            ]
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "postgresdbgenerated" : {
+                    "db" : {
+                        "TestCases" : [ "postgresdbgenerated" ]
                     }
                 }
             }

--- a/providers/awstest/scenarios/db.ftl
+++ b/providers/awstest/scenarios/db.ftl
@@ -1,0 +1,92 @@
+[#ftl]
+
+[#-- Get stack output --]
+[#macro awstest_scenario_db ]
+
+    [#-- Base database setup --]
+    [@addScenario
+        blueprint={
+            "Tiers" : {
+                "db" : {
+                    "Components" : {
+                        "postgresdbbase" : {
+                            "db" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "DeploymentUnits" : ["aws-db-postgres-base"]
+                                    }
+                                },
+                                "Engine" : "postgres",
+                                "EngineVersion" : "11",
+                                "Profiles" : {
+                                    "Testing" : [ "Component" ]
+                                },
+                                "GenerateCredentials" : {
+                                    "Enabled" : true
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "postgresdbbase" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "rdsInstance" : {
+                                    "Name" : "rdsXdbXpostgresdbbase",
+                                    "Type" : "AWS::RDS::DBInstance"
+                                },
+                                "rdsOptionGroup" : {
+                                    "Name" : "rdsOptionGroupXdbXpostgresdbbaseXpostgres11",
+                                    "Type" : "AWS::RDS::OptionGroup"
+                                },
+                                "rdsParameterGroup" : {
+                                    "Name" : "rdsParameterGroupXdbXpostgresdbbaseXpostgres11",
+                                    "Type" : "AWS::RDS::DBParameterGroup"
+                                }
+                            },
+                            "Output" : [
+                                "rdsXdbXpostgresdbbaseXdns",
+                                "rdsXdbXpostgresdbbaseXport",
+                                "securityGroupXdbXpostgresdbbase"
+                            ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "RDSEngine" : {
+                                    "Path"  : "Resources.rdsXdbXpostgresdbbase.Properties.Engine",
+                                    "Value" : "postgres"
+                                },
+                                "RDSEngineVersion" : {
+                                    "Path"  : "Resources.rdsXdbXpostgresdbbase.Properties.EngineVersion",
+                                    "Value" : "11"
+                                },
+                                "OptionGroupVersion" : {
+                                    "Path" : "Resources.rdsOptionGroupXdbXpostgresdbbaseXpostgres11.Properties.MajorEngineVersion",
+                                    "Value" : "11"
+                                },
+                                "ParameterGroupVersion" : {
+                                    "Path" : "Resources.rdsParameterGroupXdbXpostgresdbbaseXpostgres11.Properties.Family",
+                                    "Value" : "postgres11"
+                                }
+                            },
+                            "NotEmpty" : [
+                                "Resources.rdsXdbXpostgresdbbase.Properties.DBInstanceClass"
+                            ]
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "Component" : {
+                    "db" : {
+                        "TestCases" : [ "postgresdbbase" ]
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]

--- a/providers/shared/components/db/id.ftl
+++ b/providers/shared/components/db/id.ftl
@@ -67,8 +67,8 @@
                     },
                     {
                         "Names" : "EncryptionScheme",
+                        "Description" : "A prefix added to encrypted strings to identify how they have been encoded",
                         "Type" : STRING_TYPE,
-                        "Values" : ["base64"],
                         "Default" : ""
                     }
                 ]


### PR DESCRIPTION
## Description
Adds some basic tests for the AWS implementation of the DB component. 
Removes the restriction on the encryption schema value that can be provided 

## Motivation and Context
The removal of the encryption schema allows for any schema to be used when encrypting strings. This aligns it with our other encyrpted strings which set the schema based on what the application supports 

Testing adds the ability to validate our database templates

## How Has This Been Tested?
Tests incl

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking Actions
None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
