### PR TITLE
refactor: base and deployment attributes

### DIFF
--- a/engine/inputdata/blueprint.ftl
+++ b/engine/inputdata/blueprint.ftl
@@ -59,7 +59,7 @@
 
         [#-- Skip any subComponents --]
         [#if !(subComponentNames?seq_contains(component))]
-            [#local attrs = coreComponentChildConfiguration]
+            [#local attrs = []]
             [#list config["ResourceGroups"]?values as resourceGroupConfig]
                 [#local attrs += asFlattenedArray(resourceGroupConfig.Attributes?values)]
             [/#list]
@@ -71,7 +71,7 @@
                     [#local components += [{
                         "Names" : child.Component,
                         "SubObjects" : true,
-                        "Children" : asFlattenedArray(componentConfiguration[child.Type]["ResourceGroups"]["default"].Attributes?values) + coreComponentChildConfiguration
+                        "Children" : asFlattenedArray(componentConfiguration[child.Type]["ResourceGroups"]["default"].Attributes?values)
                     }] ]
                 [/#list]
             [/#if]
@@ -148,7 +148,7 @@
                         {
                             "Names" : "Components",
                             "SubObjects" : true,
-                            "Children" : componentChildren + coreComponentChildConfiguration
+                            "Children" : componentChildren
                         },
                         {
                             "Names" : "Network",

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -565,6 +565,7 @@ already prefixed attribute.
 
         [#local attributes +=
             extendedSharedAttributes +
+            ((value.Attributes[BASE_ATTRIBUTES])![]) +
             ((value.Attributes[DEPLOYMENT_ATTRIBUTES])![]) +
             ((value.Attributes[provider])![])
         ]


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

- moves the DeploymentUnits attribute from the standard shared configuration to the specific deployment configuration
- Adds a base attributes macro which controls the base level attributes available on components and makes the Type attribute optional

## Motivation and Context

Both the DeploymentUnits and Type attributes are only available under specific circumstances for components 
- DeploymentUnits should only be available on components which can be deployed. This would remove the configuration option in documentation on components which won't support it 
- The Type component attribute can only be used on parent components and currently isn't supported on subcomponents 

## How Has This Been Tested?

Tested locally across a collection of CMDBs with different deployment and type configuration

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

