### PR TITLE
<feature> export method configuration in fastlane

### DIFF
--- a/aws/runExpoAppPublish.sh
+++ b/aws/runExpoAppPublish.sh
@@ -388,6 +388,8 @@ function main() {
             export IOS_DIST_APPLE_ID="$( jq -r '.BuildConfig.IOS_DIST_APPLE_ID' < "${CONFIG_FILE}" )"
             export IOS_DIST_APP_ID="$( jq -r '.BuildConfig.IOS_DIST_APP_ID' < "${CONFIG_FILE}" )"
 
+            export IOS_DIST_EXPORT_METHOD="$( jq -r '.BuildConfig.IOS_DIST_EXPORT_METHOD' < "${CONFIG_FILE}" )"
+
             export IOS_TESTFLIGHT_USERNAME="$(jq -r '.BuildConfig.IOS_TESTFLIGHT_USERNAME' < "${CONFIG_FILE}")"
             IOS_TESTFLIGHT_PASSWORD="$(jq -r '.BuildConfig.IOS_TESTFLIGHT_PASSWORD' < "${CONFIG_FILE}")"
             export IOS_TESTFLIGHT_PASSWORD="$( decrypt_kms_string "${AWS_REGION}" "${IOS_TESTFLIGHT_PASSWORD#"base64:"}")"
@@ -474,7 +476,7 @@ function main() {
 
                 # Build App
                 fastlane run cocoapods podfile:"${FASTLANE_IOS_PODFILE}" || return $?
-                fastlane run build_ios_app workspace:"${FASTLANE_IOS_WORKSPACE_FILE}" output_directory:"${BINARY_PATH}" output_name:"${EXPO_BINARY_FILE_NAME}" export_method:"app-store" codesigning_identity:"${CODESIGN_IDENTITY}" || return $?
+                fastlane run build_ios_app workspace:"${FASTLANE_IOS_WORKSPACE_FILE}" output_directory:"${BINARY_PATH}" output_name:"${EXPO_BINARY_FILE_NAME}" export_method:"${IOS_DIST_EXPORT_METHOD}" codesigning_identity:"${CODESIGN_IDENTITY}" || return $?
 
                 ;;
         esac


### PR DESCRIPTION
## Description
Allows for the ios export method to be defined in expo app publishing

## Motivation and Context
When signing an IOS binary app package the export method needs to align with the type of provisioning profile that is being used. This PR allows for the method to be defined while setting the default to app-store if it is not set. Most app builds are app-store as they either go to test flight or the real app store. The other methods are mostly for private deployment with an MDM solution 


## How Has This Been Tested?
Yes testing has been performed as part of a mobile app build 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking Actions
None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
