### PR TITLE
feat(externalnetwork): set startup action for vpn

### DIFF
--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -1814,6 +1814,7 @@
           "MarginTime": 540,
           "FuzzPercentage": 100
         },
+        "StartupAction" : "add",
         "ReplayWindowSize": 1024,
         "DeadPeerDetectionTimeout": 30,
         "DeadPeerDetectionAction": "clear",

--- a/providers/shared/references/SecurityProfile/id.ftl
+++ b/providers/shared/references/SecurityProfile/id.ftl
@@ -124,6 +124,12 @@
                     "Types" : ARRAY_OF_STRING_TYPE
                 },
                 {
+                    "Names" : "StartupAction",
+                    "Description" : "Initiation behaviour for vpn",
+                    "Types" : STRING_TYPE,
+                    "Values" : [ "add", "start" ]
+                },
+                {
                     "Names" : "Rekey",
                     "Children" : [
                         {


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds support for setting the startup action on vpn security profiles

## Motivation and Context

Allows for defining more detail on VPN gateways to ensure they handle startup behaviour as expected

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

