### PR TITLE
feat: add inside tunnel config support

### DIFF
--- a/providers/shared/components/externalnetwork/id.ftl
+++ b/providers/shared/components/externalnetwork/id.ftl
@@ -76,6 +76,18 @@
                         "Types" : STRING_TYPE
                     },
                     {
+                        "Names" : "InsideTunnelIPVersion",
+                        "Description" : "The IP Version of the internal network",
+                        "Types" : STRING_TYPE,
+                        "Values" : [ "Ipv4", "Ipv6" ],
+                        "Default" : "Ipv4"
+                    },
+                    {
+                        "Names" : "InsideTunnelCIDRs",
+                        "Description" : "An array of IP CIDR Ranges used within the tunnel",
+                        "Types" : ARRAY_OF_STRING_TYPE
+                    },
+                    {
                         "Names" : "BGP",
                         "Children" : [
                             {

--- a/providers/shared/components/gateway/id.ftl
+++ b/providers/shared/components/gateway/id.ftl
@@ -173,6 +173,23 @@
                         "Default" : "default"
                     }
                 ]
+            },
+            {
+                "Names" : "SiteToSite",
+                "Children" : [
+                    {
+                        "Names" : "InsideTunnelIPVersion",
+                        "Description" : "The IP Version of the internal network",
+                        "Types" : STRING_TYPE,
+                        "Values" : [ "Ipv4", "Ipv6" ],
+                        "Default" : "Ipv4"
+                    },
+                    {
+                        "Names" : "InsideTunnelCIDRs",
+                        "Description" : "An array of IP CIDR Ranges used within the tunnel",
+                        "Types" : ARRAY_OF_STRING_TYPE
+                    }
+                ]
             }
         ]
     parent=NETWORK_GATEWAY_COMPONENT_TYPE


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)


## Description

- Adds support for configuring the IP Address configuration for the network used inside a VPN tunnel

## Motivation and Context

Some VPN providers such as AWS use the inside address to negotiate BGP link sharing between two sites in a VPN connection. This configuration allows for them to be aligned across the VPN peers

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

