### PR TITLE
Fix - numberAttributeIfContent function

### DIFF
--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -38,7 +38,14 @@
     [#return attributeIfTrue(
         attribute,
         content?has_content,
-        value?has_content?then(value?number, content?number))]
+        value?has_content?then(
+            value?number, 
+            content?has_content?then(
+                content?number,
+                ""
+            )
+        )
+    )]
 [/#function]
 
 [#------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes an issue where if a default attribute value of "" is provided and never overwritten, the function attempts to convert it to a number anyway and then errors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes this problem by only performing the conversion from string-to-number when something is actually provided.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Creating existing Azure templates that utilise this function.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above apply.